### PR TITLE
chore(release): prepare v0.2.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-workspace",
-  "version": "0.1.1-beta.1",
+  "version": "0.2.0-beta.1",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.14",

--- a/scripts/release-note-markdown.test.ts
+++ b/scripts/release-note-markdown.test.ts
@@ -7,6 +7,6 @@ test('formats the latest bundled Release Note for a GitHub Release', () => {
   const markdown = formatReleaseNoteAsMarkdown(bundledReleaseNotes[0]!)
 
   assert.match(markdown, new RegExp(`^${bundledReleaseNotes[0]!.summary}`, 'm'))
-  assert.match(markdown, /^## Fixed$/m)
-  assert.match(markdown, /^- Dialogs now use an opaque background for clearer focus\./m)
+  assert.match(markdown, /^## New$/m)
+  assert.match(markdown, /^- Choose an available Skill from Composer autocomplete to guide Pi in a Session\./m)
 })

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -20,6 +20,16 @@ export function isSemanticVersion(version: string): boolean {
 
 export const bundledReleaseNotes: readonly ReleaseNote[] = [
   {
+    version: '0.2.0-beta.1',
+    releaseDate: '2026-07-22',
+    summary: 'This beta adds Skills to help guide Pi in a Session.',
+    changes: {
+      new: ['Choose an available Skill from Composer autocomplete to guide Pi in a Session.'],
+      improved: [],
+      fixed: [],
+    },
+  },
+  {
     version: '0.1.1-beta.1',
     releaseDate: '2026-07-21',
     summary: 'A focused beta update improves the visual clarity of dialogs.',


### PR DESCRIPTION
## Summary

- prepare Pi Workspace v0.2.0-beta.1
- add the bundled Release Note for Composer Skill autocomplete
- update the generated release-note test

## Validation

- bun run release:validate
- bun test
- bun run typecheck
- bun run lint
- bun run format:check
- bun run build