### PR TITLE
feat: show Session context window usage

### DIFF
--- a/src/demo/demo-renderer.test.tsx
+++ b/src/demo/demo-renderer.test.tsx
@@ -2,7 +2,21 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { act, fireEvent, waitFor } from '@testing-library/react'
 import { createDemoBridge } from '@/src/demo/demo-bridge'
-import { getDemoScenarioPresentation } from '@/src/demo/demo-scenarios'
+import { getDemoScenario, getDemoScenarioPresentation } from '@/src/demo/demo-scenarios'
+
+test('the multi-Session demo includes empty, half-full, and full context windows', () => {
+  const scenario = getDemoScenario('multi-session')
+  const usages = scenario.workstreams.workstreams
+    .flatMap((workstream) => workstream.sessions)
+    .slice(0, 3)
+    .map((session) => scenario.transcriptsBySessionId[session.id]?.contextUsage)
+
+  assert.deepEqual(usages, [
+    { tokens: 0, contextWindow: 200_000, percent: 0 },
+    { tokens: 100_000, contextWindow: 200_000, percent: 50 },
+    { tokens: 200_000, contextWindow: 200_000, percent: 100 },
+  ])
+})
 
 test('the normal renderer initializes against the selected demo scenario', async () => {
   document.body.innerHTML = '<div id="app"></div>'

--- a/src/demo/demo-scenarios.ts
+++ b/src/demo/demo-scenarios.ts
@@ -2,7 +2,7 @@ import { sessionId, type SessionId } from '@/src/domain/session'
 import type { OwnedSession, WorkstreamsSnapshot } from '@/src/domain/workstream'
 import type { WorkstreamKnowledgeRecord } from '@/src/domain/workstream-knowledge'
 import type { WorkstreamKnowledge } from '@/src/domain/workstream-knowledge-transitions'
-import type { SessionTranscriptSnapshot } from '@/src/session-transcript'
+import type { SessionContextUsage, SessionTranscriptSnapshot } from '@/src/session-transcript'
 import type { AgentActivityDetails } from '@/src/session-timeline'
 
 export type DemoScenario = Readonly<{
@@ -14,6 +14,16 @@ export type DemoScenario = Readonly<{
 
 const completedRunSessionId = sessionId('northstar-release-overview')
 const completedRunStartedAt = Date.UTC(2026, 6, 15, 9, 30)
+const demoContextWindow = 200_000
+const demoContextUsageFractions = [0, 0.5, 1] as const
+
+function demoContextUsage(fraction: (typeof demoContextUsageFractions)[number]): SessionContextUsage {
+  return {
+    tokens: demoContextWindow * fraction,
+    contextWindow: demoContextWindow,
+    percent: fraction * 100,
+  }
+}
 
 function ownedSession(id: string, title: string): OwnedSession {
   return {
@@ -30,11 +40,12 @@ function createEmptyScenario(sessionValues: ReadonlyArray<readonly [string, stri
   const sessions = sessionValues.map(([id, title]) => ownedSession(id, title))
   const transcriptsBySessionId: Record<string, SessionTranscriptSnapshot> = {}
 
-  for (const session of sessions) {
+  for (const [index, session] of sessions.entries()) {
     transcriptsBySessionId[session.id] = {
       sessionId: session.id,
       revision: 0,
       isWorking: false,
+      contextUsage: demoContextUsage(demoContextUsageFractions[index % demoContextUsageFractions.length]!),
       runs: [],
       entries: [],
     }
@@ -217,6 +228,7 @@ const workstreamScenario: DemoScenario = {
       sessionId: brainstormSessionId,
       revision: 6,
       isWorking: false,
+      contextUsage: demoContextUsage(0),
       runs: [
         {
           id: 'offline-brainstorm-run',
@@ -315,6 +327,7 @@ const workstreamScenario: DemoScenario = {
       sessionId: implementationSessionId,
       revision: 6,
       isWorking: false,
+      contextUsage: demoContextUsage(0.5),
       runs: [
         {
           id: 'offline-implementation-run',
@@ -631,6 +644,7 @@ const completedRunScenario: DemoScenario = {
       sessionId: completedRunSessionId,
       revision: 6,
       isWorking: false,
+      contextUsage: demoContextUsage(1),
       runs: [
         {
           id: 'release-run',
@@ -903,6 +917,7 @@ const quickSessionsScenario: DemoScenario = {
       sessionId: frontendQuickSessionId,
       revision: 10,
       isWorking: false,
+      contextUsage: demoContextUsage(0.5),
       runs: [
         {
           id: 'frontend-build-run',
@@ -1074,6 +1089,7 @@ const quickSessionsScenario: DemoScenario = {
       sessionId: apiQuickSessionId,
       revision: 10,
       isWorking: false,
+      contextUsage: demoContextUsage(1),
       runs: [
         {
           id: 'api-events-run',

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -289,6 +289,10 @@ export async function createPiSessionRuntime(
         const normalized = normalizePiSessionEvent(event, modelTurnNoProgressTimeoutMs)
 
         if (normalized) listener(normalized)
+
+        if (event.type === 'message_end' || event.type === 'compaction_end') {
+          listener({ type: 'context_usage', usage: session.getContextUsage() })
+        }
       })
 
       return () => {
@@ -398,6 +402,7 @@ export async function createPiSessionRuntime(
 
       await session.setModel(model)
       session.settingsManager.setDefaultModelAndProvider(model.provider, model.id)
+      runtimeListeners.forEach((listener) => listener({ type: 'context_usage', usage: session.getContextUsage() }))
     },
     async setConfigurationEffort(effort: SessionConfigurationEffort) {
       if (!session.supportsThinking() && effort === 'off') return

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -245,6 +245,9 @@ export async function createPiSessionRuntime(
     rename(title) {
       session.sessionManager.appendSessionInfo(title)
     },
+    getContextUsage() {
+      return session.getContextUsage()
+    },
     subscribe(listener) {
       runtimeListeners.add(listener)
 

--- a/src/main/pi-session-runtime-transcript.ts
+++ b/src/main/pi-session-runtime-transcript.ts
@@ -1,11 +1,12 @@
 import type { ActivityLayerRecord } from '@/src/main/activity-records'
 import type { AgentActivity, AgentRun, SessionTimelineEntry, ToolExecution } from '@/src/session-timeline'
-import type { SessionTranscriptMessage } from '@/src/session-transcript'
+import type { SessionContextUsage, SessionTranscriptMessage } from '@/src/session-transcript'
 import type { PiSessionRuntime, PiSessionRuntimeHistory } from './pi-session-runtimes'
 
 export type SessionRuntimeTimeline = {
   revision: number
   runtimeDirectory?: string
+  contextUsage?: SessionContextUsage
   runs: AgentRun[]
   entries: SessionTimelineEntry[]
   messages: Map<string, SessionTranscriptMessage>

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -30,6 +30,7 @@ import {
   type ToolExecution,
 } from '@/src/session-timeline'
 import type {
+  SessionContextUsage,
   SessionTranscriptEntry,
   SessionTranscriptMessage,
   SessionTranscriptMutation,
@@ -70,6 +71,7 @@ export interface PiSessionRuntime {
   loadRawOperation?(toolCallId: string): Readonly<{ input: unknown; result?: unknown }> | undefined
   getSkills?(): readonly SessionSkill[]
   getSkillPrompt?(name: string): string | undefined
+  getContextUsage?(): SessionContextUsage | undefined
   getConfiguration?(): Promise<Omit<SessionConfigurationSnapshot, 'sessionId' | 'revision' | 'persistenceWarning'>>
   setConfigurationModel?(model: SessionConfigurationModelSelection): Promise<void>
   setConfigurationEffort?(effort: SessionConfigurationEffort): Promise<void>
@@ -84,6 +86,7 @@ export type PiSessionRuntimeHistory = Readonly<{
 }>
 
 export type PiSessionRuntimeEvent =
+  | Readonly<{ type: 'context_usage'; usage?: SessionContextUsage }>
   | Readonly<{ type: 'tool_execution_start'; toolCallId: string; toolName: string; input: unknown }>
   | Readonly<{
       type: 'activity_control_accepted'
@@ -251,6 +254,7 @@ export function createPiSessionRuntimeRegistry({
       sessionId,
       revision: timeline.revision,
       isWorking: timeline.runs.some((run) => run.status === 'running'),
+      contextUsage: timeline.contextUsage,
       runs: timeline.runs,
       entries,
       runFailureReason:
@@ -519,6 +523,13 @@ export function createPiSessionRuntimeRegistry({
 
   function handleRuntimeEvent(sessionId: SessionId, event: PiSessionRuntimeEvent): void {
     const timeline = getTimeline(sessionId)
+
+    if (event.type === 'context_usage') {
+      timeline.contextUsage = event.usage
+      publishTimeline(sessionId)
+
+      return
+    }
 
     if (event.type === 'tool_execution_start') {
       clearNoProgressTimeout(sessionId)
@@ -1256,7 +1267,9 @@ export function createPiSessionRuntimeRegistry({
       }
     },
     async getTranscript(sessionId) {
-      await getRuntime(sessionId)
+      const runtime = await getRuntime(sessionId)
+      const timeline = getTimeline(sessionId)
+      timeline.contextUsage = runtime?.getContextUsage?.()
 
       return transcriptSnapshot(sessionId)
     },

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -908,6 +908,9 @@ export function createPiSessionRuntimeRegistry({
     timeline.runtimeDirectory = runtimeDirectory
     timeline.persist = runtime.appendActivityRecord?.bind(runtime)
     timeline.loadRawOperation = runtime.loadRawOperation?.bind(runtime)
+    // The attaching runtime is authoritative for the Model's context window;
+    // context_usage events keep it current from here.
+    timeline.contextUsage = runtime.getContextUsage?.()
     hydrateTimeline(timeline, runtime.loadHistory?.())
 
     const unsubscribes = [runtime.subscribe((event) => handleRuntimeEvent(sessionId, event))]
@@ -1267,9 +1270,7 @@ export function createPiSessionRuntimeRegistry({
       }
     },
     async getTranscript(sessionId) {
-      const runtime = await getRuntime(sessionId)
-      const timeline = getTimeline(sessionId)
-      timeline.contextUsage = runtime?.getContextUsage?.()
+      await getRuntime(sessionId)
 
       return transcriptSnapshot(sessionId)
     },

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -132,6 +132,53 @@ test('rejects a selected Skill that is unavailable to the Session runtime', asyn
   assert.equal(prompted, false)
 })
 
+test('includes the Session context window usage in its transcript snapshot', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    getContextUsage() {
+      return { tokens: 48_000, contextWindow: 200_000, percent: 24 }
+    },
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  const snapshot = await registry.getTranscript(sessionId('context-session'))
+
+  assert.deepEqual(snapshot.contextUsage, { tokens: 48_000, contextWindow: 200_000, percent: 24 })
+})
+
+test('publishes updated context usage to transcript subscribers', async () => {
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const snapshots: unknown[] = []
+  registry.subscribeTranscript((mutation) => snapshots.push(mutation.snapshot.contextUsage))
+  const id = sessionId('live-context-session')
+
+  await registry.getTranscript(id)
+  emit({ type: 'context_usage', usage: { tokens: null, contextWindow: 200_000, percent: null } })
+
+  assert.deepEqual(snapshots, [{ tokens: null, contextWindow: 200_000, percent: null }])
+})
+
 test('publishes a failed transcript run without a parallel failure stream', async () => {
   let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
   const runtime: PiSessionRuntime = {

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -179,6 +179,30 @@ test('publishes updated context usage to transcript subscribers', async () => {
   assert.deepEqual(snapshots, [{ tokens: null, contextWindow: 200_000, percent: null }])
 })
 
+test('keeps published context usage when the runtime cannot report it', async () => {
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('retained-context-session')
+
+  await registry.getTranscript(id)
+  emit({ type: 'context_usage', usage: { tokens: 48_000, contextWindow: 200_000, percent: 24 } })
+  const snapshot = await registry.getTranscript(id)
+
+  assert.deepEqual(snapshot.contextUsage, { tokens: 48_000, contextWindow: 200_000, percent: 24 })
+})
+
 test('publishes a failed transcript run without a parallel failure stream', async () => {
   let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
   const runtime: PiSessionRuntime = {

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -655,6 +655,44 @@ test('prevents Agent Run acceptance while a Model change is pending', async () =
   )
 })
 
+test('shows the current context window usage and remaining capacity', () => {
+  const view = renderInBrowser(
+    <Composer
+      session={session}
+      draft=""
+      isWorking={false}
+      contextUsage={{ tokens: 48_000, contextWindow: 200_000, percent: 24 }}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+    />
+  )
+
+  const contextWindow = view.getByRole('progressbar', { name: 'Context window' })
+
+  assert.equal(contextWindow.getAttribute('aria-valuenow'), '24')
+  assert.equal(contextWindow.getAttribute('aria-valuetext'), '48k used of 200k tokens; 152k left')
+  assert.match(view.getByText('152k left').textContent ?? '', /152k left/)
+})
+
+test('explains when context usage is recalculating after compaction', () => {
+  const view = renderInBrowser(
+    <Composer
+      session={session}
+      draft=""
+      isWorking={false}
+      contextUsage={{ tokens: null, contextWindow: 200_000, percent: null }}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+    />
+  )
+
+  assert.ok(view.getByText('Updating after compaction…'))
+  assert.match(view.getByText('? / 200k').textContent ?? '', /\? \/ 200k/)
+  assert.equal(view.queryByRole('progressbar', { name: 'Context window' }), null)
+})
+
 test('explains how to configure Pi when no Model is available while preserving the draft', async () => {
   const configuration = {
     sessionId: session.id,

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -655,7 +655,7 @@ test('prevents Agent Run acceptance while a Model change is pending', async () =
   )
 })
 
-test('shows the current context window usage and remaining capacity', () => {
+test('shows the current context window usage in the Composer action cluster', () => {
   const view = renderInBrowser(
     <Composer
       session={session}
@@ -670,9 +670,107 @@ test('shows the current context window usage and remaining capacity', () => {
 
   const contextWindow = view.getByRole('progressbar', { name: 'Context window' })
 
+  const fill = contextWindow.querySelector('[data-slot="context-usage-fill"]') as HTMLElement
+
+  assert.equal(fill.style.width, '24%')
+  assert.match(contextWindow.textContent ?? '', /24%/)
   assert.equal(contextWindow.getAttribute('aria-valuenow'), '24')
   assert.equal(contextWindow.getAttribute('aria-valuetext'), '48k used of 200k tokens; 152k left')
-  assert.match(view.getByText('152k left').textContent ?? '', /152k left/)
+  assert.equal(contextWindow.getAttribute('title'), '48k used of 200k tokens; 152k left')
+  assert.equal(contextWindow.getAttribute('data-level'), 'nominal')
+})
+
+test('grows the context window fill in place so increments animate', () => {
+  const composer = (percent: number) => (
+    <Composer
+      session={session}
+      draft=""
+      isWorking={false}
+      contextUsage={{ tokens: 2_000 * percent, contextWindow: 200_000, percent }}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+    />
+  )
+  const view = renderInBrowser(composer(24))
+  const fill = view.container.querySelector('[data-slot="context-usage-fill"]')
+
+  assert.ok(fill)
+  assert.equal((fill as HTMLElement).style.width, '24%')
+
+  view.rerender(composer(62))
+
+  // The same element must survive the update; a replaced node would jump
+  // straight to the new width with no transition to run.
+  assert.equal(view.container.querySelector('[data-slot="context-usage-fill"]'), fill)
+  assert.equal((fill as HTMLElement).style.width, '62%')
+})
+
+test('rounds the reported context window fraction for display', () => {
+  const view = renderInBrowser(
+    <Composer
+      session={session}
+      draft=""
+      isWorking={false}
+      contextUsage={{ tokens: 47_483, contextWindow: 200_000, percent: 23.7415 }}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+    />
+  )
+
+  const contextWindow = view.getByRole('progressbar', { name: 'Context window' })
+
+  const fill = contextWindow.querySelector('[data-slot="context-usage-fill"]') as HTMLElement
+
+  assert.match(contextWindow.textContent ?? '', /^24%$/)
+  assert.equal(contextWindow.getAttribute('aria-valuenow'), '24')
+  assert.equal(fill.style.width, '23.7415%')
+})
+
+test('rolls a token count just short of a million over to millions', () => {
+  const view = renderInBrowser(
+    <Composer
+      session={session}
+      draft=""
+      isWorking={false}
+      contextUsage={{ tokens: 999_600, contextWindow: 1_000_000, percent: 99.96 }}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+    />
+  )
+
+  const contextWindow = view.getByRole('progressbar', { name: 'Context window' })
+
+  assert.equal(contextWindow.getAttribute('aria-valuetext'), '1m used of 1m tokens; 400 left')
+})
+
+test('escalates the context window usage level as the window fills', () => {
+  const levels = [
+    { percent: 74, level: 'nominal' },
+    { percent: 75, level: 'caution' },
+    { percent: 89, level: 'caution' },
+    { percent: 90, level: 'critical' },
+  ] as const
+
+  for (const { percent, level } of levels) {
+    const view = renderInBrowser(
+      <Composer
+        session={session}
+        draft=""
+        isWorking={false}
+        contextUsage={{ tokens: 2_000 * percent, contextWindow: 200_000, percent }}
+        onActivate={() => {}}
+        onDraftChange={() => {}}
+        submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+      />
+    )
+
+    const contextWindow = view.getByRole('progressbar', { name: 'Context window' })
+
+    assert.equal(contextWindow.getAttribute('data-level'), level)
+  }
 })
 
 test('explains when context usage is recalculating after compaction', () => {
@@ -688,8 +786,10 @@ test('explains when context usage is recalculating after compaction', () => {
     />
   )
 
-  assert.ok(view.getByText('Updating after compaction…'))
-  assert.match(view.getByText('? / 200k').textContent ?? '', /\? \/ 200k/)
+  const updating = view.getByRole('status')
+
+  assert.equal(updating.querySelector('[data-slot="context-usage-fill"]'), null)
+  assert.equal(updating.getAttribute('title'), 'Context window usage is updating after compaction')
   assert.equal(view.queryByRole('progressbar', { name: 'Context window' }), null)
 })
 

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -4,6 +4,7 @@ import { Combobox, ComboboxDescription, ComboboxLabel, ComboboxOption } from '@/
 import { Listbox, ListboxOption } from '@/components/ui-kit/listbox'
 import type { ComposerBridge, SessionMessageDelivery } from '@/src/composer'
 import type { Session } from '@/src/domain/session'
+import type { SessionContextUsage } from '@/src/session-transcript'
 import type {
   SessionConfigurationBridge,
   SessionConfigurationCommandResult,
@@ -21,6 +22,7 @@ type ComposerProperties = Readonly<{
   draft: string
   focusRequest?: number
   isWorking: boolean
+  contextUsage?: SessionContextUsage
   onActivate: () => void
   onDraftChange: (draft: string) => void
   submitMessage: ComposerBridge['submit']
@@ -34,6 +36,7 @@ export function Composer({
   draft,
   focusRequest,
   isWorking,
+  contextUsage,
   onActivate,
   onDraftChange,
   submitMessage,
@@ -245,15 +248,20 @@ export function Composer({
           onSubmit={(delivery) => void submit(delivery)}
         />
         <div className="flex items-end justify-between gap-2 px-3 pt-1 pb-2" data-slot="composer-control-row">
-          {sessionConfiguration && (
-            <ComposerConfigurationControls
-              snapshot={configuration}
-              disabled={configurationDisabled || modelConfigurationRequired}
-              pending={pendingConfiguration}
-              describedBy={statusId}
-              onModelChange={changeModel}
-              onEffortChange={changeEffort}
-            />
+          {(contextUsage || sessionConfiguration) && (
+            <div className="flex min-w-0 items-end gap-3">
+              {contextUsage && <ContextWindowUsage usage={contextUsage} />}
+              {sessionConfiguration && (
+                <ComposerConfigurationControls
+                  snapshot={configuration}
+                  disabled={configurationDisabled || modelConfigurationRequired}
+                  pending={pendingConfiguration}
+                  describedBy={statusId}
+                  onModelChange={changeModel}
+                  onEffortChange={changeEffort}
+                />
+              )}
+            </div>
           )}
           <div className="ml-auto flex items-end gap-1">
             {isWorking && stopRun && (
@@ -314,6 +322,64 @@ export function Composer({
       </div>
     </div>
   )
+}
+
+type ContextWindowUsageProperties = Readonly<{
+  usage: SessionContextUsage
+}>
+
+function ContextWindowUsage({ usage }: ContextWindowUsageProperties) {
+  const contextWindow = formatTokenCount(usage.contextWindow)
+
+  if (usage.tokens === null || usage.percent === null) {
+    return (
+      <div aria-live="polite" className="min-w-28 text-xs/4 text-composer-muted-foreground">
+        <p className="font-medium text-composer-foreground">Context</p>
+        <p>Updating after compaction…</p>
+        <p className="sr-only">Context window usage is unavailable until Pi finishes its next response.</p>
+        <p className="mt-1 h-1 overflow-hidden rounded-full bg-content-subtle-background">
+          <span className="block h-full w-1/3 animate-pulse rounded-full bg-content-muted-foreground motion-reduce:animate-none" />
+        </p>
+        <p className="mt-1">? / {contextWindow}</p>
+      </div>
+    )
+  }
+
+  const percent = Math.max(0, Math.min(100, usage.percent))
+  const remaining = Math.max(0, usage.contextWindow - usage.tokens)
+  const used = formatTokenCount(usage.tokens)
+  const remainingText = `${formatTokenCount(remaining)} left`
+  const valueText = `${used} used of ${contextWindow} tokens; ${remainingText}`
+
+  return (
+    <div aria-live="polite" className="min-w-28 text-xs/4 text-composer-muted-foreground">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium text-composer-foreground">Context</span>
+        <span>{remainingText}</span>
+      </div>
+      <div
+        aria-label="Context window"
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={percent}
+        aria-valuetext={valueText}
+        className="mt-1 h-1 overflow-hidden rounded-full bg-content-subtle-background"
+        role="progressbar"
+      >
+        <div className="h-full rounded-full bg-content-foreground" style={{ width: `${percent}%` }} />
+      </div>
+      <p className="mt-1">
+        {used} / {contextWindow}
+      </p>
+    </div>
+  )
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) return `${Math.round((tokens / 1_000_000) * 10) / 10}m`
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`
+
+  return String(tokens)
 }
 
 type ComposerConfigurationControlsProperties = Readonly<{

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -248,22 +248,18 @@ export function Composer({
           onSubmit={(delivery) => void submit(delivery)}
         />
         <div className="flex items-end justify-between gap-2 px-3 pt-1 pb-2" data-slot="composer-control-row">
-          {(contextUsage || sessionConfiguration) && (
-            <div className="flex min-w-0 items-end gap-3">
-              {contextUsage && <ContextWindowUsage usage={contextUsage} />}
-              {sessionConfiguration && (
-                <ComposerConfigurationControls
-                  snapshot={configuration}
-                  disabled={configurationDisabled || modelConfigurationRequired}
-                  pending={pendingConfiguration}
-                  describedBy={statusId}
-                  onModelChange={changeModel}
-                  onEffortChange={changeEffort}
-                />
-              )}
-            </div>
+          {sessionConfiguration && (
+            <ComposerConfigurationControls
+              snapshot={configuration}
+              disabled={configurationDisabled || modelConfigurationRequired}
+              pending={pendingConfiguration}
+              describedBy={statusId}
+              onModelChange={changeModel}
+              onEffortChange={changeEffort}
+            />
           )}
           <div className="ml-auto flex items-end gap-1">
+            {contextUsage && <ContextWindowUsage usage={contextUsage} />}
             {isWorking && stopRun && (
               <button
                 type="button"
@@ -328,56 +324,78 @@ type ContextWindowUsageProperties = Readonly<{
   usage: SessionContextUsage
 }>
 
+type ContextUsageLevel = 'nominal' | 'caution' | 'critical'
+
+function contextUsageLevel(percent: number): ContextUsageLevel {
+  if (percent >= 90) return 'critical'
+  if (percent >= 75) return 'caution'
+
+  return 'nominal'
+}
+
 function ContextWindowUsage({ usage }: ContextWindowUsageProperties) {
   const contextWindow = formatTokenCount(usage.contextWindow)
 
   if (usage.tokens === null || usage.percent === null) {
     return (
-      <div aria-live="polite" className="min-w-28 text-xs/4 text-composer-muted-foreground">
-        <p className="font-medium text-composer-foreground">Context</p>
-        <p>Updating after compaction…</p>
-        <p className="sr-only">Context window usage is unavailable until Pi finishes its next response.</p>
-        <p className="mt-1 h-1 overflow-hidden rounded-full bg-content-subtle-background">
-          <span className="block h-full w-1/3 animate-pulse rounded-full bg-content-muted-foreground motion-reduce:animate-none" />
-        </p>
-        <p className="mt-1">? / {contextWindow}</p>
+      <div className="flex h-11 items-end pb-3">
+        <span
+          className="context-usage"
+          data-level="nominal"
+          role="status"
+          title="Context window usage is updating after compaction"
+        >
+          <span aria-hidden="true" className="context-usage-track" />
+          <span aria-hidden="true" className="context-usage-value">
+            —
+          </span>
+          <span className="sr-only">
+            Context window usage is updating after compaction, and is unavailable until Pi finishes its next response.
+          </span>
+        </span>
       </div>
     )
   }
 
-  const percent = Math.max(0, Math.min(100, usage.percent))
+  // The runtime reports an unrounded float. The bar is drawn from it directly so
+  // sub-percent growth still moves;
+  const fraction = Math.max(0, Math.min(100, usage.percent))
+  const percent = Math.round(fraction)
   const remaining = Math.max(0, usage.contextWindow - usage.tokens)
   const used = formatTokenCount(usage.tokens)
-  const remainingText = `${formatTokenCount(remaining)} left`
-  const valueText = `${used} used of ${contextWindow} tokens; ${remainingText}`
+  const valueText = `${used} used of ${contextWindow} tokens; ${formatTokenCount(remaining)} left`
 
   return (
-    <div aria-live="polite" className="min-w-28 text-xs/4 text-composer-muted-foreground">
-      <div className="flex items-center justify-between gap-2">
-        <span className="font-medium text-composer-foreground">Context</span>
-        <span>{remainingText}</span>
-      </div>
-      <div
+    <div className="flex h-11 items-end pb-3">
+      <span
         aria-label="Context window"
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={percent}
         aria-valuetext={valueText}
-        className="mt-1 h-1 overflow-hidden rounded-full bg-content-subtle-background"
+        className="context-usage"
+        data-level={contextUsageLevel(percent)}
         role="progressbar"
+        title={valueText}
       >
-        <div className="h-full rounded-full bg-content-foreground" style={{ width: `${percent}%` }} />
-      </div>
-      <p className="mt-1">
-        {used} / {contextWindow}
-      </p>
+        <span aria-hidden="true" className="context-usage-track">
+          <span className="context-usage-fill" data-slot="context-usage-fill" style={{ width: `${fraction}%` }} />
+        </span>
+        <span aria-hidden="true" className="context-usage-value">
+          {percent}%
+        </span>
+      </span>
     </div>
   )
 }
 
 function formatTokenCount(tokens: number): string {
-  if (tokens >= 1_000_000) return `${Math.round((tokens / 1_000_000) * 10) / 10}m`
-  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`
+  const thousands = Math.round(tokens / 1_000)
+
+  // Roll over to millions once the rounded thousands would reach four digits,
+  // so a count just short of a million does not read as "1000k".
+  if (thousands >= 1_000) return `${Math.round((tokens / 1_000_000) * 10) / 10}m`
+  if (tokens >= 1_000) return `${thousands}k`
 
   return String(tokens)
 }

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -158,6 +158,7 @@ export function SessionContainer({
           draft={draft}
           focusRequest={composerFocusRequest}
           isWorking={isWorking}
+          contextUsage={transcriptState.snapshot?.contextUsage}
           onActivate={onActivate}
           onDraftChange={onDraftChange}
           submitMessage={submitMessage}

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -154,6 +154,8 @@
   --theme-success-background: color-mix(in oklab, #16a34a 15%, transparent);
   --theme-success-foreground: #15803d;
   --theme-activity-blocked: #b45309;
+  --theme-warning-foreground: #b45309;
+  --theme-warning-border: #b45309;
   --theme-activity-completed: #047857;
   --theme-activity-failed: #b91c1c;
   --theme-activity-running: var(--theme-content-foreground);
@@ -186,6 +188,8 @@
   --theme-success-background: color-mix(in oklab, #22c55e 10%, transparent);
   --theme-success-foreground: #4ade80;
   --theme-activity-blocked: #fcd34d;
+  --theme-warning-foreground: #fcd34d;
+  --theme-warning-border: #fcd34d;
   --theme-activity-completed: #6ee7b7;
   --theme-activity-failed: #f87171;
   --theme-activity-running: var(--theme-content-foreground);
@@ -218,6 +222,8 @@
   --theme-success-background: color-mix(in oklab, #50a14f 15%, transparent);
   --theme-success-foreground: #367a36;
   --theme-activity-blocked: #986801;
+  --theme-warning-foreground: #986801;
+  --theme-warning-border: #986801;
   --theme-activity-completed: #3d843c;
   --theme-activity-failed: #c43e34;
   --theme-activity-running: #4078f2;
@@ -251,6 +257,8 @@
   --theme-success-background: color-mix(in oklab, #98c379 12%, transparent);
   --theme-success-foreground: #98c379;
   --theme-activity-blocked: #e5c07b;
+  --theme-warning-foreground: #e5c07b;
+  --theme-warning-border: #e5c07b;
   --theme-activity-completed: #98c379;
   --theme-activity-failed: #e06c75;
   --theme-activity-running: #61afef;
@@ -306,6 +314,61 @@ body,
 
   .session-messages-reading-column {
     padding-inline: 1.5rem;
+  }
+}
+
+.context-usage {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  --context-usage-fill: var(--theme-accent);
+  --context-usage-foreground: var(--theme-composer-muted-foreground);
+}
+
+.context-usage[data-level='caution'] {
+  --context-usage-fill: var(--theme-warning-border);
+  --context-usage-foreground: var(--theme-warning-foreground);
+}
+
+.context-usage[data-level='critical'] {
+  --context-usage-fill: var(--theme-danger-border);
+  --context-usage-foreground: var(--theme-danger-foreground);
+}
+
+.context-usage-track {
+  width: 3.5rem;
+  height: 0.25rem;
+  overflow: hidden;
+  border-radius: 9999px;
+  background-color: color-mix(in oklab, var(--theme-content-border) 65%, transparent);
+}
+
+.context-usage-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background-color: var(--context-usage-fill);
+  /* An even ease reads as the bar filling; a sharply front-loaded curve makes
+     small increments snap and then crawl to a stop. */
+  transition:
+    width 340ms cubic-bezier(0.4, 0, 0.2, 1),
+    background-color 240ms ease-out;
+}
+
+/* Fixed width and tabular figures keep the bar from shifting as the count grows. */
+.context-usage-value {
+  width: 2rem;
+  font-size: 0.6875rem;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--context-usage-foreground);
+  transition: color 240ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .context-usage-fill,
+  .context-usage-value {
+    transition: none;
   }
 }
 

--- a/src/session-transcript.ts
+++ b/src/session-transcript.ts
@@ -28,10 +28,17 @@ export type SessionTranscriptEntry =
   | Readonly<{ type: 'message'; message: SessionTranscriptMessage }>
   | Readonly<{ type: 'activity'; activity: AgentActivity }>
 
+export type SessionContextUsage = Readonly<{
+  tokens: number | null
+  contextWindow: number
+  percent: number | null
+}>
+
 export type SessionTranscriptSnapshot = Readonly<{
   sessionId: SessionId
   revision: number
   isWorking: boolean
+  contextUsage?: SessionContextUsage
   runs: readonly AgentRun[]
   entries: readonly SessionTranscriptEntry[]
   runFailureReason?: 'failed' | 'cancelled'


### PR DESCRIPTION
## Summary

Expose Pi SDK context-window usage in the Session Composer. The indicator shows used and remaining capacity through an accessible progress bar, refreshes after replies and model changes, and explains its temporary post-compaction recalculation state. Pi SDK automatic compaction remains unchanged.

Demo scenarios now include zero, half-full, and full context-window examples for visual review.

## Related issue

Closes #8

## Validation

- [x] `bun run check` — passed: format, lint, typecheck, 464 tests, and production build.
- [x] Focused coverage verifies transcript projection/publication, Composer usage/recalculation states, and demo context states.
- [x] `bun run security:scan` was not run; this change does not affect dependencies or security-sensitive behavior.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed: none.
- [x] I have read and will follow the Code of Conduct.
