### PR TITLE
feat: isolate Agent bash tool executions

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -45,8 +45,9 @@ resolution:
 
 A Session can contain prompts, assistant responses and reasoning, provider and model identifiers, token and cost
 metadata, tool calls, tool input and output, command output, errors, summaries, timestamps, absolute paths, and Pi
-Workspace Agent Activity metadata. Session history is append-only and tree-shaped; compacting the model context does
-not remove earlier records from the Session file.
+Workspace Agent Activity metadata. Agent `bash` Tool Executions also retain their peak observed memory and termination
+outcome. Session history is append-only and tree-shaped; compacting the model context does not remove earlier records
+from the Session file.
 
 User-level Pi resources remain available in every Session. Managed Brainstorm and Implement Sessions also aggregate
 conventional instruction, extension, skill, prompt-template, and theme paths from every current Workspace Repository.
@@ -105,14 +106,26 @@ not confined by Brainstorm mode, Workspace membership, Repository routing, or ma
 inspect, create, change, or delete files and run programs with the permissions of the user who launched Pi Workspace.
 Only install extensions and packages whose authority is appropriate for the Workspace.
 
+Pi Workspace applies a default 2 GiB aggregate memory limit to each built-in Agent `bash` Tool Execution and records
+its peak observed memory and termination outcome. On Debian, the command runs in a transient user-systemd control group
+with swap disabled; the kernel enforces the limit across the control group, and Pi Workspace stops the complete control
+group when the Tool Execution ends. If user-systemd isolation is unavailable, the command fails rather than running
+without the limit.
+
+On macOS, where an equivalent unprivileged control-group facility is unavailable, Pi Workspace uses best-effort
+containment. It polls aggregate resident memory for the command's process group and observable descendants, then stops
+those processes when the Tool Execution ends or the observed total exceeds 2 GiB. A process can allocate beyond the
+limit between samples or deliberately evade observation by changing its process identity and environment. Treat this as
+protection against ordinary runaway commands, not as a security sandbox.
+
 Review prompts and Agent operations as carefully as shell commands. Use an operating-system account, container,
-virtual machine, filesystem permissions, and network controls appropriate to the sensitivity of the work. Pi Workspace
-does not currently provide per-command approval, repository-only filesystem confinement, process isolation, or network
-isolation for the Agent.
+virtual machine, filesystem permissions, and network controls appropriate to the sensitivity of the work. The built-in
+`bash` containment does not provide per-command approval, repository-only filesystem confinement, or network isolation,
+and it does not constrain processes started directly by user-installed extensions or other tools.
 
 Electron's renderer is separately sandboxed with context isolation, no Node integration, restricted navigation, and a
-narrow validated IPC bridge. This protects the privileged main process from renderer content; it does **not** sandbox
-the Pi Agent or its tools.
+narrow validated IPC bridge. This protects the privileged main process from renderer content; it does **not** turn the
+Pi Agent or its tools into a security sandbox.
 
 ## Logging and telemetry
 

--- a/src/main/activity-records.test.ts
+++ b/src/main/activity-records.test.ts
@@ -62,6 +62,18 @@ test('rejects malformed operation records', () => {
         inputPreview: 1,
       },
     },
+    {
+      version: 1,
+      type: 'operation',
+      execution: {
+        toolCallId: 'tool-1',
+        activityId: 'activity-1',
+        toolName: 'bash',
+        label: 'bash',
+        status: 'failed',
+        commandOutcome: { termination: 'memory-limit', peakMemoryBytes: -1 },
+      },
+    },
   ]
 
   for (const record of malformedOperations) assert.equal(isActivityLayerRecord(record), false)
@@ -138,6 +150,11 @@ test('accepts complete historical records', () => {
         status: 'completed',
         rawResultReference: 'tool-1',
         inputPreview: 'src/main/activity-records.ts',
+        commandOutcome: {
+          termination: 'exited',
+          peakMemoryBytes: 1_048_576,
+          exitCode: 0,
+        },
       },
     },
     { version: 1, type: 'activity-removed', activityId: 'activity-1' },

--- a/src/main/activity-records.ts
+++ b/src/main/activity-records.ts
@@ -112,7 +112,26 @@ function isToolExecution(value: unknown): value is Omit<ToolExecution, 'input'> 
     isNonEmptyString(value.label) &&
     (value.status === 'running' || value.status === 'completed' || value.status === 'failed') &&
     isOptionalString(value.rawResultReference) &&
-    isOptionalString(value.inputPreview)
+    isOptionalString(value.inputPreview) &&
+    isOptionalCommandOutcome(value.commandOutcome)
+  )
+}
+
+function isOptionalCommandOutcome(value: unknown): boolean {
+  if (value === undefined) return true
+  if (!isRecord(value)) return false
+
+  return (
+    (value.termination === 'exited' ||
+      value.termination === 'exit-code' ||
+      value.termination === 'signaled' ||
+      value.termination === 'memory-limit' ||
+      value.termination === 'timeout' ||
+      value.termination === 'aborted' ||
+      value.termination === 'isolation-failure') &&
+    isCount(value.peakMemoryBytes) &&
+    (value.exitCode === undefined || isCount(value.exitCode)) &&
+    isOptionalString(value.signal)
   )
 }
 

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -36,6 +36,8 @@ import {
 } from '@/src/main/pi-session-runtimes'
 import { classifyPersistedAgentState } from '@/src/main/pi-session-history'
 import { createManagedSessionServices } from '@/src/main/managed-session-resources'
+import { createIsolatedBashTool } from '@/src/main/isolated-bash-tool'
+import type { IsolatedCommandResult } from '@/src/main/isolated-command'
 import {
   managedSessionMethodology,
   parsePiWorkstreamKnowledgeMutation,
@@ -77,6 +79,7 @@ export async function createPiSessionRuntime(
   ])
 
   const runtimeListeners = new Set<(event: PiSessionRuntimeEvent) => void>()
+  const commandOutcomes = new Map<string, IsolatedCommandResult>()
   let managedPolicyFailure: string | undefined
   const managedRunControl: { abort?: () => void } = {}
 
@@ -193,7 +196,12 @@ export async function createPiSessionRuntime(
           }),
         ]
       : []
-  const customTools = [startActivity, completeActivity, ...managedTools]
+  const isolatedBash = createIsolatedBashTool(directoryPath, {
+    onExecutionFinished(toolCallId, outcome) {
+      commandOutcomes.set(toolCallId, outcome)
+    },
+  })
+  const customTools = [isolatedBash, startActivity, completeActivity, ...managedTools]
   const managedServices =
     options.kind === 'managed'
       ? await createManagedSessionServices(
@@ -286,7 +294,7 @@ export async function createPiSessionRuntime(
           }
         }
 
-        const normalized = normalizePiSessionEvent(event, modelTurnNoProgressTimeoutMs)
+        const normalized = normalizePiSessionEvent(event, modelTurnNoProgressTimeoutMs, commandOutcomes)
 
         if (normalized) listener(normalized)
       })
@@ -414,6 +422,7 @@ export async function createPiSessionRuntime(
       return session.settingsManager.drainErrors().map(({ error }) => error.message)
     },
     dispose() {
+      commandOutcomes.clear()
       session.dispose()
     },
   }
@@ -458,7 +467,8 @@ function messageContent(content: unknown): { text: string; hasToolCalls: boolean
 
 function normalizePiSessionEvent(
   event: { type: string; [key: string]: unknown },
-  modelTurnNoProgressTimeoutMs: number
+  modelTurnNoProgressTimeoutMs: number,
+  commandOutcomes?: Map<string, IsolatedCommandResult>
 ): PiSessionRuntimeEvent | undefined {
   if (event.type === 'tool_execution_start') {
     return {
@@ -469,13 +479,18 @@ function normalizePiSessionEvent(
     }
   }
   if (event.type === 'tool_execution_end') {
+    const toolCallId = String(event.toolCallId)
+    const commandOutcome = commandOutcomes?.get(toolCallId)
+    commandOutcomes?.delete(toolCallId)
+
     return {
       type: event.type,
-      toolCallId: String(event.toolCallId),
+      toolCallId,
       toolName: String(event.toolName),
       result: event.result,
       isError: event.isError === true,
-      rawResultReference: String(event.toolCallId),
+      rawResultReference: toolCallId,
+      commandOutcome,
     }
   }
   if (event.type === 'turn_start') {

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -36,7 +36,7 @@ import {
 } from '@/src/main/pi-session-runtimes'
 import { classifyPersistedAgentState } from '@/src/main/pi-session-history'
 import { createManagedSessionServices } from '@/src/main/managed-session-resources'
-import { createIsolatedBashTool } from '@/src/main/isolated-bash-tool'
+import { createIsolatedBashTool, type IsolatedShellOptions } from '@/src/main/isolated-bash-tool'
 import type { IsolatedCommandResult } from '@/src/main/isolated-command'
 import {
   managedSessionMethodology,
@@ -80,6 +80,7 @@ export async function createPiSessionRuntime(
 
   const runtimeListeners = new Set<(event: PiSessionRuntimeEvent) => void>()
   const commandOutcomes = new Map<string, IsolatedCommandResult>()
+  let resolveShellOptions: () => IsolatedShellOptions = () => ({})
   let managedPolicyFailure: string | undefined
   const managedRunControl: { abort?: () => void } = {}
 
@@ -197,6 +198,7 @@ export async function createPiSessionRuntime(
         ]
       : []
   const isolatedBash = createIsolatedBashTool(directoryPath, {
+    getShellOptions: () => resolveShellOptions(),
     onExecutionFinished(toolCallId, outcome) {
       commandOutcomes.set(toolCallId, outcome)
     },
@@ -216,6 +218,10 @@ export async function createPiSessionRuntime(
     customTools,
     resourceLoader: managedServices?.resourceLoader,
     settingsManager: managedServices?.settingsManager,
+  })
+  resolveShellOptions = () => ({
+    commandPrefix: session.settingsManager.getShellCommandPrefix(),
+    shellPath: session.settingsManager.getShellPath(),
   })
   const getAvailableSkillResources = () =>
     session.settingsManager.getEnableSkillCommands()

--- a/src/main/isolated-bash-tool.ts
+++ b/src/main/isolated-bash-tool.ts
@@ -1,3 +1,5 @@
+import { constants } from 'node:fs'
+import { access as fsAccess } from 'node:fs/promises'
 import { createBashTool, type BashOperations } from '@earendil-works/pi-coding-agent'
 import {
   defaultToolExecutionMemoryLimitBytes,
@@ -5,8 +7,17 @@ import {
   type IsolatedCommandResult,
 } from './isolated-command'
 
+const maximumTimeoutMilliseconds = 2_147_483_647
+const maximumTimeoutSeconds = maximumTimeoutMilliseconds / 1000
+
+export type IsolatedShellOptions = Readonly<{
+  commandPrefix?: string
+  shellPath?: string
+}>
+
 type IsolatedBashToolOptions = Readonly<{
   memoryLimitBytes?: number
+  getShellOptions?: () => IsolatedShellOptions
   onExecutionFinished?: (toolCallId: string, outcome: IsolatedCommandResult) => void
 }>
 
@@ -22,14 +33,33 @@ export function createIsolatedBashTool(cwd: string, options: IsolatedBashToolOpt
       signal?: AbortSignal,
       onUpdate?: Parameters<typeof template.execute>[3]
     ) {
+      const shellOptions = options.getShellOptions?.() ?? {}
       let outcome: IsolatedCommandResult | undefined
       const operations: BashOperations = {
         async exec(command, commandCwd, executionOptions) {
+          validateTimeout(executionOptions.timeout)
+          if (executionOptions.signal?.aborted) throw new Error('aborted')
+
+          if (shellOptions.shellPath) {
+            try {
+              await fsAccess(shellOptions.shellPath, constants.F_OK)
+            } catch {
+              throw new Error(`Custom shell path not found: ${shellOptions.shellPath}`)
+            }
+          }
+
+          try {
+            await fsAccess(commandCwd, constants.F_OK)
+          } catch {
+            throw new Error(`Working directory does not exist: ${commandCwd}\nCannot execute bash commands.`)
+          }
+
           outcome = await executeIsolatedCommand(command, commandCwd, {
             memoryLimitBytes,
             timeoutSeconds: executionOptions.timeout,
             signal: executionOptions.signal,
             env: executionOptions.env,
+            shellPath: shellOptions.shellPath,
             onData: executionOptions.onData,
           })
 
@@ -50,7 +80,7 @@ export function createIsolatedBashTool(cwd: string, options: IsolatedBashToolOpt
           throw new Error('Command could not start because isolated execution is unavailable.')
         },
       }
-      const tool = createBashTool(cwd, { operations })
+      const tool = createBashTool(cwd, { commandPrefix: shellOptions.commandPrefix, operations })
 
       try {
         return await tool.execute(toolCallId, input, signal, onUpdate)
@@ -58,6 +88,16 @@ export function createIsolatedBashTool(cwd: string, options: IsolatedBashToolOpt
         if (outcome) options.onExecutionFinished?.(toolCallId, outcome)
       }
     },
+  }
+}
+
+function validateTimeout(timeoutSeconds: number | undefined): void {
+  if (timeoutSeconds === undefined) return
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+    throw new Error('Invalid timeout: must be a finite number of seconds')
+  }
+  if (timeoutSeconds > maximumTimeoutSeconds) {
+    throw new Error(`Invalid timeout: maximum is ${maximumTimeoutSeconds} seconds`)
   }
 }
 

--- a/src/main/isolated-bash-tool.ts
+++ b/src/main/isolated-bash-tool.ts
@@ -1,0 +1,75 @@
+import { createBashTool, type BashOperations } from '@earendil-works/pi-coding-agent'
+import {
+  defaultToolExecutionMemoryLimitBytes,
+  executeIsolatedCommand,
+  type IsolatedCommandResult,
+} from './isolated-command'
+
+type IsolatedBashToolOptions = Readonly<{
+  memoryLimitBytes?: number
+  onExecutionFinished?: (toolCallId: string, outcome: IsolatedCommandResult) => void
+}>
+
+export function createIsolatedBashTool(cwd: string, options: IsolatedBashToolOptions = {}) {
+  const memoryLimitBytes = options.memoryLimitBytes ?? defaultToolExecutionMemoryLimitBytes
+  const template = createBashTool(cwd)
+
+  return {
+    ...template,
+    async execute(
+      toolCallId: string,
+      input: Readonly<{ command: string; timeout?: number }>,
+      signal?: AbortSignal,
+      onUpdate?: Parameters<typeof template.execute>[3]
+    ) {
+      let outcome: IsolatedCommandResult | undefined
+      const operations: BashOperations = {
+        async exec(command, commandCwd, executionOptions) {
+          outcome = await executeIsolatedCommand(command, commandCwd, {
+            memoryLimitBytes,
+            timeoutSeconds: executionOptions.timeout,
+            signal: executionOptions.signal,
+            env: executionOptions.env,
+            onData: executionOptions.onData,
+          })
+
+          if (outcome.termination === 'exited' || outcome.termination === 'exit-code') {
+            return { exitCode: outcome.exitCode ?? null }
+          }
+          if (outcome.termination === 'aborted') throw new Error('aborted')
+          if (outcome.termination === 'timeout') throw new Error(`timeout:${executionOptions.timeout}`)
+          if (outcome.termination === 'memory-limit') {
+            throw new Error(
+              `Command exceeded its ${formatMemorySize(memoryLimitBytes)} memory limit (peak ${formatMemorySize(outcome.peakMemoryBytes)}).`
+            )
+          }
+          if (outcome.termination === 'signaled') {
+            throw new Error(`Command was stopped by signal ${outcome.signal ?? 'unknown'}.`)
+          }
+
+          throw new Error('Command could not start because isolated execution is unavailable.')
+        },
+      }
+      const tool = createBashTool(cwd, { operations })
+
+      try {
+        return await tool.execute(toolCallId, input, signal, onUpdate)
+      } finally {
+        if (outcome) options.onExecutionFinished?.(toolCallId, outcome)
+      }
+    },
+  }
+}
+
+function formatMemorySize(bytes: number): string {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
+  let value = bytes
+  let unitIndex = 0
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  return `${Number.isInteger(value) ? value : value.toFixed(1)} ${units[unitIndex]}`
+}

--- a/src/main/isolated-command-process-group.ts
+++ b/src/main/isolated-command-process-group.ts
@@ -1,0 +1,220 @@
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import type { IsolatedCommandOptions, IsolatedCommandResult } from './isolated-command'
+
+type IsolatedProcess = Readonly<{
+  pid: number
+  processGroupId: number
+  residentMemoryBytes: number
+}>
+
+export function executeInProcessGroup(
+  command: string,
+  cwd: string,
+  options: IsolatedCommandOptions
+): Promise<IsolatedCommandResult> {
+  const markerName = `PI_WORKSPACE_TOOL_${randomUUID().replaceAll('-', '')}`
+  const markerValue = '1'
+  const executionMarker = `${markerName}=${markerValue}`
+  const child = spawn('/bin/bash', ['-c', command], {
+    cwd,
+    detached: true,
+    env: { [markerName]: markerValue, ...(options.env ?? process.env) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+  let peakMemoryBytes = 0
+  let requestedTermination: 'memory-limit' | 'timeout' | 'aborted' | 'isolation-failure' | undefined
+  let exited = false
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let sampleInProgress = false
+  let observedProcesses: readonly IsolatedProcess[] = []
+
+  const killGroup = () => {
+    killIsolatedProcesses(observedProcesses, child.pid)
+  }
+  const stop = (termination: 'memory-limit' | 'timeout' | 'aborted' | 'isolation-failure') => {
+    if (requestedTermination) return
+
+    requestedTermination = termination
+    killGroup()
+  }
+  const onAbort = () => stop('aborted')
+  const sampleMemory = async () => {
+    if (!child.pid || exited || sampleInProgress) return
+
+    sampleInProgress = true
+
+    try {
+      const processes = await isolatedProcessSnapshot(executionMarker)
+      if (processes === undefined) {
+        stop('isolation-failure')
+        return
+      }
+
+      observedProcesses = processes
+      const currentMemoryBytes = processes.reduce((total, process) => total + process.residentMemoryBytes, 0)
+      peakMemoryBytes = Math.max(peakMemoryBytes, currentMemoryBytes)
+
+      if (exited) {
+        killGroup()
+        return
+      }
+
+      if (currentMemoryBytes > options.memoryLimitBytes) stop('memory-limit')
+    } finally {
+      sampleInProgress = false
+    }
+  }
+
+  if (options.timeoutSeconds !== undefined) {
+    timeout = setTimeout(() => stop('timeout'), options.timeoutSeconds * 1000)
+    timeout.unref?.()
+  }
+  if (options.signal) {
+    if (options.signal.aborted) onAbort()
+    else options.signal.addEventListener('abort', onAbort, { once: true })
+  }
+
+  child.stdout.on('data', (data: Buffer) => options.onData?.(data))
+  child.stderr.on('data', (data: Buffer) => options.onData?.(data))
+  const memoryPoll = setInterval(() => void sampleMemory(), 25)
+  memoryPoll.unref?.()
+  void sampleMemory()
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (result: IsolatedCommandResult) => {
+      if (settled) return
+
+      settled = true
+      exited = true
+      if (timeout) clearTimeout(timeout)
+      clearInterval(memoryPoll)
+      if (options.signal) options.signal.removeEventListener('abort', onAbort)
+      resolve(result)
+    }
+
+    child.once('error', () => finish({ termination: 'isolation-failure', peakMemoryBytes }))
+    child.once('exit', () => {
+      exited = true
+      killGroup()
+    })
+    child.once('close', async (exitCode, childSignal) => {
+      const finalProcesses = await isolatedProcessSnapshot(executionMarker)
+      if (finalProcesses === undefined && !requestedTermination) {
+        finish({ termination: 'isolation-failure', peakMemoryBytes })
+        return
+      }
+      if (finalProcesses) {
+        observedProcesses = finalProcesses
+        const finalMemoryBytes = finalProcesses.reduce((total, process) => total + process.residentMemoryBytes, 0)
+        peakMemoryBytes = Math.max(peakMemoryBytes, finalMemoryBytes)
+        if (finalMemoryBytes > options.memoryLimitBytes) requestedTermination ??= 'memory-limit'
+      }
+      killGroup()
+
+      if (requestedTermination) {
+        finish({ termination: requestedTermination, peakMemoryBytes, signal: childSignal ?? undefined })
+      } else if (exitCode === 0) {
+        finish({ termination: 'exited', peakMemoryBytes, exitCode })
+      } else if (exitCode !== null) {
+        finish({ termination: 'exit-code', peakMemoryBytes, exitCode })
+      } else {
+        finish({ termination: 'signaled', peakMemoryBytes, signal: childSignal ?? undefined })
+      }
+    })
+  })
+}
+
+function isolatedProcessSnapshot(executionMarker: string): Promise<readonly IsolatedProcess[] | undefined> {
+  const markerMidpoint = Math.floor(executionMarker.length / 2)
+  const markerStart = executionMarker.slice(0, markerMidpoint)
+  const markerEnd = executionMarker.slice(markerMidpoint)
+  const processList = spawn('/bin/ps', ['axeww', '-o', 'pid=,pgid=,rss=,command='], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+    windowsHide: true,
+  })
+  const filter = spawn(
+    '/usr/bin/awk',
+    [
+      '-v',
+      `markerStart=${markerStart}`,
+      '-v',
+      `markerEnd=${markerEnd}`,
+      'index($0, markerStart markerEnd) { print $1, $2, $3 }',
+    ],
+    { stdio: ['pipe', 'pipe', 'ignore'], windowsHide: true }
+  )
+  let output = ''
+  let processListFailed = false
+
+  processList.stdout.pipe(filter.stdin)
+  filter.stdin.on('error', () => {})
+  processList.once('error', () => {
+    processListFailed = true
+    filter.stdin.end()
+  })
+  processList.once('close', (exitCode) => {
+    if (exitCode !== 0) processListFailed = true
+  })
+  filter.stdout.on('data', (data: Buffer) => {
+    output += data.toString('utf8')
+  })
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (processes: readonly IsolatedProcess[] | undefined) => {
+      if (settled) return
+
+      settled = true
+      resolve(processes)
+    }
+
+    filter.once('error', () => finish(undefined))
+    filter.once('close', (exitCode) => {
+      if (exitCode !== 0 || processListFailed) {
+        finish(undefined)
+        return
+      }
+
+      const processes = output
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => {
+          const [pid, processGroupId, residentKibibytes] = line.trim().split(/\s+/).map(Number)
+
+          return {
+            pid: pid ?? 0,
+            processGroupId: processGroupId ?? 0,
+            residentMemoryBytes: (residentKibibytes ?? 0) * 1024,
+          }
+        })
+        .filter((process) => process.pid > 1 && process.processGroupId > 1)
+
+      finish(processes)
+    })
+  })
+}
+
+function killIsolatedProcesses(processes: readonly IsolatedProcess[], rootPid: number | undefined): void {
+  const processGroupIds = new Set(processes.map((process) => process.processGroupId))
+  if (rootPid) processGroupIds.add(rootPid)
+
+  for (const processGroupId of processGroupIds) {
+    try {
+      process.kill(-processGroupId, 'SIGKILL')
+    } catch {
+      // The process group has already stopped.
+    }
+  }
+
+  for (const isolatedProcess of processes) {
+    try {
+      process.kill(isolatedProcess.pid, 'SIGKILL')
+    } catch {
+      // The process has already stopped.
+    }
+  }
+}

--- a/src/main/isolated-command-process-group.ts
+++ b/src/main/isolated-command-process-group.ts
@@ -16,7 +16,7 @@ export function executeInProcessGroup(
   const markerName = `PI_WORKSPACE_TOOL_${randomUUID().replaceAll('-', '')}`
   const markerValue = '1'
   const executionMarker = `${markerName}=${markerValue}`
-  const child = spawn('/bin/bash', ['-c', command], {
+  const child = spawn(options.shellPath ?? '/bin/bash', ['-c', command], {
     cwd,
     detached: true,
     env: { [markerName]: markerValue, ...(options.env ?? process.env) },

--- a/src/main/isolated-command-systemd.ts
+++ b/src/main/isolated-command-systemd.ts
@@ -17,8 +17,9 @@ export function executeInSystemdUnit(
   const unitName = `pi-workspace-tool-${randomUUID()}`
   const loaderScript = [
     "IFS= read -r -d '' command",
+    "IFS= read -r -d '' shell",
     'while IFS= read -r -d \'\' assignment; do export "$assignment"; done',
-    'exec /bin/bash -c "$command"',
+    'exec "$shell" -c "$command"',
   ]
     .join('\n')
     .replaceAll('$', '$$')
@@ -50,6 +51,7 @@ export function executeInSystemdUnit(
   const environment = options.env ?? process.env
   const payload = [
     command,
+    options.shellPath ?? '/bin/bash',
     ...Object.entries(environment).flatMap(([name, value]) => (value === undefined ? [] : [`${name}=${value}`])),
   ]
     .map((value) => `${value}\0`)

--- a/src/main/isolated-command-systemd.ts
+++ b/src/main/isolated-command-systemd.ts
@@ -1,0 +1,186 @@
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import type { IsolatedCommandOptions, IsolatedCommandResult } from './isolated-command'
+
+const systemdSummaryPrefixes = [
+  'Main processes terminated with:',
+  'Service runtime:',
+  'CPU time consumed:',
+  'Memory peak:',
+]
+
+export function executeInSystemdUnit(
+  command: string,
+  cwd: string,
+  options: IsolatedCommandOptions
+): Promise<IsolatedCommandResult> {
+  const unitName = `pi-workspace-tool-${randomUUID()}`
+  const loaderScript = [
+    "IFS= read -r -d '' command",
+    'while IFS= read -r -d \'\' assignment; do export "$assignment"; done',
+    'exec /bin/bash -c "$command"',
+  ]
+    .join('\n')
+    .replaceAll('$', '$$')
+  const child = spawn(
+    'systemd-run',
+    [
+      '--user',
+      '--pipe',
+      '--wait',
+      '--collect',
+      `--unit=${unitName}`,
+      `--working-directory=${cwd}`,
+      '--service-type=exec',
+      '--property=MemoryAccounting=yes',
+      `--property=MemoryMax=${options.memoryLimitBytes}`,
+      '--property=MemorySwapMax=0',
+      '--property=OOMPolicy=stop',
+      '--property=KillMode=control-group',
+      '/bin/bash',
+      '-c',
+      loaderScript,
+    ],
+    {
+      env: { ...process.env, LC_ALL: 'C' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    }
+  )
+  const environment = options.env ?? process.env
+  const payload = [
+    command,
+    ...Object.entries(environment).flatMap(([name, value]) => (value === undefined ? [] : [`${name}=${value}`])),
+  ]
+    .map((value) => `${value}\0`)
+    .join('')
+  child.stdin.on('error', () => {})
+  child.stdin.end(payload)
+
+  let stderr = ''
+  let summaryStarted = false
+  let summaryLines: string[] = []
+  let systemdResult: string | undefined
+  let peakMemoryBytes = 0
+  let exitCode: number | undefined
+  let signal: string | undefined
+  let requestedTermination: 'timeout' | 'aborted' | undefined
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let unitStarted = false
+
+  const flushSummaryCandidate = () => {
+    if (summaryLines.length > 0) options.onData?.(Buffer.from(`${summaryLines.join('\n')}\n`))
+
+    summaryStarted = false
+    summaryLines = []
+    systemdResult = undefined
+    peakMemoryBytes = 0
+    exitCode = undefined
+    signal = undefined
+  }
+  const stopUnit = () => {
+    const stopper = spawn('systemctl', ['--user', 'stop', `${unitName}.service`], {
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    stopper.on('error', () => {})
+    stopper.unref()
+  }
+  const stop = (termination: 'timeout' | 'aborted') => {
+    if (requestedTermination) return
+
+    requestedTermination = termination
+    if (unitStarted) stopUnit()
+  }
+  const onAbort = () => stop('aborted')
+
+  if (options.timeoutSeconds !== undefined) {
+    timeout = setTimeout(() => stop('timeout'), options.timeoutSeconds * 1000)
+    timeout.unref?.()
+  }
+  if (options.signal) {
+    if (options.signal.aborted) onAbort()
+    else options.signal.addEventListener('abort', onAbort, { once: true })
+  }
+
+  child.stdout.on('data', (data: Buffer) => options.onData?.(data))
+  child.stderr.on('data', (data: Buffer) => {
+    stderr += data.toString('utf8')
+    const lines = stderr.split('\n')
+    stderr = lines.pop() ?? ''
+
+    for (const line of lines) {
+      if (line.startsWith(`Running as unit: ${unitName}.service`)) {
+        unitStarted = true
+        if (requestedTermination) stopUnit()
+        continue
+      }
+
+      const summaryOffset = line.lastIndexOf('Finished with result:')
+      if (summaryOffset >= 0) {
+        if (summaryStarted) flushSummaryCandidate()
+        if (summaryOffset > 0) options.onData?.(Buffer.from(line.slice(0, summaryOffset)))
+
+        summaryStarted = true
+        summaryLines.push(line.slice(summaryOffset))
+        systemdResult = line.slice(summaryOffset + 'Finished with result:'.length).trim()
+        continue
+      }
+
+      if (summaryStarted && systemdSummaryPrefixes.some((prefix) => line.startsWith(prefix))) {
+        summaryLines.push(line)
+
+        const peak = line.match(/^Memory peak:\s+([\d.]+)([KMGT]?)\b/)
+        if (peak) peakMemoryBytes = memorySizeInBytes(Number(peak[1]), peak[2] ?? '')
+
+        const termination = line.match(/^Main processes terminated with: code=(\w+), status=(\d+)\/([A-Z0-9]+)$/)
+        if (termination?.[1] === 'exited') exitCode = Number(termination[2])
+        if (termination?.[1] === 'killed') signal = termination[3]
+        continue
+      }
+
+      if (summaryStarted) flushSummaryCandidate()
+      options.onData?.(Buffer.from(`${line}\n`))
+    }
+  })
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (result: IsolatedCommandResult) => {
+      if (settled) return
+
+      settled = true
+      if (timeout) clearTimeout(timeout)
+      if (options.signal) options.signal.removeEventListener('abort', onAbort)
+      resolve(result)
+    }
+
+    child.once('error', () => finish({ termination: 'isolation-failure', peakMemoryBytes: 0 }))
+    child.once('close', (systemdExitCode) => {
+      if (stderr) {
+        if (summaryStarted) flushSummaryCandidate()
+        options.onData?.(Buffer.from(stderr))
+      }
+
+      if (requestedTermination) {
+        finish({ termination: requestedTermination, peakMemoryBytes, signal })
+      } else if (systemdResult === 'oom-kill') {
+        finish({ termination: 'memory-limit', peakMemoryBytes, signal })
+      } else if (systemdResult === 'success' && (exitCode ?? systemdExitCode) === 0) {
+        finish({ termination: 'exited', peakMemoryBytes, exitCode: 0 })
+      } else if (exitCode !== undefined) {
+        finish({ termination: 'exit-code', peakMemoryBytes, exitCode })
+      } else if (signal) {
+        finish({ termination: 'signaled', peakMemoryBytes, signal })
+      } else {
+        finish({ termination: 'isolation-failure', peakMemoryBytes })
+      }
+    })
+  })
+}
+
+function memorySizeInBytes(value: number, unit: string): number {
+  const exponent = ['', 'K', 'M', 'G', 'T'].indexOf(unit)
+
+  return Math.round(value * 1024 ** Math.max(0, exponent))
+}

--- a/src/main/isolated-command.test.ts
+++ b/src/main/isolated-command.test.ts
@@ -1,10 +1,21 @@
 import assert from 'node:assert/strict'
+import { randomUUID } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { test } from 'node:test'
 import { createIsolatedBashTool } from './isolated-bash-tool'
 import { defaultToolExecutionMemoryLimitBytes, executeIsolatedCommand } from './isolated-command'
 
 const mebibyte = 1024 * 1024
 const memoryExhaustionCommand = `${JSON.stringify(process.execPath)} -e 'const value = new Uint8Array(256 * 1024 * 1024); value.fill(1); setTimeout(() => console.log(value.length), 10_000)'`
+
+function firstTextContent(
+  result: Awaited<ReturnType<ReturnType<typeof createIsolatedBashTool>['execute']>>
+): string | undefined {
+  const content = result.content[0]
+
+  return content?.type === 'text' ? content.text : undefined
+}
 
 async function waitForProcessExit(pid: number): Promise<void> {
   for (let attempt = 0; attempt < 20; attempt += 1) {
@@ -34,6 +45,45 @@ const userSystemdAvailable = await canUseUserSystemd()
 
 test('Agent bash commands default to a 2 GiB memory limit', () => {
   assert.equal(defaultToolExecutionMemoryLimitBytes, 2 * 1024 * mebibyte)
+})
+
+test('the bash tool retains Pi timeout validation', async () => {
+  const tool = createIsolatedBashTool(process.cwd())
+
+  await assert.rejects(
+    () => tool.execute('tool-1', { command: 'true', timeout: 0 }),
+    /Invalid timeout: must be a finite number of seconds/
+  )
+})
+
+test('the bash tool retains Pi working-directory errors', async () => {
+  const missingDirectory = join(tmpdir(), `pi-workspace-missing-${randomUUID()}`)
+  const tool = createIsolatedBashTool(missingDirectory)
+
+  await assert.rejects(
+    () => tool.execute('tool-1', { command: 'true' }),
+    new RegExp(`Working directory does not exist: ${missingDirectory}`)
+  )
+})
+
+test('the bash tool retains Pi shell command prefixes', { skip: !userSystemdAvailable }, async () => {
+  const tool = createIsolatedBashTool(process.cwd(), {
+    getShellOptions: () => ({ commandPrefix: 'export PI_WORKSPACE_PREFIX=retained' }),
+  })
+
+  const result = await tool.execute('tool-1', { command: 'printf %s "$PI_WORKSPACE_PREFIX"' })
+
+  assert.equal(firstTextContent(result), 'retained')
+})
+
+test('the bash tool retains Pi configured shell paths', { skip: !userSystemdAvailable }, async () => {
+  const tool = createIsolatedBashTool(process.cwd(), {
+    getShellOptions: () => ({ shellPath: '/bin/sh' }),
+  })
+
+  const result = await tool.execute('tool-1', { command: 'printf %s "$0"' })
+
+  assert.equal(firstTextContent(result), '/bin/sh')
 })
 
 test(

--- a/src/main/isolated-command.test.ts
+++ b/src/main/isolated-command.test.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createIsolatedBashTool } from './isolated-bash-tool'
+import { defaultToolExecutionMemoryLimitBytes, executeIsolatedCommand } from './isolated-command'
+
+const mebibyte = 1024 * 1024
+const memoryExhaustionCommand = `${JSON.stringify(process.execPath)} -e 'const value = new Uint8Array(256 * 1024 * 1024); value.fill(1); setTimeout(() => console.log(value.length), 10_000)'`
+
+async function waitForProcessExit(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      process.kill(pid, 0)
+    } catch {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+
+  assert.fail(`Process ${pid} remained alive.`)
+}
+
+async function canUseUserSystemd(): Promise<boolean> {
+  if (process.platform !== 'linux') return false
+
+  const result = await executeIsolatedCommand('true', process.cwd(), {
+    memoryLimitBytes: 64 * mebibyte,
+  }).catch(() => undefined)
+
+  return result?.termination === 'exited'
+}
+
+const userSystemdAvailable = await canUseUserSystemd()
+
+test('Agent bash commands default to a 2 GiB memory limit', () => {
+  assert.equal(defaultToolExecutionMemoryLimitBytes, 2 * 1024 * mebibyte)
+})
+
+test(
+  'a command exceeding its memory limit is stopped without terminating the caller',
+  { skip: !userSystemdAvailable },
+  async () => {
+    const result = await executeIsolatedCommand(memoryExhaustionCommand, process.cwd(), {
+      memoryLimitBytes: 96 * mebibyte,
+    })
+
+    assert.equal(result.termination, 'memory-limit')
+    assert.ok(result.peakMemoryBytes > 0)
+  }
+)
+
+test('a successful command preserves stderr without a trailing newline', { skip: !userSystemdAvailable }, async () => {
+  let output = ''
+
+  const result = await executeIsolatedCommand('printf error-output >&2', process.cwd(), {
+    memoryLimitBytes: 64 * mebibyte,
+    onData(data) {
+      output += data.toString('utf8')
+    },
+  })
+
+  assert.equal(result.termination, 'exited')
+  assert.equal(output, 'error-output')
+})
+
+test('a successful command preserves stderr resembling systemd metadata', { skip: !userSystemdAvailable }, async () => {
+  let output = ''
+
+  const result = await executeIsolatedCommand("printf 'Finished with result: success\\n' >&2", process.cwd(), {
+    memoryLimitBytes: 64 * mebibyte,
+    onData(data) {
+      output += data.toString('utf8')
+    },
+  })
+
+  assert.equal(result.termination, 'exited')
+  assert.equal(output, 'Finished with result: success\n')
+})
+
+test('process-group isolation stops a command exceeding its memory limit', async () => {
+  const result = await executeIsolatedCommand(memoryExhaustionCommand, process.cwd(), {
+    memoryLimitBytes: 96 * mebibyte,
+    platform: 'darwin',
+  })
+
+  assert.equal(result.termination, 'memory-limit')
+  assert.ok(result.peakMemoryBytes > 96 * mebibyte)
+})
+
+test('process-group memory accounting includes a descendant in another process group', async () => {
+  const allocatorProgram = `const value = new Uint8Array(256 * 1024 * 1024); value.fill(1); setTimeout(() => {}, 10_000)`
+  const descendantProgram = `const { spawn } = require('node:child_process'); const child = spawn(process.execPath, ['-e', ${JSON.stringify(allocatorProgram)}], { detached: true, stdio: 'ignore' }); console.log(child.pid); child.unref(); setTimeout(() => {}, 10_000)`
+  const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(descendantProgram)}`
+  let output = ''
+  let descendantPid = 0
+
+  try {
+    const result = await executeIsolatedCommand(command, process.cwd(), {
+      memoryLimitBytes: 96 * mebibyte,
+      platform: 'darwin',
+      onData(data) {
+        output += data.toString('utf8')
+      },
+    })
+    descendantPid = Number(output.trim())
+
+    assert.equal(result.termination, 'memory-limit')
+    assert.ok(Number.isInteger(descendantPid) && descendantPid > 1, JSON.stringify(output))
+  } finally {
+    if (descendantPid > 1) {
+      try {
+        process.kill(descendantPid, 'SIGKILL')
+      } catch {
+        // The isolated command already stopped the descendant.
+      }
+    }
+  }
+})
+
+test('the bash tool reports memory exhaustion as a useful failure', { skip: !userSystemdAvailable }, async () => {
+  const tool = createIsolatedBashTool(process.cwd(), { memoryLimitBytes: 96 * mebibyte })
+
+  await assert.rejects(
+    () => tool.execute('tool-1', { command: memoryExhaustionCommand }),
+    /exceeded its 96 MiB memory limit/
+  )
+})
+
+test('the bash tool retains the command termination outcome', { skip: !userSystemdAvailable }, async () => {
+  let observedTermination: string | undefined
+  const tool = createIsolatedBashTool(process.cwd(), {
+    memoryLimitBytes: 96 * mebibyte,
+    onExecutionFinished(_toolCallId, outcome) {
+      observedTermination = outcome.termination
+    },
+  })
+
+  await tool.execute('tool-1', { command: memoryExhaustionCommand }).catch(() => undefined)
+
+  assert.equal(observedTermination, 'memory-limit')
+})
+
+test('background descendants are stopped when their command completes', { skip: !userSystemdAvailable }, async () => {
+  let output = ''
+
+  const result = await executeIsolatedCommand('nohup sleep 60 >/dev/null 2>&1 & echo $!', process.cwd(), {
+    memoryLimitBytes: 64 * mebibyte,
+    onData(data) {
+      output += data.toString('utf8')
+    },
+  })
+  const descendantPid = Number(output.trim())
+
+  assert.equal(result.termination, 'exited')
+  assert.ok(Number.isInteger(descendantPid) && descendantPid > 1, JSON.stringify(output))
+  await waitForProcessExit(descendantPid)
+})
+
+test('timing out a command stops all of its descendants', { skip: !userSystemdAvailable }, async () => {
+  let output = ''
+
+  const result = await executeIsolatedCommand('nohup sleep 60 >/dev/null 2>&1 & echo $!; wait', process.cwd(), {
+    memoryLimitBytes: 64 * mebibyte,
+    timeoutSeconds: 1,
+    onData(data) {
+      output += data.toString('utf8')
+    },
+  })
+  const descendantPid = Number(output.trim())
+
+  assert.equal(result.termination, 'timeout')
+  assert.ok(Number.isInteger(descendantPid) && descendantPid > 1, JSON.stringify(output))
+  await waitForProcessExit(descendantPid)
+})
+
+test('process-group isolation also stops background descendants when their command completes', async () => {
+  let output = ''
+
+  const result = await executeIsolatedCommand('nohup sleep 60 >/dev/null 2>&1 & echo $!', process.cwd(), {
+    memoryLimitBytes: 64 * mebibyte,
+    platform: 'darwin',
+    onData(data) {
+      output += data.toString('utf8')
+    },
+  })
+  const descendantPid = Number(output.trim())
+
+  assert.equal(result.termination, 'exited')
+  assert.ok(Number.isInteger(descendantPid) && descendantPid > 1, JSON.stringify(output))
+  await waitForProcessExit(descendantPid)
+})
+
+test('process-group isolation stops a descendant that creates another process group', async () => {
+  const descendantProgram = `const { spawn } = require('node:child_process'); const child = spawn('sleep', ['60'], { detached: true, stdio: 'ignore' }); console.log(child.pid); child.unref()`
+  const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(descendantProgram)}`
+  let output = ''
+  let descendantPid = 0
+
+  try {
+    const result = await executeIsolatedCommand(command, process.cwd(), {
+      memoryLimitBytes: 64 * mebibyte,
+      platform: 'darwin',
+      onData(data) {
+        output += data.toString('utf8')
+      },
+    })
+    descendantPid = Number(output.trim())
+
+    assert.equal(result.termination, 'exited')
+    assert.ok(Number.isInteger(descendantPid) && descendantPid > 1, JSON.stringify(output))
+    await waitForProcessExit(descendantPid)
+  } finally {
+    if (descendantPid > 1) {
+      try {
+        process.kill(descendantPid, 'SIGKILL')
+      } catch {
+        // The isolated command already stopped the descendant.
+      }
+    }
+  }
+})

--- a/src/main/isolated-command.ts
+++ b/src/main/isolated-command.ts
@@ -9,6 +9,7 @@ export type IsolatedCommandOptions = Readonly<{
   timeoutSeconds?: number
   signal?: AbortSignal
   env?: NodeJS.ProcessEnv
+  shellPath?: string
   onData?: (data: Buffer) => void
   platform?: NodeJS.Platform
 }>

--- a/src/main/isolated-command.ts
+++ b/src/main/isolated-command.ts
@@ -1,0 +1,29 @@
+import type { ToolExecutionCommandOutcome } from '@/src/session-timeline'
+import { executeInProcessGroup } from './isolated-command-process-group'
+import { executeInSystemdUnit } from './isolated-command-systemd'
+
+export type IsolatedCommandResult = ToolExecutionCommandOutcome
+
+export type IsolatedCommandOptions = Readonly<{
+  memoryLimitBytes: number
+  timeoutSeconds?: number
+  signal?: AbortSignal
+  env?: NodeJS.ProcessEnv
+  onData?: (data: Buffer) => void
+  platform?: NodeJS.Platform
+}>
+
+export const defaultToolExecutionMemoryLimitBytes = 2 * 1024 * 1024 * 1024
+
+export function executeIsolatedCommand(
+  command: string,
+  cwd: string,
+  options: IsolatedCommandOptions
+): Promise<IsolatedCommandResult> {
+  const platform = options.platform ?? process.platform
+
+  if (platform === 'linux') return executeInSystemdUnit(command, cwd, options)
+  if (platform === 'darwin') return executeInProcessGroup(command, cwd, options)
+
+  return Promise.resolve({ termination: 'isolation-failure', peakMemoryBytes: 0 })
+}

--- a/src/main/pi-session-runtime-transcript.ts
+++ b/src/main/pi-session-runtime-transcript.ts
@@ -55,6 +55,7 @@ export function operationRecord(execution: ToolExecution): Omit<ToolExecution, '
     status: execution.status,
     rawResultReference: execution.rawResultReference,
     inputPreview: execution.inputPreview,
+    commandOutcome: execution.commandOutcome,
   }
 }
 

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -28,6 +28,7 @@ import {
   type ConversationEntry,
   type SessionWorkingStateSnapshot,
   type ToolExecution,
+  type ToolExecutionCommandOutcome,
 } from '@/src/session-timeline'
 import type {
   SessionTranscriptEntry,
@@ -97,6 +98,7 @@ export type PiSessionRuntimeEvent =
       result: unknown
       isError: boolean
       rawResultReference?: string
+      commandOutcome?: ToolExecutionCommandOutcome
     }>
   | Readonly<{ type: 'message_upsert'; message: SessionTranscriptMessage }>
   | Readonly<{ type: 'model_turn_started'; noProgressTimeoutMs: number }>
@@ -738,6 +740,7 @@ export function createPiSessionRuntimeRegistry({
         ...operation.execution,
         status: event.isError ? 'failed' : 'completed',
         rawResultReference: event.rawResultReference ?? event.toolCallId,
+        commandOutcome: event.commandOutcome,
       }
       operation.result = event.result
 
@@ -1251,6 +1254,7 @@ export function createPiSessionRuntimeRegistry({
             input: input.text,
             output: output?.text,
             truncated: input.truncated || (output?.truncated ?? false),
+            commandOutcome: execution.commandOutcome,
           }
         }),
       }

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { sessionId } from '@/src/domain/session'
+import type { ActivityLayerRecord } from './activity-records'
 import { createPiSessionRuntimeRegistry, type PiSessionRuntime } from './pi-session-runtimes'
 
 test('keeps duplicate messages ordered and updates one streaming identity', async () => {
@@ -130,6 +131,50 @@ test('rejects a selected Skill that is unavailable to the Session runtime', asyn
 
   assert.deepEqual(result, { status: 'rejected', reason: 'skill-unavailable' })
   assert.equal(prompted, false)
+})
+
+test('persists command resource usage and termination in its Tool Execution', async () => {
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const records: ActivityLayerRecord[] = []
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt(_text, options) {
+      options.preflightResult(true)
+    },
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('command-outcome-session')
+
+  await registry.submit({ sessionId: id, text: 'run it', delivery: 'steer' })
+  emit({ type: 'tool_execution_start', toolCallId: 'tool-1', toolName: 'bash', input: { command: 'bun test' } })
+  emit({
+    type: 'tool_execution_end',
+    toolCallId: 'tool-1',
+    toolName: 'bash',
+    result: { content: [{ type: 'text', text: 'memory limit exceeded' }] },
+    isError: true,
+    commandOutcome: { termination: 'memory-limit', peakMemoryBytes: 2_147_483_648, signal: 'KILL' },
+  })
+
+  const operation = records.findLast((record) => record.type === 'operation')
+
+  assert.equal(operation?.type, 'operation')
+  assert.deepEqual(operation?.type === 'operation' ? operation.execution.commandOutcome : undefined, {
+    termination: 'memory-limit',
+    peakMemoryBytes: 2_147_483_648,
+    signal: 'KILL',
+  })
 })
 
 test('publishes a failed transcript run without a parallel failure stream', async () => {

--- a/src/session-timeline.ts
+++ b/src/session-timeline.ts
@@ -14,6 +14,15 @@ export type AgentActivityKind = (typeof agentActivityKinds)[number] | 'other'
 export type AgentRunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 export type AgentActivityStatus = 'pending' | 'running' | 'completed' | 'failed' | 'blocked'
 export type ToolExecutionStatus = 'running' | 'completed' | 'failed'
+export type ToolExecutionCommandTermination =
+  'exited' | 'exit-code' | 'signaled' | 'memory-limit' | 'timeout' | 'aborted' | 'isolation-failure'
+
+export type ToolExecutionCommandOutcome = Readonly<{
+  termination: ToolExecutionCommandTermination
+  peakMemoryBytes: number
+  exitCode?: number
+  signal?: string
+}>
 
 export type ConversationEntry = Readonly<{
   type: 'conversation'
@@ -64,6 +73,7 @@ export type ToolExecution = Readonly<{
   input: unknown
   rawResultReference?: string
   inputPreview?: string
+  commandOutcome?: ToolExecutionCommandOutcome
 }>
 
 export type AgentActivity = Readonly<{
@@ -108,6 +118,7 @@ export type ActivityOperationDetail = Readonly<{
   input: string
   output?: string
   truncated: boolean
+  commandOutcome?: ToolExecutionCommandOutcome
 }>
 
 export type AgentActivityDetails = Readonly<{


### PR DESCRIPTION
## Summary

- replace Pi's built-in Agent `bash` execution with a resource-contained adapter
- enforce a 2 GiB aggregate memory limit with transient user-systemd control groups on Debian and best-effort process accounting on macOS
- stop background descendants when Tool Executions finish, time out, abort, or exceed the observed memory limit
- retain command termination and peak-memory metadata in Tool Executions and document the platform guarantees
- preserve Pi's configured shell path and command prefix, timeout validation, working-directory errors, output handling, and rendering

On macOS, aggregate RSS enforcement is sampled and best-effort because the platform does not expose an unprivileged cgroup equivalent. The security documentation describes this limitation and keeps extension-launched processes outside the guarantee.

## Related issue

None.

## Validation

- `bun test src/main/isolated-command.test.ts --max-concurrency=1` — 16 passed
- `bun run check` — formatting, lint, type checking, 476 tests, and production build passed
- `bun run security:scan` — no leaks or dependency issues found
- manually confirmed no `sleep 60` descendants or `pi-workspace-tool-*` user-systemd units remained after validation
- TDD regression tests initially reproduced the Linux stderr parsing and detached-descendant failures; an interim typecheck also caught a shadowed variable. All were corrected before the final successful validation.

- [x] `bun run check`
- [x] Focused tests or manual validation are described above.
- [x] `bun run security:scan` was run, or this change does not affect dependencies or security-sensitive behavior.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed. No dependencies, copied material, generated assets, or license implications were added.
- [x] I have read and will follow the Code of Conduct.

