### PR TITLE
Create Implement Session worktrees lazily

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,11 +46,14 @@ The Session mode for investigating every Repository in its Workspace, asking que
 _Avoid_: Research Mode
 
 **Implement**:
-The Session mode for changing and validating Workspace Repositories with Pi's normal tools across supplied Repository working paths.
+The Session mode for changing and validating Workspace Repositories with Pi's normal tools. It can inspect every current Workspace Repository checkout and lazily creates an isolated Implement Session Worktree before changing a Repository.
 _Avoid_: Implementation Mode, Execution Mode
 
+**Implement Session Worktree**:
+An ordinary Git worktree owned by one Implement Session for one Repository. It is created only when that Session prepares to modify the Repository, starts from the Repository's current local `HEAD`, and is never shared with another Session.
+
 **Session**:
-A persistent Pi interaction associated with one Workstream. Each Session has an immutable mode and Repository access: direct access to one selected Repository working location for Default or automatic access to every current Workspace Repository working location for Brainstorm and Implement.
+A persistent Pi interaction associated with one Workstream. Each Session has an immutable mode and Repository access: direct access to one selected Repository working location for Default or automatic access to every current Workspace Repository for Brainstorm and Implement. Implement changes use that Session's lazily created Implement Session Worktrees.
 _Avoid_: Chat, thread
 
 **Changelog**:

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Then:
 
 ## Session modes
 
-| Mode           | Best for                                  | Repository access                                                                               |
-| -------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Default**    | A focused Quick Session in one Repository | Works directly in the selected Repository's current checkout or a dedicated worktree.           |
-| **Brainstorm** | Investigation, questions, and planning    | Can inspect every Repository in the Workspace. Read-only behavior is instructed, not sandboxed. |
-| **Implement**  | Making and validating Repository changes  | Can use Pi's normal tools across every current Workspace Repository.                            |
+| Mode           | Best for                                  | Repository access                                                                                                      |
+| -------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Default**    | A focused Quick Session in one Repository | Works directly in the selected Repository's current checkout or a dedicated worktree.                                  |
+| **Brainstorm** | Investigation, questions, and planning    | Can inspect every Repository in the Workspace. Read-only behavior is instructed, not sandboxed.                        |
+| **Implement**  | Making and validating Repository changes  | Can inspect every Repository and lazily creates a separate Session worktree for each Repository it prepares to change. |
 
 A Workspace is a routing boundary, not an operating-system sandbox. Pi, installed extensions, and commands run with your normal user permissions.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -95,10 +95,12 @@ A Workspace or Workstream is an application routing boundary, not an operating-s
   worktree with Pi's normal tools.
 - A **Brainstorm Session** receives every current Workspace Repository working path and Pi's normal tools. Its system
   prompt instructs the Agent not to modify Repository content, but this is methodology rather than sandbox enforcement.
-- An **Implement Session** receives the same Workspace Repository working paths and may use Pi's normal tools to change
-  and validate Repository content.
-- Managed Sessions expose Workspace metadata and structured Workstream knowledge through Pi Workspace-owned tools. They do
-  not add Repository approval prompts or per-operation confirmations before normal Pi tool use.
+- An **Implement Session** can inspect every current Workspace Repository checkout. Before changing a Repository, its
+  methodology directs the Agent to request a dedicated worktree created for that Session from the Repository's current
+  local `HEAD`, then make and validate changes there. This routing is instructed rather than filesystem-enforced.
+- Managed Sessions expose Workspace metadata, lazy Implement worktree preparation, and structured Workstream knowledge
+  through Pi Workspace-owned tools. They do not add Repository approval prompts or per-operation confirmations before
+  normal Pi tool use.
 
 User-installed extensions remain trusted local code with their normal authority. Their tools and lifecycle hooks are
 not confined by Brainstorm mode, Workspace membership, Repository routing, or managed worktrees. An extension can

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -190,9 +190,7 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       },
       async previewWorktreeLocations(_workspaceId, repositoryId) {
         const workstreamId = '00000000-0000-4000-8000-000000000052'
-        const repositories = repositoryId
-          ? demoRepositories.filter((repository) => repository.id === repositoryId)
-          : demoRepositories
+        const repositories = demoRepositories.filter((repository) => repository.id === repositoryId)
 
         return {
           workstreamId,
@@ -208,8 +206,7 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       async createWorkstream(workspaceId, options) {
         createdSessionNumber += 1
         const createdSessionId = sessionId(`workstream-session-${createdSessionNumber}`)
-        const workstreamId = options.workstreamId ?? `workstream-${createdSessionNumber}`
-        const workingLocation = options.workingLocation ?? ('current-checkouts' as const)
+        const workstreamId = `workstream-${createdSessionNumber}`
         workstreamsSnapshot = {
           revision: workstreamsSnapshot.revision + 1,
           workstreams: [
@@ -219,16 +216,13 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
               workspaceId,
               goal: options.goal.trim(),
               lifecycle: 'active' as const,
-              workingLocation,
+              workingLocation: 'current-checkouts' as const,
               repositoryWorkingLocations: demoRepositories.map((repository) => ({
                 repositoryId: repository.id,
                 repositoryName: repository.name,
-                kind: workingLocation === 'worktrees' ? ('worktree' as const) : ('current-checkout' as const),
+                kind: 'current-checkout' as const,
                 availability: 'available' as const,
-                workingPath:
-                  workingLocation === 'worktrees'
-                    ? `/Users/maya/Projects/.worktrees/${workstreamId}/${repository.id}`
-                    : repository.directoryPath,
+                workingPath: repository.directoryPath,
               })),
               sessions: [
                 {

--- a/src/domain/managed-session.ts
+++ b/src/domain/managed-session.ts
@@ -10,7 +10,14 @@ type ManagedSessionRuntimeRepositoryProperties = Readonly<{
 }>
 
 export type ManagedSessionRuntimeRepository = ManagedSessionRuntimeRepositoryProperties &
-  (Readonly<{ availability: 'available'; workingPath: string }> | Readonly<{ availability: 'unavailable' }>)
+  (
+    | Readonly<{
+        availability: 'available'
+        workingPath: string
+        workingLocation: 'source-checkout' | 'session-worktree'
+      }>
+    | Readonly<{ availability: 'unavailable' }>
+  )
 
 export type ManagedSessionRuntimePolicy = Readonly<{
   workspaceId: string

--- a/src/domain/workstream.ts
+++ b/src/domain/workstream.ts
@@ -77,8 +77,6 @@ export type WorktreeLocationsPreview = Readonly<{
 export type CreateWorkstreamOptions = Readonly<{
   goal: string
   mode?: ManagedSessionMode
-  workingLocation?: WorkstreamWorkingLocation
-  workstreamId?: string
 }>
 
 export type CreateQuickSessionOptions = Readonly<{

--- a/src/main/application-state/index.ts
+++ b/src/main/application-state/index.ts
@@ -16,6 +16,7 @@ import type {
 import {
   createWorktree as createGitWorktree,
   inspectGitRepository,
+  restoreWorktree as restoreGitWorktree,
   type InspectedGitRepository,
   type WorktreeProposal,
 } from '@/src/main/git-repositories'
@@ -28,6 +29,7 @@ import { createWorkstreamKnowledgeFacade } from './workstream-knowledge-facade'
 import {
   createWorkstreamSessionStore,
   type OwnedSessionResolution,
+  type PreparedSessionRepository,
   type WorkstreamCreationResult,
 } from './workstream-session-store'
 import { incrementRevision, initializeApplicationStateStore, loadSqlite } from './application-state-store'
@@ -43,7 +45,11 @@ export type ApplicationAuthorityOptions = Readonly<{
   createWorktree?: (proposal: WorktreeProposal) => Promise<WorktreeProposal>
 }>
 
-export type { OwnedSessionResolution, WorkstreamCreationResult } from './workstream-session-store'
+export type {
+  OwnedSessionResolution,
+  PreparedSessionRepository,
+  WorkstreamCreationResult,
+} from './workstream-session-store'
 
 export type ApplicationAuthority = Readonly<{
   startup: ApplicationStateStartup
@@ -60,9 +66,10 @@ export type ApplicationAuthority = Readonly<{
     update: WorkspaceMembershipUpdate
   ): Promise<WorkspacesSnapshot>
   getWorkstreamSnapshot(workspaceId: string): Promise<WorkstreamsSnapshot>
-  previewWorktreeLocations(workspaceId: string, repositoryId?: string): Promise<WorktreeLocationsPreview>
+  previewWorktreeLocations(workspaceId: string, repositoryId: string): Promise<WorktreeLocationsPreview>
   createWorkstream(workspaceId: string, options: CreateWorkstreamOptions): Promise<WorkstreamCreationResult>
   createQuickSession(workspaceId: string, options: CreateQuickSessionOptions): Promise<WorkstreamCreationResult>
+  prepareSessionRepository(sessionId: SessionId, repositoryId: string): Promise<PreparedSessionRepository>
   createWorkstreamSession(workstreamId: string, options: CreateSessionOptions): Promise<WorkstreamCreationResult>
   setWorkstreamLifecycle(workstreamId: string, lifecycle: WorkstreamLifecycle): Promise<WorkstreamsSnapshot>
   renameWorkstreamSession(sessionId: SessionId, title: string): Promise<WorkstreamsSnapshot>
@@ -130,6 +137,7 @@ export async function initializeApplicationAuthority(
     openDatabase,
     inspectRepository,
     createWorktree,
+    restoreWorktree: restoreGitWorktree,
     sessionFiles,
     incrementRevision,
     reconcilePendingSessionFiles,
@@ -141,6 +149,7 @@ export async function initializeApplicationAuthority(
     previewWorktreeLocations,
     createWorkstream,
     createQuickSession,
+    prepareSessionRepository,
     createWorkstreamSession,
     setWorkstreamLifecycle,
     renameWorkstreamSession,
@@ -165,6 +174,7 @@ export async function initializeApplicationAuthority(
     previewWorktreeLocations,
     createWorkstream,
     createQuickSession,
+    prepareSessionRepository,
     createWorkstreamSession,
     setWorkstreamLifecycle,
     renameWorkstreamSession,

--- a/src/main/application-state/workstream-knowledge-store.ts
+++ b/src/main/application-state/workstream-knowledge-store.ts
@@ -61,6 +61,11 @@ export function assertRepositoryMembershipRemovalAllowed(
                 SELECT location.repository_id
                   FROM workstream_repository_locations location
                  WHERE location.workstream_id = w.id AND location.kind = 'worktree'
+                UNION
+                SELECT location.repository_id
+                  FROM session_repository_locations location
+                  JOIN sessions owner ON owner.id = location.session_id
+                 WHERE owner.workstream_id = w.id AND location.kind = 'worktree'
               ) current_repositories
              WHERE current_repositories.repository_id = ?
           )
@@ -87,11 +92,16 @@ export function readCurrentWorkstreamRepositorySet(database: SqliteDatabase, wor
            SELECT location.repository_id
              FROM workstream_repository_locations location
             WHERE location.workstream_id = ? AND location.kind = 'worktree'
+           UNION
+           SELECT location.repository_id
+             FROM session_repository_locations location
+             JOIN sessions owner ON owner.id = location.session_id
+            WHERE owner.workstream_id = ? AND location.kind = 'worktree'
          )
         WHERE repository_id IS NOT NULL
         ORDER BY repository_id`
     )
-    .all(workstreamId, workstreamId, workstreamId)
+    .all(workstreamId, workstreamId, workstreamId, workstreamId)
 
   return rows.map((row) => String(row.repository_id))
 }

--- a/src/main/application-state/workstream-session-store.ts
+++ b/src/main/application-state/workstream-session-store.ts
@@ -44,6 +44,7 @@ type WorkstreamSessionStoreOptions = Readonly<{
   openDatabase: () => SqliteDatabase
   inspectRepository: RepositoryInspector
   createWorktree: (proposal: WorktreeProposal) => Promise<WorktreeProposal>
+  restoreWorktree: (proposal: WorktreeProposal) => Promise<WorktreeProposal>
   sessionFiles: PiSessionFileStore
   incrementRevision: (database: SqliteDatabase) => void
   reconcilePendingSessionFiles: (
@@ -74,10 +75,17 @@ export type WorkstreamCreationResult = Readonly<{
   snapshot: WorkstreamsSnapshot
 }>
 
+export type PreparedSessionRepository = Readonly<{
+  repositoryId: string
+  workingPath: string
+  resourcePolicyRevision: number
+}>
+
 export function createWorkstreamSessionStore({
   openDatabase,
   inspectRepository,
   createWorktree,
+  restoreWorktree,
   sessionFiles,
   incrementRevision,
   reconcilePendingSessionFiles,
@@ -368,181 +376,26 @@ export function createWorkstreamSessionStore({
       .run(sessionId, workstreamId, repositoryId ?? null, repositoryId ?? null)
   }
 
-  const sessionLocationPreparations = new Map<SessionId, Promise<void>>()
-
-  async function prepareDedicatedSessionWorktrees(sessionId: SessionId): Promise<void> {
-    const ongoing = sessionLocationPreparations.get(sessionId)
-    if (ongoing) return ongoing
-
-    const preparation = prepareDedicatedSessionWorktreesNow(sessionId)
-    sessionLocationPreparations.set(sessionId, preparation)
-
-    try {
-      await preparation
-    } finally {
-      if (sessionLocationPreparations.get(sessionId) === preparation) sessionLocationPreparations.delete(sessionId)
-    }
-  }
-
-  async function prepareDedicatedSessionWorktreesNow(sessionId: SessionId): Promise<void> {
-    const sessionDatabase = openDatabase()
-    let session: Readonly<{ workstreamId: string; workspaceId: string }> | undefined
-
-    try {
-      const row = sessionDatabase
-        .prepare(
-          `SELECT session.workstream_id, workstream.workspace_id
-             FROM sessions session
-             JOIN workstreams workstream ON workstream.id = session.workstream_id
-            WHERE session.id = ?
-              AND session.access_kind = 'managed'
-              AND session.mode IN ('brainstorm', 'implement')
-              AND workstream.lifecycle = 'active'`
-        )
-        .get(sessionId)
-      session = row ? { workstreamId: String(row.workstream_id), workspaceId: String(row.workspace_id) } : undefined
-    } finally {
-      sessionDatabase.close()
-    }
-
-    if (!session) return
-
-    const repositoryDatabase = openDatabase()
-    let repositories: readonly Readonly<{ id: string; directoryPath: string }>[]
-
-    try {
-      repositories = repositoryDatabase
-        .prepare(
-          `SELECT repository.id, repository.directory_path
-             FROM workspace_repositories membership
-             JOIN repositories repository ON repository.id = membership.repository_id
-            WHERE membership.workspace_id = ? AND repository.availability = 'available'
-            ORDER BY membership.rowid`
-        )
-        .all(session.workspaceId)
-        .map((row) => ({ id: String(row.id), directoryPath: String(row.directory_path) }))
-    } finally {
-      repositoryDatabase.close()
-    }
-
-    for (const repository of repositories) {
-      await prepareDedicatedSessionRepositoryWorktree(sessionId, session.workstreamId, repository)
-    }
-  }
-
-  async function prepareDedicatedSessionRepositoryWorktree(
+  function insertCurrentCheckoutSessionLocation(
+    database: SqliteDatabase,
     sessionId: SessionId,
-    workstreamId: string,
-    repository: Readonly<{ id: string; directoryPath: string }>
-  ): Promise<void> {
-    const existing = openDatabase()
-
-    try {
-      const location = existing
-        .prepare('SELECT 1 FROM session_repository_locations WHERE session_id = ? AND repository_id = ?')
-        .get(sessionId, repository.id)
-      if (location) return
-    } finally {
-      existing.close()
-    }
-
-    let proposal: WorktreeProposal
-
-    try {
-      proposal = await proposeWorktree({
-        repositoryId: repository.id,
-        repositoryPath: repository.directoryPath,
-        workstreamId: sessionId,
-      })
-    } catch {
-      const fallback = openDatabase()
-      try {
-        fallback.exec('BEGIN IMMEDIATE;')
-        fallback
-          .prepare(
-            `INSERT INTO session_repository_locations
-              (session_id, repository_id, kind, working_path, availability)
-             VALUES (?, ?, 'current-checkout', ?, 'available')
-             ON CONFLICT (session_id, repository_id) DO NOTHING`
-          )
-          .run(sessionId, repository.id, repository.directoryPath)
-        fallback.exec('COMMIT;')
-      } catch {
-        try {
-          fallback.exec('ROLLBACK;')
-        } catch {
-          // The transaction may already have rolled back.
-        }
-      } finally {
-        fallback.close()
-      }
-      return
-    }
-
-    const recorded = openDatabase()
-    try {
-      recorded.exec('BEGIN IMMEDIATE;')
-      recorded
-        .prepare(
-          `INSERT INTO session_repository_locations
-            (session_id, repository_id, kind, working_path, branch, base_commit, availability)
-           VALUES (?, ?, 'worktree', ?, ?, ?, 'unavailable')
-           ON CONFLICT (session_id, repository_id) DO NOTHING`
-        )
-        .run(sessionId, repository.id, proposal.worktreePath, proposal.branch, proposal.baseCommit)
-      recorded.exec('COMMIT;')
-    } catch {
-      try {
-        recorded.exec('ROLLBACK;')
-      } catch {
-        // The transaction may already have rolled back.
-      }
-      return
-    } finally {
-      recorded.close()
-    }
-
-    let available: boolean
-
-    try {
-      const exists =
-        (await inspectWorktree({
-          worktreePath: proposal.worktreePath,
-          commonDirectoryPath: proposal.commonDirectoryPath,
-          expectedBranch: proposal.branch,
-        })) === 'available'
-      if (!exists) await createWorktree(proposal)
-      available = true
-    } catch {
-      available = false
-    }
-
-    const updated = openDatabase()
-    try {
-      updated.exec('BEGIN IMMEDIATE;')
-      updated
-        .prepare('UPDATE session_repository_locations SET availability = ? WHERE session_id = ? AND repository_id = ?')
-        .run(available ? 'available' : 'unavailable', sessionId, repository.id)
-      updated
-        .prepare('UPDATE workstreams SET working_location_revision = working_location_revision + 1 WHERE id = ?')
-        .run(workstreamId)
-      incrementRevision(updated)
-      updated.exec('COMMIT;')
-    } catch {
-      try {
-        updated.exec('ROLLBACK;')
-      } catch {
-        // The transaction may already have rolled back.
-      }
-    } finally {
-      updated.close()
-    }
+    repositoryId: string
+  ): void {
+    database
+      .prepare(
+        `INSERT INTO session_repository_locations
+          (session_id, repository_id, kind, working_path, availability)
+         SELECT ?, id, 'current-checkout', directory_path, availability
+           FROM repositories
+          WHERE id = ?`
+      )
+      .run(sessionId, repositoryId)
   }
 
   async function previewWorktreeProposal(
     workspaceId: string,
     workstreamId: string,
-    repositoryId?: string
+    repositoryId: string
   ): Promise<readonly WorktreeProposal[]> {
     const database = openDatabase()
 
@@ -558,12 +411,12 @@ export function createWorkstreamSessionStore({
            JOIN repositories repository ON repository.id = membership.repository_id
           WHERE membership.workspace_id = ?
             AND repository.availability = 'available'
-            AND (? IS NULL OR repository.id = ?)
+            AND repository.id = ?
           ORDER BY membership.rowid`
         )
-        .all(workspaceId, repositoryId ?? null, repositoryId ?? null)
+        .all(workspaceId, repositoryId)
 
-      if (repositoryId && repositories.length === 0) {
+      if (repositories.length === 0) {
         throw new TypeError('Select an available Repository from the current Workspace.')
       }
 
@@ -572,7 +425,7 @@ export function createWorkstreamSessionStore({
           proposeWorktree({
             repositoryId: String(repository.id),
             repositoryPath: String(repository.directory_path),
-            workstreamId,
+            worktreeId: workstreamId,
           })
         )
       )
@@ -583,7 +436,7 @@ export function createWorkstreamSessionStore({
 
   async function previewWorktreeLocations(
     workspaceId: string,
-    repositoryId?: string
+    repositoryId: string
   ): Promise<WorktreeLocationsPreview> {
     const workstreamId = createWorkstreamId()
     const proposals = await previewWorktreeProposal(workspaceId, workstreamId, repositoryId)
@@ -600,24 +453,10 @@ export function createWorkstreamSessionStore({
     }
   }
 
-  function insertCurrentCheckoutLocations(database: SqliteDatabase, workspaceId: string, workstreamId: string): void {
-    database
-      .prepare(
-        `INSERT INTO workstream_repository_locations
-        (workstream_id, repository_id, kind, working_path, availability)
-       SELECT ?, repository.id, 'current-checkout', repository.directory_path, repository.availability
-         FROM workspace_repositories membership
-         JOIN repositories repository ON repository.id = membership.repository_id
-        WHERE membership.workspace_id = ?`
-      )
-      .run(workstreamId, workspaceId)
-  }
-
-  async function prepareWorktreeBackedWorkstream(
+  async function prepareWorktreeBackedQuickSession(
     workspaceId: string,
     workstreamId: string,
-    goal: string | null,
-    repositoryId?: string
+    repositoryId: string
   ): Promise<void> {
     const proposals = await previewWorktreeProposal(workspaceId, workstreamId, repositoryId)
     const database = openDatabase()
@@ -659,7 +498,7 @@ export function createWorkstreamSessionStore({
 
         if (
           existing.workspace_id !== workspaceId ||
-          existing.goal !== goal ||
+          existing.goal !== null ||
           existing.working_location !== 'worktrees' ||
           Number(existing.session_count) > 0 ||
           !previewMatches
@@ -671,10 +510,9 @@ export function createWorkstreamSessionStore({
       } else {
         database
           .prepare(
-            "INSERT INTO workstreams (id, workspace_id, goal, lifecycle, working_location, created_at) VALUES (?, ?, ?, 'active', 'worktrees', ?)"
+            "INSERT INTO workstreams (id, workspace_id, goal, lifecycle, working_location, created_at) VALUES (?, ?, NULL, 'active', 'worktrees', ?)"
           )
-          .run(workstreamId, workspaceId, goal, Date.now())
-        if (goal !== null) initializeStoredWorkstreamKnowledge(database, workstreamId)
+          .run(workstreamId, workspaceId, Date.now())
         for (const proposal of proposals) {
           database
             .prepare(
@@ -746,41 +584,6 @@ export function createWorkstreamSessionStore({
     options: CreateWorkstreamOptions
   ): Promise<WorkstreamCreationResult> {
     const goal = normalizeWorkstreamGoal(options.goal)
-    const workingLocation = options.workingLocation ?? 'current-checkouts'
-
-    if (workingLocation === 'worktrees') {
-      if (
-        !options.workstreamId ||
-        !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(options.workstreamId)
-      ) {
-        throw new TypeError('Preview the Workstream worktree locations before creation.')
-      }
-
-      await prepareWorktreeBackedWorkstream(workspaceId, options.workstreamId, goal)
-
-      const finalized = openDatabase()
-      let sessionId: SessionId
-      try {
-        finalized.exec('BEGIN IMMEDIATE;')
-        sessionId = insertOwnedSession(finalized, options.workstreamId, { mode: normalizeSessionMode(options.mode) })
-        insertSessionWorkingLocationsFromWorkstream(finalized, sessionId, options.workstreamId)
-        incrementRevision(finalized)
-        finalized.exec('COMMIT;')
-      } catch (error) {
-        try {
-          finalized.exec('ROLLBACK;')
-        } catch {
-          // The transaction may already have rolled back.
-        }
-        throw error
-      } finally {
-        finalized.close()
-      }
-
-      const status = await reconcileCommittedSession(sessionId)
-      return { status, sessionId, snapshot: await getWorkstreamSnapshot(workspaceId, false) }
-    }
-
     const database = openDatabase()
     let sessionId: SessionId
 
@@ -790,52 +593,14 @@ export function createWorkstreamSessionStore({
         throw new TypeError('The Workspace no longer exists.')
       }
 
-      const workstreamId = options.workstreamId ?? createWorkstreamId()
-      if (
-        options.workstreamId &&
-        !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(options.workstreamId)
-      ) {
-        throw new TypeError('The Workstream worktree preview can no longer be used.')
-      }
-
-      const failedWorktreeCreation = database
-        .prepare(
-          `SELECT workstream.workspace_id, workstream.goal, workstream.working_location,
-                COUNT(session.id) AS session_count,
-                SUM(CASE WHEN location.availability = 'available' THEN 1 ELSE 0 END) AS available_location_count
-           FROM workstreams workstream
-           LEFT JOIN sessions session ON session.workstream_id = workstream.id
-           LEFT JOIN workstream_repository_locations location ON location.workstream_id = workstream.id
-          WHERE workstream.id = ?
-          GROUP BY workstream.id`
-        )
-        .get(workstreamId)
-
-      if (failedWorktreeCreation) {
-        if (
-          failedWorktreeCreation.workspace_id !== workspaceId ||
-          failedWorktreeCreation.goal !== goal ||
-          failedWorktreeCreation.working_location !== 'worktrees' ||
-          Number(failedWorktreeCreation.session_count) > 0 ||
-          Number(failedWorktreeCreation.available_location_count) > 0
-        ) {
-          throw new TypeError('Retry Workstream worktree creation before using current checkouts.')
-        }
-
-        database.prepare('DELETE FROM workstream_repository_locations WHERE workstream_id = ?').run(workstreamId)
-        database.prepare('DELETE FROM workstream_knowledge WHERE workstream_id = ?').run(workstreamId)
-        database.prepare('DELETE FROM workstreams WHERE id = ?').run(workstreamId)
-      }
-
+      const workstreamId = createWorkstreamId()
       database
         .prepare(
           "INSERT INTO workstreams (id, workspace_id, goal, lifecycle, working_location, created_at) VALUES (?, ?, ?, 'active', 'current-checkouts', ?)"
         )
         .run(workstreamId, workspaceId, goal, Date.now())
       initializeStoredWorkstreamKnowledge(database, workstreamId)
-      insertCurrentCheckoutLocations(database, workspaceId, workstreamId)
       sessionId = insertOwnedSession(database, workstreamId, { mode: normalizeSessionMode(options.mode) })
-      insertSessionWorkingLocationsFromWorkstream(database, sessionId, workstreamId)
       incrementRevision(database)
       database.exec('COMMIT;')
     } catch (error) {
@@ -876,7 +641,7 @@ export function createWorkstreamSessionStore({
         throw new TypeError('Preview the Quick Session worktree location before creation.')
       }
 
-      await prepareWorktreeBackedWorkstream(workspaceId, workstreamId, null, options.repositoryId)
+      await prepareWorktreeBackedQuickSession(workspaceId, workstreamId, options.repositoryId)
     }
 
     const database = openDatabase()
@@ -939,7 +704,11 @@ export function createWorkstreamSessionStore({
         title: 'Quick Session',
         repositoryId: options.repositoryId,
       })
-      insertSessionWorkingLocationsFromWorkstream(database, sessionId, workstreamId, options.repositoryId)
+      if (workingLocation === 'current-checkouts') {
+        insertCurrentCheckoutSessionLocation(database, sessionId, options.repositoryId)
+      } else {
+        insertSessionWorkingLocationsFromWorkstream(database, sessionId, workstreamId, options.repositoryId)
+      }
       incrementRevision(database)
       database.exec('COMMIT;')
     } catch (error) {
@@ -956,6 +725,168 @@ export function createWorkstreamSessionStore({
     const status = await reconcileCommittedSession(sessionId)
 
     return { status, sessionId, snapshot: await getWorkstreamSnapshot(workspaceId, false) }
+  }
+
+  function incrementSessionWorkingLocationRevision(database: SqliteDatabase, sessionId: SessionId): void {
+    database
+      .prepare(
+        `UPDATE workstreams
+            SET working_location_revision = working_location_revision + 1
+          WHERE id = (SELECT workstream_id FROM sessions WHERE id = ?)`
+      )
+      .run(sessionId)
+  }
+
+  function readSessionResourcePolicyRevision(database: SqliteDatabase, sessionId: SessionId): number {
+    const revision = database
+      .prepare(
+        `SELECT workspace.metadata_revision + workstream.working_location_revision AS revision
+           FROM sessions session
+           JOIN workstreams workstream ON workstream.id = session.workstream_id
+           JOIN workspaces workspace ON workspace.id = workstream.workspace_id
+          WHERE session.id = ?`
+      )
+      .get(sessionId)?.revision
+
+    if (typeof revision !== 'number') throw new Error('The Session resource policy is unavailable.')
+
+    return revision
+  }
+
+  async function prepareSessionRepository(
+    sessionId: SessionId,
+    repositoryId: string
+  ): Promise<PreparedSessionRepository> {
+    const database = openDatabase()
+    let proposal: WorktreeProposal
+    let restoresPersistedWorktree = false
+
+    try {
+      await refreshRepositoryAvailability(database, inspectRepository, incrementRevision)
+      const repository = database
+        .prepare(
+          `SELECT repository.directory_path, repository.common_directory_path, repository.availability
+             FROM sessions session
+             JOIN workstreams workstream ON workstream.id = session.workstream_id
+             JOIN workspace_repositories membership ON membership.workspace_id = workstream.workspace_id
+             JOIN repositories repository
+               ON repository.id = membership.repository_id AND repository.id = ?
+            WHERE session.id = ?
+              AND session.mode = 'implement'
+              AND workstream.lifecycle = 'active'`
+        )
+        .get(repositoryId, sessionId)
+
+      if (!repository) throw new TypeError('Select a Repository from the Implement Session Workspace.')
+      if (repository.availability !== 'available') throw new TypeError('The selected Repository is unavailable.')
+
+      const existing = database
+        .prepare(
+          `SELECT kind, working_path, branch, base_commit, availability
+             FROM session_repository_locations
+            WHERE session_id = ? AND repository_id = ?`
+        )
+        .get(sessionId, repositoryId)
+
+      if (existing && existing.kind !== 'current-checkout' && existing.kind !== 'worktree') {
+        throw new Error('The persisted Session working location is malformed.')
+      }
+      if (
+        existing?.kind === 'worktree' &&
+        (typeof existing.working_path !== 'string' ||
+          typeof existing.branch !== 'string' ||
+          typeof existing.base_commit !== 'string')
+      ) {
+        throw new Error('The persisted Session worktree is malformed.')
+      }
+
+      if (
+        existing?.kind === 'worktree' &&
+        typeof existing.working_path === 'string' &&
+        typeof existing.branch === 'string' &&
+        typeof existing.base_commit === 'string'
+      ) {
+        const observedAvailability = await inspectWorktree({
+          worktreePath: existing.working_path,
+          commonDirectoryPath: String(repository.common_directory_path),
+          expectedBranch: existing.branch,
+        })
+
+        if (observedAvailability === 'available') {
+          if (existing.availability !== 'available') {
+            database
+              .prepare(
+                "UPDATE session_repository_locations SET availability = 'available' WHERE session_id = ? AND repository_id = ?"
+              )
+              .run(sessionId, repositoryId)
+            incrementSessionWorkingLocationRevision(database, sessionId)
+            incrementRevision(database)
+          }
+
+          return {
+            repositoryId,
+            workingPath: existing.working_path,
+            resourcePolicyRevision: readSessionResourcePolicyRevision(database, sessionId),
+          }
+        }
+
+        proposal = {
+          repositoryId,
+          sourcePath: String(repository.directory_path),
+          commonDirectoryPath: String(repository.common_directory_path),
+          worktreePath: existing.working_path,
+          branch: existing.branch,
+          baseCommit: existing.base_commit,
+        }
+        restoresPersistedWorktree = true
+      } else {
+        proposal = await proposeWorktree({
+          repositoryId,
+          repositoryPath: String(repository.directory_path),
+          worktreeId: sessionId,
+        })
+        database
+          .prepare(
+            `INSERT INTO session_repository_locations
+              (session_id, repository_id, kind, working_path, branch, base_commit, availability)
+             VALUES (?, ?, 'worktree', ?, ?, ?, 'unavailable')
+             ON CONFLICT (session_id, repository_id) DO UPDATE SET
+               kind = excluded.kind,
+               working_path = excluded.working_path,
+               branch = excluded.branch,
+               base_commit = excluded.base_commit,
+               availability = excluded.availability`
+          )
+          .run(sessionId, repositoryId, proposal.worktreePath, proposal.branch, proposal.baseCommit)
+        incrementRevision(database)
+      }
+    } finally {
+      database.close()
+    }
+
+    await (restoresPersistedWorktree ? restoreWorktree(proposal) : createWorktree(proposal))
+
+    const prepared = openDatabase()
+    let resourcePolicyRevision: number
+    try {
+      prepared.exec('BEGIN IMMEDIATE;')
+      prepared
+        .prepare(
+          "UPDATE session_repository_locations SET availability = 'available' WHERE session_id = ? AND repository_id = ?"
+        )
+        .run(sessionId, repositoryId)
+      incrementSessionWorkingLocationRevision(prepared, sessionId)
+      incrementRevision(prepared)
+      resourcePolicyRevision = readSessionResourcePolicyRevision(prepared, sessionId)
+      prepared.exec('COMMIT;')
+    } catch (error) {
+      prepared.exec('ROLLBACK;')
+      throw error
+    } finally {
+      prepared.close()
+    }
+
+    return { repositoryId, workingPath: proposal.worktreePath, resourcePolicyRevision }
   }
 
   async function createWorkstreamSession(
@@ -993,7 +924,6 @@ export function createWorkstreamSessionStore({
       database.close()
     }
 
-    await prepareDedicatedSessionWorktrees(sessionId)
     const status = await reconcileCommittedSession(sessionId)
 
     return { status, sessionId, snapshot: await getWorkstreamSnapshot(workspaceId, false) }
@@ -1076,7 +1006,6 @@ export function createWorkstreamSessionStore({
   }
 
   async function resolveOwnedSession(sessionId: SessionId): Promise<OwnedSessionResolution | undefined> {
-    await prepareDedicatedSessionWorktrees(sessionId)
     const database = openDatabase()
 
     try {
@@ -1200,29 +1129,28 @@ export function createWorkstreamSessionStore({
                 repository.location_kind === undefined || repository.location_kind === null
                   ? undefined
                   : parseWorkstreamRepositoryLocationKind(repository.location_kind)
-              const workingPath = repository.working_path
-              let locationAvailability =
-                repository.location_availability === undefined || repository.location_availability === null
-                  ? 'unavailable'
-                  : parseSessionAvailability(repository.location_availability)
+              const sessionWorkingPath =
+                locationKind === 'worktree' && typeof repository.working_path === 'string'
+                  ? repository.working_path
+                  : undefined
+              const sessionWorkingBranch =
+                locationKind === 'worktree' && typeof repository.branch === 'string' ? repository.branch : undefined
+              let usesSessionWorktree = false
 
-              if (
-                locationKind === 'worktree' &&
-                typeof repository.working_path === 'string' &&
-                typeof repository.branch === 'string'
-              ) {
+              if (sessionWorkingPath && sessionWorkingBranch && repository.location_availability === 'available') {
                 const observedAvailability = await inspectWorktree({
-                  worktreePath: repository.working_path,
+                  worktreePath: sessionWorkingPath,
                   commonDirectoryPath: String(repository.common_directory_path),
+                  expectedBranch: sessionWorkingBranch,
                 })
+                usesSessionWorktree = observedAvailability === 'available'
 
-                if (observedAvailability !== locationAvailability) {
-                  locationAvailability = observedAvailability
+                if (!usesSessionWorktree) {
                   database
                     .prepare(
-                      'UPDATE session_repository_locations SET availability = ? WHERE session_id = ? AND repository_id = ?'
+                      "UPDATE session_repository_locations SET availability = 'unavailable' WHERE session_id = ? AND repository_id = ?"
                     )
-                    .run(locationAvailability, sessionId, repository.id)
+                    .run(sessionId, repository.id)
                   database
                     .prepare(
                       'UPDATE workstreams SET working_location_revision = working_location_revision + 1 WHERE id = ?'
@@ -1232,6 +1160,9 @@ export function createWorkstreamSessionStore({
                   incrementRevision(database)
                 }
               }
+
+              const workingPath = usesSessionWorktree ? sessionWorkingPath : repository.directory_path
+              const locationAvailability = usesSessionWorktree ? 'available' : repositoryAvailability
 
               const availability =
                 repositoryAvailability === 'available' && locationAvailability === 'available'
@@ -1250,7 +1181,12 @@ export function createWorkstreamSessionStore({
               }
 
               return availability === 'available' && typeof workingPath === 'string'
-                ? { ...properties, availability: 'available' as const, workingPath }
+                ? {
+                    ...properties,
+                    availability: 'available' as const,
+                    workingPath,
+                    workingLocation: usesSessionWorktree ? ('session-worktree' as const) : ('source-checkout' as const),
+                  }
                 : { ...properties, availability: 'unavailable' as const }
             })
           )
@@ -1332,6 +1268,7 @@ export function createWorkstreamSessionStore({
     previewWorktreeLocations,
     createWorkstream,
     createQuickSession,
+    prepareSessionRepository,
     createWorkstreamSession,
     setWorkstreamLifecycle,
     renameWorkstreamSession,

--- a/src/main/application-state/workstreams.test.ts
+++ b/src/main/application-state/workstreams.test.ts
@@ -47,6 +47,48 @@ async function createFixture(sessionFiles?: PiSessionFileStore, inspectRepositor
   return { authority, storageDirectory, workspace }
 }
 
+async function commitRepositoryFile(
+  repositoryPath: string,
+  fileName: string,
+  contents: string,
+  message: string
+): Promise<void> {
+  await writeFile(join(repositoryPath, fileName), contents)
+  await exec('git', ['-C', repositoryPath, 'add', fileName])
+  await exec('git', [
+    '-C',
+    repositoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    message,
+  ])
+}
+
+async function createInterruptedSessionWorktreeFixture() {
+  const storageDirectory = await mkdtemp(join(tmpdir(), 'pi-workspace-session-worktree-retry-'))
+  temporaryDirectories.push(storageDirectory)
+  const repositoryPath = join(storageDirectory, 'repository')
+  await exec('git', ['init', repositoryPath])
+  await commitRepositoryFile(repositoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  const interrupted = await initializeApplicationAuthority(storageDirectory, {
+    sqlite: bunSqlite,
+    createWorktree: async (proposal) => {
+      await createWorktree(proposal)
+      throw new Error('simulated crash after Git worktree creation')
+    },
+  })
+  const workspace = (await interrupted.createWorkspace('Workspace', [repositoryPath])).workspaces[0]!
+  const repository = workspace.repositories[0]!
+  const created = await interrupted.createWorkstream(workspace.id, { goal: 'Recover Session preparation' })
+  await assert.rejects(interrupted.prepareSessionRepository(created.sessionId, repository.id), /simulated crash/)
+
+  return { storageDirectory, repositoryPath, interrupted, repository, created }
+}
+
 test('reset preserves external Git and Pi Session artifacts without adopting them', async () => {
   const { authority, storageDirectory, workspace } = await createFixture()
   const repository = workspace.repositories[0]
@@ -118,7 +160,7 @@ test('creates a Workstream with exactly one default Implement Session', async ()
   assert.equal(workstream?.sessions[0]?.availability, 'available')
 })
 
-test('gives each managed Session an isolated worktree', async () => {
+test('lazily creates a Repository worktree for an Implement Session', async () => {
   const { authority, storageDirectory, workspace } = await createFixture()
   const repository = workspace.repositories[0]!
   await writeFile(join(repository.directoryPath, 'tracked.txt'), 'committed')
@@ -134,56 +176,100 @@ test('gives each managed Session an isolated worktree', async () => {
     '-m',
     'Initial commit',
   ])
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Work separately' })
+  const expectedPath = join(storageDirectory, '.worktrees', worktreeName(created.sessionId), repository.id)
 
-  const preview = await authority.previewWorktreeLocations(workspace.id)
-  const created = await authority.createWorkstream(workspace.id, {
-    goal: 'Work separately',
-    workingLocation: 'worktrees',
-    workstreamId: preview.workstreamId,
-  })
-  const workstream = created.snapshot.workstreams[0]!
-  const expectedPath = join(storageDirectory, '.worktrees', worktreeName(workstream.id), repository.id)
+  await assert.rejects(access(expectedPath))
 
-  assert.match(workstream.id, /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
-  assert.equal(preview.repositories[0]?.workingPath, expectedPath)
-  assert.equal(workstream.workingLocation, 'worktrees')
-  assert.deepEqual(workstream.repositoryWorkingLocations, [
-    {
-      repositoryId: repository.id,
-      repositoryName: repository.name,
-      kind: 'worktree',
-      availability: 'available',
-      workingPath: expectedPath,
-    },
-  ])
-  assert.equal(await authority.resolveWorkstreamWorkingLocation(workstream.id, repository.id), expectedPath)
-  const firstRepository = (await authority.resolveOwnedSession(created.sessionId))?.managedPolicy?.repositories[0]
-  assert.equal(firstRepository?.availability, 'available')
-  if (firstRepository?.availability === 'available') assert.equal(firstRepository.workingPath, expectedPath)
+  const prepared = await authority.prepareSessionRepository(created.sessionId, repository.id)
 
-  const second = await authority.createWorkstreamSession(workstream.id, { mode: 'brainstorm' })
-  const secondRepository = (await authority.resolveOwnedSession(second.sessionId))?.managedPolicy?.repositories[0]
-  const secondExpectedPath = join(storageDirectory, '.worktrees', worktreeName(second.sessionId), repository.id)
-  assert.equal(secondRepository?.availability, 'available')
-  if (secondRepository?.availability === 'available') assert.equal(secondRepository.workingPath, secondExpectedPath)
-  assert.notEqual(secondRepository?.workingPath, expectedPath)
-
-  const restarted = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
-  const reopenedRepository = (await restarted.resolveOwnedSession(created.sessionId))?.managedPolicy?.repositories[0]
-  assert.equal(reopenedRepository?.availability, 'available')
-  if (reopenedRepository?.availability === 'available') assert.equal(reopenedRepository.workingPath, expectedPath)
+  assert.equal(prepared.workingPath, expectedPath)
+  assert.equal(await readFile(join(expectedPath, 'tracked.txt'), 'utf8'), 'committed')
 })
 
-test('records an exact matching worktree when retrying after Git succeeded', async () => {
-  const storageDirectory = await mkdtemp(join(tmpdir(), 'pi-workspace-worktree-retry-'))
-  temporaryDirectories.push(storageDirectory)
-  const repositoryPath = join(storageDirectory, 'repository')
-  await exec('git', ['init', repositoryPath])
-  await writeFile(join(repositoryPath, 'tracked.txt'), 'committed')
-  await exec('git', ['-C', repositoryPath, 'add', 'tracked.txt'])
+test('restores a removed Implement Session worktree from its persisted branch', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Restore isolated changes' })
+  const prepared = await authority.prepareSessionRepository(created.sessionId, repository.id)
+  await commitRepositoryFile(prepared.workingPath, 'session-change.txt', 'preserved', 'Session change')
+  await exec('git', ['-C', repository.directoryPath, 'worktree', 'remove', '--force', prepared.workingPath])
+
+  const restored = await authority.prepareSessionRepository(created.sessionId, repository.id)
+
+  assert.equal(restored.workingPath, prepared.workingPath)
+  assert.equal(await readFile(join(restored.workingPath, 'session-change.txt'), 'utf8'), 'preserved')
+})
+
+test('falls back to the source checkout immediately after a Session worktree is removed', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Keep Repository access current' })
+  const prepared = await authority.prepareSessionRepository(created.sessionId, repository.id)
+  await exec('git', ['-C', repository.directoryPath, 'worktree', 'remove', '--force', prepared.workingPath])
+
+  const resolution = await authority.resolveOwnedSession(created.sessionId)
+  const resolvedRepository = resolution?.managedPolicy?.repositories[0]
+
+  assert.notEqual(resolution?.managedPolicy?.resourcePolicyRevision, prepared.resourcePolicyRevision)
+  assert.equal(resolvedRepository?.availability, 'available')
+  if (resolvedRepository?.availability === 'available') {
+    assert.equal(resolvedRepository.workingPath, repository.directoryPath)
+    assert.equal(resolvedRepository.workingLocation, 'source-checkout')
+  }
+})
+
+test('gives each Implement Session a distinct worktree from the Repository current HEAD', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await writeFile(join(repository.directoryPath, 'first.txt'), 'first')
+  await exec('git', ['-C', repository.directoryPath, 'add', 'first.txt'])
   await exec('git', [
     '-C',
-    repositoryPath,
+    repository.directoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    'First commit',
+  ])
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Prepare parallel changes' })
+  const workstream = created.snapshot.workstreams[0]!
+  const first = await authority.prepareSessionRepository(created.sessionId, repository.id)
+
+  await writeFile(join(repository.directoryPath, 'second.txt'), 'second')
+  await exec('git', ['-C', repository.directoryPath, 'add', 'second.txt'])
+  await exec('git', [
+    '-C',
+    repository.directoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    'Second commit',
+  ])
+  const secondSession = await authority.createWorkstreamSession(workstream.id, { mode: 'implement' })
+  const second = await authority.prepareSessionRepository(secondSession.sessionId, repository.id)
+
+  assert.notEqual(second.workingPath, first.workingPath)
+  await assert.rejects(access(join(first.workingPath, 'second.txt')))
+  assert.equal(await readFile(join(second.workingPath, 'second.txt'), 'utf8'), 'second')
+})
+
+test('resolves a prepared worktree only for its owning Implement Session', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await writeFile(join(repository.directoryPath, 'tracked.txt'), 'committed')
+  await exec('git', ['-C', repository.directoryPath, 'add', 'tracked.txt'])
+  await exec('git', [
+    '-C',
+    repository.directoryPath,
     '-c',
     'user.name=Pi Workspace tests',
     '-c',
@@ -192,107 +278,65 @@ test('records an exact matching worktree when retrying after Git succeeded', asy
     '-m',
     'Initial commit',
   ])
-  const interrupted = await initializeApplicationAuthority(storageDirectory, {
-    sqlite: bunSqlite,
-    createWorktree: async (proposal) => {
-      await createWorktree(proposal)
-      throw new Error('simulated crash after Git worktree creation')
-    },
-  })
-  const workspaces = await interrupted.createWorkspace('Workspace', [repositoryPath])
-  const workspace = workspaces.workspaces[0]!
-  const preview = await interrupted.previewWorktreeLocations(workspace.id)
-  const options = {
-    goal: 'Recover exact worktree creation',
-    workingLocation: 'worktrees' as const,
-    workstreamId: preview.workstreamId,
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Keep Session changes separate' })
+  const workstream = created.snapshot.workstreams[0]!
+  const sibling = await authority.createWorkstreamSession(workstream.id, { mode: 'implement' })
+  const before = await authority.resolveOwnedSession(created.sessionId)
+  const prepared = await authority.prepareSessionRepository(created.sessionId, repository.id)
+
+  const ownerResolution = await authority.resolveOwnedSession(created.sessionId)
+  const ownerRepository = ownerResolution?.managedPolicy?.repositories[0]
+  const siblingRepository = (await authority.resolveOwnedSession(sibling.sessionId))?.managedPolicy?.repositories[0]
+
+  assert.notEqual(ownerResolution?.managedPolicy?.resourcePolicyRevision, before?.managedPolicy?.resourcePolicyRevision)
+  assert.equal(ownerRepository?.availability, 'available')
+  if (ownerRepository?.availability === 'available') {
+    assert.equal(ownerRepository.workingPath, prepared.workingPath)
+    assert.equal(ownerRepository.workingLocation, 'session-worktree')
   }
+  assert.equal(siblingRepository?.availability, 'available')
+  if (siblingRepository?.availability === 'available') {
+    assert.equal(siblingRepository.workingPath, repository.directoryPath)
+    assert.equal(siblingRepository.workingLocation, 'source-checkout')
+  }
+})
 
-  await assert.rejects(interrupted.createWorkstream(workspace.id, options), /simulated crash/)
+test('does not prepare a Repository worktree for a Brainstorm Session', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  const created = await authority.createWorkstream(workspace.id, {
+    goal: 'Investigate without changes',
+    mode: 'brainstorm',
+  })
 
+  await assert.rejects(
+    authority.prepareSessionRepository(created.sessionId, repository.id),
+    /Implement Session Workspace/
+  )
+})
+
+test('keeps the source checkout available when Session worktree preparation is interrupted', async () => {
+  const { interrupted, repositoryPath, created } = await createInterruptedSessionWorktreeFixture()
+
+  const interruptedRepository = (await interrupted.resolveOwnedSession(created.sessionId))?.managedPolicy
+    ?.repositories[0]
+
+  assert.equal(interruptedRepository?.availability, 'available')
+  if (interruptedRepository?.availability === 'available') {
+    assert.equal(interruptedRepository.workingPath, repositoryPath)
+    assert.equal(interruptedRepository.workingLocation, 'source-checkout')
+  }
+})
+
+test('recovers a Session worktree after interrupted preparation and restart', async () => {
+  const { storageDirectory, repository, created } = await createInterruptedSessionWorktreeFixture()
   const restarted = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
-  const created = await restarted.createWorkstream(workspace.id, options)
+
+  const prepared = await restarted.prepareSessionRepository(created.sessionId, repository.id)
   const runtimeRepository = (await restarted.resolveOwnedSession(created.sessionId))?.managedPolicy?.repositories[0]
 
   assert.equal(runtimeRepository?.availability, 'available')
-  if (runtimeRepository?.availability === 'available') {
-    assert.equal(runtimeRepository.workingPath, preview.repositories[0]!.workingPath)
-  }
-})
-
-test('can use current checkouts after worktree creation fails before creating any worktree', async () => {
-  const { authority, workspace } = await createFixture()
-  const repository = workspace.repositories[0]!
-  await writeFile(join(repository.directoryPath, 'tracked.txt'), 'committed')
-  await exec('git', ['-C', repository.directoryPath, 'add', 'tracked.txt'])
-  await exec('git', [
-    '-C',
-    repository.directoryPath,
-    '-c',
-    'user.name=Pi Workspace tests',
-    '-c',
-    'user.email=tests@pi-workspace.invalid',
-    'commit',
-    '-m',
-    'Initial commit',
-  ])
-  const preview = await authority.previewWorktreeLocations(workspace.id)
-  await mkdir(preview.repositories[0]!.workingPath, { recursive: true })
-  await writeFile(join(preview.repositories[0]!.workingPath, 'unexpected.txt'), 'do not overwrite')
-
-  await assert.rejects(
-    authority.createWorkstream(workspace.id, {
-      goal: 'Fall back safely',
-      workingLocation: 'worktrees',
-      workstreamId: preview.workstreamId,
-    }),
-    /already exists/
-  )
-
-  const created = await authority.createWorkstream(workspace.id, {
-    goal: 'Fall back safely',
-    workingLocation: 'current-checkouts',
-    workstreamId: preview.workstreamId,
-  })
-
-  assert.equal(created.snapshot.workstreams.length, 1)
-  assert.equal(created.snapshot.workstreams[0]?.workingLocation, 'current-checkouts')
-  const runtimeRepository = (await authority.resolveOwnedSession(created.sessionId))?.managedPolicy?.repositories[0]
-  assert.equal(runtimeRepository?.availability, 'available')
-  if (runtimeRepository?.availability === 'available') {
-    assert.equal(runtimeRepository.workingPath, repository.directoryPath)
-  }
-})
-
-test('shows a missing recorded Workstream worktree as unavailable without recreating it', async () => {
-  const { authority, workspace } = await createFixture()
-  const repository = workspace.repositories[0]!
-  await writeFile(join(repository.directoryPath, 'tracked.txt'), 'committed')
-  await exec('git', ['-C', repository.directoryPath, 'add', 'tracked.txt'])
-  await exec('git', [
-    '-C',
-    repository.directoryPath,
-    '-c',
-    'user.name=Pi Workspace tests',
-    '-c',
-    'user.email=tests@pi-workspace.invalid',
-    'commit',
-    '-m',
-    'Initial commit',
-  ])
-  const preview = await authority.previewWorktreeLocations(workspace.id)
-  const created = await authority.createWorkstream(workspace.id, {
-    goal: 'Keep recorded locations',
-    workingLocation: 'worktrees',
-    workstreamId: preview.workstreamId,
-  })
-  const workingPath = preview.repositories[0]!.workingPath
-  await rm(workingPath, { recursive: true })
-
-  const resolution = await authority.resolveOwnedSession(created.sessionId)
-
-  assert.equal(resolution?.managedPolicy?.repositories[0]?.availability, 'unavailable')
-  await assert.rejects(access(workingPath))
+  if (runtimeRepository?.availability === 'available') assert.equal(runtimeRepository.workingPath, prepared.workingPath)
 })
 
 test('persists Workstream records, revisions, and mutation history across restart', async () => {
@@ -1004,7 +1048,7 @@ test('rejects removing a Repository used by an active Quick Session', async () =
   assert.deepEqual(await authority.getCurrentWorkstreamRepositorySet(quick.snapshot.workstreams[0]!.id), [first.id])
 })
 
-test('rejects removing a Repository with a recorded active Workstream worktree', async () => {
+test('rejects removing a Repository with an active Session worktree', async () => {
   const { authority, storageDirectory, workspace } = await createFixture()
   const first = workspace.repositories[0]!
   const secondPath = join(storageDirectory, 'second-repository')
@@ -1027,12 +1071,8 @@ test('rejects removing a Repository with a recorded active Workstream worktree',
   }
 
   await authority.addWorkspaceRepositories(workspace.id, [secondPath])
-  const preview = await authority.previewWorktreeLocations(workspace.id)
-  await authority.createWorkstream(workspace.id, {
-    goal: 'Keep worktrees attached',
-    workingLocation: 'worktrees',
-    workstreamId: preview.workstreamId,
-  })
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Keep worktrees attached' })
+  await authority.prepareSessionRepository(created.sessionId, first.id)
 
   await assert.rejects(authority.removeWorkspaceRepository(workspace.id, first.membershipId), /active Workstream/)
 })
@@ -1549,6 +1589,8 @@ test('allows concurrent Session Agent Runs in isolated Session worktrees', async
   const created = await authority.createWorkstream(workspace.id, { goal: 'Coordinate the work' })
   const workstream = created.snapshot.workstreams[0]!
   const second = await authority.createWorkstreamSession(workstream.id, { mode: 'implement' })
+  await authority.prepareSessionRepository(created.sessionId, repository.id)
+  await authority.prepareSessionRepository(second.sessionId, repository.id)
 
   assert.equal(await authority.acquireSessionRunLease(created.sessionId), true)
   assert.equal(await authority.acquireSessionRunLease(second.sessionId), true)
@@ -1565,14 +1607,14 @@ test('allows concurrent Session Agent Runs in isolated Session worktrees', async
 
 test('blocks concurrent Agent Runs that share a Repository working path', async () => {
   const { authority, workspace } = await createFixture()
-  const created = await authority.createWorkstream(workspace.id, { goal: 'Protect shared checkouts' })
-  const workstream = created.snapshot.workstreams[0]!
-  const second = await authority.createWorkstreamSession(workstream.id, { mode: 'brainstorm' })
+  const repository = workspace.repositories[0]!
+  const first = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+  const second = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
 
-  assert.equal(await authority.acquireSessionRunLease(created.sessionId), true)
+  assert.equal(await authority.acquireSessionRunLease(first.sessionId), true)
   assert.equal(await authority.acquireSessionRunLease(second.sessionId), false)
 
-  await authority.settleSessionRunLease(created.sessionId)
+  await authority.settleSessionRunLease(first.sessionId)
 })
 
 test('migrates prior application state to Session work locations', async () => {
@@ -1681,7 +1723,11 @@ test('keeps a malformed recorded working location bounded to its Workstream', as
   const database = new Database(join(storageDirectory, 'application-state.sqlite'))
   database.prepare("UPDATE workstreams SET working_location = 'worktrees' WHERE id = ?").run(malformedId)
   database
-    .prepare("UPDATE workstream_repository_locations SET kind = 'unknown' WHERE workstream_id = ?")
+    .prepare(
+      `INSERT INTO workstream_repository_locations
+        (workstream_id, repository_id, kind, working_path, availability)
+       SELECT ?, id, 'unknown', directory_path, 'available' FROM repositories LIMIT 1`
+    )
     .run(malformedId)
   database.close()
 
@@ -1701,7 +1747,11 @@ test('does not reject Session lookup for a malformed recorded working location',
   const database = new Database(join(storageDirectory, 'application-state.sqlite'))
   database.prepare("UPDATE workstreams SET working_location = 'worktrees' WHERE id = ?").run(workstream.id)
   database
-    .prepare("UPDATE session_repository_locations SET kind = 'unknown' WHERE session_id = ?")
+    .prepare(
+      `INSERT INTO session_repository_locations
+        (session_id, repository_id, kind, working_path, availability)
+       SELECT ?, id, 'unknown', directory_path, 'available' FROM repositories LIMIT 1`
+    )
     .run(created.sessionId)
   database.close()
 

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -36,6 +36,7 @@ import {
 } from '@/src/main/pi-session-runtimes'
 import { classifyPersistedAgentState } from '@/src/main/pi-session-history'
 import { createManagedSessionServices } from '@/src/main/managed-session-resources'
+import { createManagedSessionRuntimePolicyGuard } from '@/src/main/managed-session-runtime-policy'
 import {
   managedSessionMethodology,
   parsePiWorkstreamKnowledgeMutation,
@@ -64,6 +65,9 @@ type PiSessionRuntimeOptions =
       applyWorkstreamKnowledgeCommand: (
         command: WorkstreamKnowledgeCommand
       ) => Promise<WorkstreamKnowledgeMutationResult>
+      prepareSessionRepository: (
+        repositoryId: string
+      ) => Promise<Readonly<{ repositoryId: string; workingPath: string; resourcePolicyRevision: number }>>
     }>
 
 export async function createPiSessionRuntime(
@@ -79,20 +83,26 @@ export async function createPiSessionRuntime(
   const runtimeListeners = new Set<(event: PiSessionRuntimeEvent) => void>()
   let managedPolicyFailure: string | undefined
   const managedRunControl: { abort?: () => void } = {}
+  const managedPolicyGuard =
+    options.kind === 'managed'
+      ? createManagedSessionRuntimePolicyGuard(options, (error) => {
+          if (managedPolicyFailure) return
 
-  const validateManagedPolicy = async (
-    managedOptions: Extract<PiSessionRuntimeOptions, { kind: 'managed' }>
-  ): Promise<ManagedSessionRuntimePolicy> => {
-    try {
-      return await requireCurrentManagedPolicy(managedOptions)
-    } catch (error) {
-      if (!managedPolicyFailure) {
-        managedPolicyFailure = error instanceof Error ? error.message : 'The managed Session runtime policy failed.'
-        managedRunControl.abort?.()
-      }
+          managedPolicyFailure = error instanceof Error ? error.message : 'The managed Session runtime policy failed.'
+          managedRunControl.abort?.()
+        })
+      : undefined
 
-      throw error
-    }
+  const validateManagedPolicy = (): Promise<ManagedSessionRuntimePolicy> => {
+    if (!managedPolicyGuard) throw new Error('The managed Session runtime policy is unavailable.')
+
+    return managedPolicyGuard.validate()
+  }
+
+  const prepareManagedRepository = (repositoryId: string) => {
+    if (!managedPolicyGuard) throw new Error('The managed Session runtime policy is unavailable.')
+
+    return managedPolicyGuard.prepareRepository(repositoryId)
   }
 
   const startActivity = defineTool({
@@ -110,7 +120,7 @@ export async function createPiSessionRuntime(
       expectedOutcome: Type.Optional(Type.String({ minLength: 1 })),
     }),
     async execute(toolCallId) {
-      if (options.kind === 'managed') await validateManagedPolicy(options)
+      if (options.kind === 'managed') await validateManagedPolicy()
 
       runtimeListeners.forEach((listener) =>
         listener({ type: 'activity_control_accepted', toolCallId, toolName: 'start_activity' })
@@ -130,7 +140,7 @@ export async function createPiSessionRuntime(
       summary: Type.String({ minLength: 1, description: 'A concise summary of the achieved or observed outcome' }),
     }),
     async execute(toolCallId) {
-      if (options.kind === 'managed') await validateManagedPolicy(options)
+      if (options.kind === 'managed') await validateManagedPolicy()
 
       runtimeListeners.forEach((listener) =>
         listener({ type: 'activity_control_accepted', toolCallId, toolName: 'complete_activity' })
@@ -149,19 +159,48 @@ export async function createPiSessionRuntime(
             description: 'Read metadata about the current Workspace and its Repositories without Repository content.',
             parameters: Type.Object({}),
             async execute() {
-              const policy = await validateManagedPolicy(options)
+              const policy = await validateManagedPolicy()
               const overview = projectWorkspaceOverview(policy)
 
               return { content: [{ type: 'text' as const, text: JSON.stringify(overview) }], details: {} }
             },
           }),
+          ...(options.policy.mode === 'implement'
+            ? [
+                defineTool({
+                  name: 'prepare_repository',
+                  label: 'Prepare Repository',
+                  description:
+                    'Create or reuse this Implement Session’s isolated worktree for one Workspace Repository before modifying it.',
+                  parameters: Type.Object({
+                    repositoryId: Type.String({ minLength: 1, description: 'Repository id from workspace_overview' }),
+                  }),
+                  async execute(_toolCallId, input) {
+                    const prepared = await prepareManagedRepository(input.repositoryId)
+
+                    return {
+                      content: [
+                        {
+                          type: 'text' as const,
+                          text: JSON.stringify({
+                            repositoryId: prepared.repositoryId,
+                            workingPath: prepared.workingPath,
+                          }),
+                        },
+                      ],
+                      details: {},
+                    }
+                  },
+                }),
+              ]
+            : []),
           defineTool({
             name: 'workstream_knowledge',
             label: 'Workstream knowledge',
             description: 'Read the current durable knowledge owned by this Workstream.',
             parameters: Type.Object({}),
             async execute() {
-              await validateManagedPolicy(options)
+              await validateManagedPolicy()
               const state = await options.getWorkstreamKnowledge()
 
               return { content: [{ type: 'text' as const, text: JSON.stringify(state) }], details: {} }
@@ -182,7 +221,7 @@ export async function createPiSessionRuntime(
               ),
             }),
             async execute(_toolCallId, input) {
-              await validateManagedPolicy(options)
+              await validateManagedPolicy()
               const command = parsePiWorkstreamKnowledgeMutation(input)
               if (!command) throw new TypeError('A valid Pi-authorized Workstream knowledge mutation is required.')
 
@@ -427,25 +466,6 @@ export async function createPiSessionRuntime(
   }
 }
 
-async function requireCurrentManagedPolicy(
-  options: Extract<PiSessionRuntimeOptions, { kind: 'managed' }>
-): Promise<ManagedSessionRuntimePolicy> {
-  const current = await options.resolvePolicy()
-
-  if (
-    !current ||
-    current.sessionId !== options.policy.sessionId ||
-    current.mode !== options.policy.mode ||
-    current.lifecycle !== options.policy.lifecycle ||
-    current.resourcePolicyRevision !== options.policy.resourcePolicyRevision ||
-    current.runLeaseId !== options.policy.runLeaseId
-  ) {
-    throw new Error('The managed Session runtime policy is stale.')
-  }
-
-  return current
-}
-
 function messageContent(content: unknown): { text: string; hasToolCalls: boolean } {
   if (typeof content === 'string') return { text: content, hasToolCalls: false }
   if (!Array.isArray(content)) return { text: '', hasToolCalls: false }
@@ -533,6 +553,8 @@ export function initializeComposer(authority: ApplicationAuthority): void {
         getWorkstreamKnowledge: () => authority.getWorkstreamKnowledge(managedPolicy.workstreamId),
         applyWorkstreamKnowledgeCommand: (command) =>
           authority.applyPiWorkstreamKnowledgeCommand(managedPolicy.workstreamId, command, managedPolicy.sessionId),
+        prepareSessionRepository: (repositoryId) =>
+          authority.prepareSessionRepository(managedPolicy.sessionId, repositoryId),
       })
     },
   })

--- a/src/main/git-repositories.test.ts
+++ b/src/main/git-repositories.test.ts
@@ -60,7 +60,7 @@ test('creates a deterministic ordinary worktree without changing dirty source fi
   const proposal = await proposeWorktree({
     repositoryId: 'repository-a',
     repositoryPath,
-    workstreamId: '018f35d8-4b2c-7abc-8def-0123456789ab',
+    worktreeId: '018f35d8-4b2c-7abc-8def-0123456789ab',
   })
   const created = await createWorktree(proposal)
 

--- a/src/main/git-repositories.ts
+++ b/src/main/git-repositories.ts
@@ -23,7 +23,7 @@ export type WorktreeProposal = Readonly<{
 export async function proposeWorktree(options: {
   repositoryId: string
   repositoryPath: string
-  workstreamId: string
+  worktreeId: string
 }): Promise<WorktreeProposal> {
   const repository = await inspectGitRepository(options.repositoryPath)
   const { stdout } = await exec('git', ['-C', repository.directoryPath, 'rev-parse', 'HEAD']).catch(() => {
@@ -40,10 +40,10 @@ export async function proposeWorktree(options: {
     worktreePath: join(
       dirname(repository.directoryPath),
       '.worktrees',
-      worktreeName(options.workstreamId),
+      worktreeName(options.worktreeId),
       options.repositoryId
     ),
-    branch: `pi-workspace/${worktreeName(options.workstreamId)}/${options.repositoryId}`,
+    branch: `pi-workspace/${worktreeName(options.worktreeId)}/${options.repositoryId}`,
     baseCommit,
   }
 }
@@ -68,20 +68,35 @@ export async function inspectWorktree(options: {
 }
 
 export async function createWorktree(proposal: WorktreeProposal): Promise<WorktreeProposal> {
+  return addWorktree(proposal, ['-b', proposal.branch, proposal.worktreePath, proposal.baseCommit])
+}
+
+export async function restoreWorktree(proposal: WorktreeProposal): Promise<WorktreeProposal> {
+  const branchExists = await exec('git', [
+    '-C',
+    proposal.sourcePath,
+    'show-ref',
+    '--verify',
+    '--quiet',
+    `refs/heads/${proposal.branch}`,
+  ]).then(
+    () => true,
+    () => false
+  )
+
+  if (!branchExists) return createWorktree(proposal)
+
+  return addWorktree(proposal, [proposal.worktreePath, proposal.branch])
+}
+
+async function addWorktree(
+  proposal: WorktreeProposal,
+  worktreeArguments: readonly string[]
+): Promise<WorktreeProposal> {
   try {
-    await exec('git', [
-      '-C',
-      proposal.sourcePath,
-      'worktree',
-      'add',
-      '-b',
-      proposal.branch,
-      proposal.worktreePath,
-      proposal.baseCommit,
-    ])
+    await exec('git', ['-C', proposal.sourcePath, 'worktree', 'add', ...worktreeArguments])
   } catch (error) {
-    const detail = error instanceof Error && 'stderr' in error ? String(error.stderr).trim() : ''
-    throw new Error(detail || `Git could not create the worktree at ${proposal.worktreePath}.`, { cause: error })
+    throw worktreeCreationError(proposal, error)
   }
 
   const availability = await inspectWorktree({
@@ -94,6 +109,12 @@ export async function createWorktree(proposal: WorktreeProposal): Promise<Worktr
   }
 
   return proposal
+}
+
+function worktreeCreationError(proposal: WorktreeProposal, error: unknown): Error {
+  const detail = error instanceof Error && 'stderr' in error ? String(error.stderr).trim() : ''
+
+  return new Error(detail || `Git could not create the worktree at ${proposal.worktreePath}.`, { cause: error })
 }
 
 export async function inspectGitRepository(selectedDirectoryPath: string): Promise<InspectedGitRepository> {

--- a/src/main/managed-session-resources.test.ts
+++ b/src/main/managed-session-resources.test.ts
@@ -48,6 +48,7 @@ test('managed Sessions load normal global and Workspace Repository resources', a
         id: 'repository-a',
         name: 'Repository',
         workingPath: repositoryPath,
+        workingLocation: 'source-checkout',
         commonDirectoryPath: join(repositoryPath, '.git'),
         availability: 'available',
         role: '',

--- a/src/main/managed-session-runtime-policy.test.ts
+++ b/src/main/managed-session-runtime-policy.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { sessionId } from '@/src/domain/session'
+import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
+import { createManagedSessionRuntimePolicyGuard } from './managed-session-runtime-policy'
+
+function policy(
+  resourcePolicyRevision: number,
+  workingLocation: 'source-checkout' | 'session-worktree'
+): ManagedSessionRuntimePolicy {
+  return {
+    workspaceId: 'workspace-a',
+    workstreamId: 'workstream-a',
+    sessionId: sessionId('session-a'),
+    mode: 'implement',
+    lifecycle: 'active',
+    runLeaseId: 'lease-a',
+    repositories: [
+      {
+        id: 'repository-a',
+        name: 'Repository A',
+        commonDirectoryPath: '/repositories/a/.git',
+        role: '',
+        relationships: [],
+        availability: 'available',
+        workingPath:
+          workingLocation === 'source-checkout' ? '/repositories/a' : '/repositories/.worktrees/session-a/repository-a',
+        workingLocation,
+      },
+    ],
+    piSessionPath: '/sessions/session-a.jsonl',
+    resourcePolicyRevision,
+  }
+}
+
+test('keeps the managed runtime policy current after preparing a Repository', async () => {
+  let currentPolicy = policy(1, 'source-checkout')
+  const preparedWorkingPath = '/repositories/.worktrees/session-a/repository-a'
+  const policyFailures: unknown[] = []
+  const guard = createManagedSessionRuntimePolicyGuard(
+    {
+      policy: currentPolicy,
+      resolvePolicy: async () => currentPolicy,
+      prepareSessionRepository: async (repositoryId) => {
+        currentPolicy = policy(2, 'session-worktree')
+
+        return {
+          repositoryId,
+          workingPath: preparedWorkingPath,
+          resourcePolicyRevision: currentPolicy.resourcePolicyRevision,
+        }
+      },
+    },
+    (error) => policyFailures.push(error)
+  )
+
+  await guard.prepareRepository('repository-a')
+  const validated = await guard.validate()
+
+  assert.equal(validated.repositories[0]?.availability, 'available')
+  if (validated.repositories[0]?.availability === 'available') {
+    assert.equal(validated.repositories[0].workingLocation, 'session-worktree')
+  }
+  assert.deepEqual(policyFailures, [])
+})

--- a/src/main/managed-session-runtime-policy.ts
+++ b/src/main/managed-session-runtime-policy.ts
@@ -1,0 +1,77 @@
+import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
+import type { PreparedSessionRepository } from './application-state'
+
+export type ManagedSessionRuntimePolicyGuardOptions = Readonly<{
+  policy: ManagedSessionRuntimePolicy
+  resolvePolicy: () => Promise<ManagedSessionRuntimePolicy | undefined>
+  prepareSessionRepository: (repositoryId: string) => Promise<PreparedSessionRepository>
+}>
+
+export interface ManagedSessionRuntimePolicyGuard {
+  validate(): Promise<ManagedSessionRuntimePolicy>
+  prepareRepository(repositoryId: string): Promise<PreparedSessionRepository>
+}
+
+export function createManagedSessionRuntimePolicyGuard(
+  options: ManagedSessionRuntimePolicyGuardOptions,
+  onPolicyFailure: (error: unknown) => void
+): ManagedSessionRuntimePolicyGuard {
+  let activePolicy = options.policy
+
+  async function validate(): Promise<ManagedSessionRuntimePolicy> {
+    try {
+      const current = await requireCurrentPolicyIdentity(options, activePolicy)
+
+      if (current.resourcePolicyRevision !== activePolicy.resourcePolicyRevision) {
+        throw new Error('The managed Session runtime policy is stale.')
+      }
+
+      return current
+    } catch (error) {
+      onPolicyFailure(error)
+      throw error
+    }
+  }
+
+  async function prepareRepository(repositoryId: string): Promise<PreparedSessionRepository> {
+    await validate()
+    const prepared = await options.prepareSessionRepository(repositoryId)
+
+    try {
+      const current = await requireCurrentPolicyIdentity(options, activePolicy)
+      if (current.resourcePolicyRevision !== prepared.resourcePolicyRevision) {
+        throw new Error('The managed Session runtime policy is stale.')
+      }
+
+      activePolicy = current
+    } catch (error) {
+      onPolicyFailure(error)
+      throw error
+    }
+
+    return prepared
+  }
+
+  return { validate, prepareRepository }
+}
+
+async function requireCurrentPolicyIdentity(
+  options: ManagedSessionRuntimePolicyGuardOptions,
+  expected: ManagedSessionRuntimePolicy
+): Promise<ManagedSessionRuntimePolicy> {
+  const current = await options.resolvePolicy()
+
+  if (
+    !current ||
+    current.workspaceId !== expected.workspaceId ||
+    current.workstreamId !== expected.workstreamId ||
+    current.sessionId !== expected.sessionId ||
+    current.mode !== expected.mode ||
+    current.lifecycle !== expected.lifecycle ||
+    current.runLeaseId !== expected.runLeaseId
+  ) {
+    throw new Error('The managed Session runtime policy is stale.')
+  }
+
+  return current
+}

--- a/src/main/managed-session-tools.test.ts
+++ b/src/main/managed-session-tools.test.ts
@@ -20,6 +20,7 @@ function policy(mode: 'brainstorm' | 'implement' = 'brainstorm'): ManagedSession
         id: 'repository-a',
         name: 'Available Repository',
         workingPath: '/workspaces/available',
+        workingLocation: 'source-checkout',
         commonDirectoryPath: '/workspaces/available/.git',
         availability: 'available',
         role: 'Application',
@@ -43,6 +44,7 @@ test('Workspace overview supplies working paths only for available Repositories'
   const overview = projectWorkspaceOverview(policy())
 
   assert.equal(overview.repositories[0]?.workingPath, '/workspaces/available')
+  assert.equal(overview.repositories[0]?.workingLocation, 'source-checkout')
   assert.equal('workingPath' in overview.repositories[1]!, false)
   assert.deepEqual(overview.repositories[0]?.relationships, ['repository-b'])
 })
@@ -64,9 +66,9 @@ test('Implement methodology directs implementation from shared knowledge and rec
     managedSessionMethodology('implement'),
     [
       'You are operating a Pi Workspace Implement Session.',
-      'Call workspace_overview before Repository work, then use the supplied Repository working paths.',
+      'Call workspace_overview before Repository work. Source checkout paths are for inspection only.',
       'Read workstream_knowledge before implementing. Use update_workstream_knowledge to preserve relevant implementation progress and newly discovered Workstream knowledge.',
-      'Change and validate Repository content as needed to pursue the Workstream goal.',
+      'Before modifying a Repository, call prepare_repository with its id. Make and validate all changes in the returned Session worktree path.',
     ].join('\n')
   )
 })

--- a/src/main/managed-session-tools.ts
+++ b/src/main/managed-session-tools.ts
@@ -14,7 +14,9 @@ export function projectWorkspaceOverview(policy: ManagedSessionRuntimePolicy) {
       availability: repository.availability,
       role: repository.role,
       relationships: repository.relationships,
-      ...(repository.availability === 'available' ? { workingPath: repository.workingPath } : {}),
+      ...(repository.availability === 'available'
+        ? { workingPath: repository.workingPath, workingLocation: repository.workingLocation }
+        : {}),
     })),
   }
 }
@@ -23,17 +25,18 @@ export function managedSessionMethodology(mode: ManagedSessionRuntimePolicy['mod
   const modeMethodology =
     mode === 'brainstorm'
       ? [
+          'Call workspace_overview before Repository work, then use the supplied Repository working paths.',
           'Read workstream_knowledge before investigating. Use update_workstream_knowledge to preserve relevant evidence, findings, questions, proposed decisions, Repository impact, plan steps, and validation requirements for the Workstream.',
           'Investigate the Workspace and produce an implementation-ready specification. Do not modify Repository content.',
         ]
       : [
+          'Call workspace_overview before Repository work. Source checkout paths are for inspection only.',
           'Read workstream_knowledge before implementing. Use update_workstream_knowledge to preserve relevant implementation progress and newly discovered Workstream knowledge.',
-          'Change and validate Repository content as needed to pursue the Workstream goal.',
+          'Before modifying a Repository, call prepare_repository with its id. Make and validate all changes in the returned Session worktree path.',
         ]
 
   return [
     `You are operating a Pi Workspace ${mode === 'brainstorm' ? 'Brainstorm' : 'Implement'} Session.`,
-    'Call workspace_overview before Repository work, then use the supplied Repository working paths.',
     ...modeMethodology,
   ].join('\n')
 }

--- a/src/main/workstreams-ipc.ts
+++ b/src/main/workstreams-ipc.ts
@@ -31,7 +31,7 @@ export function initializeWorkstreams(authority: ApplicationAuthority, options: 
 
     return request
       ? authority.previewWorktreeLocations(request.workspaceId, request.repositoryId)
-      : Promise.reject(new TypeError('A Workspace and optional Repository are required.'))
+      : Promise.reject(new TypeError('A Workspace and selected Repository are required.'))
   })
 
   handleTrustedIpc(workstreamsIpcChannels.createWorkstream, (_event, value: unknown) => {

--- a/src/renderer/components/workstream-context.test.tsx
+++ b/src/renderer/components/workstream-context.test.tsx
@@ -44,32 +44,20 @@ test('shows the selected Workstream goal as a single-line header with its full t
   assert.match(markup, /class="[^"]*truncate[^"]*" title="Ship cancellation reasons"/)
 })
 
-test('hides the Working location section when no locations are available to show', () => {
+test('hides the Repository checkouts section when no locations are available to show', () => {
   const markup = renderToStaticMarkup(
     <WorkstreamContext workstream={{ ...workstream, repositoryWorkingLocations: [] }} />
   )
 
-  assert.doesNotMatch(markup, /Working location/)
+  assert.doesNotMatch(markup, /Repository checkouts/)
 })
 
-test('shows recorded working locations and opens one in the native file manager', async () => {
+test('shows Repository checkouts and opens one in the native file manager', async () => {
   const requests: string[][] = []
   const user = userEvent.setup({ document: browser.document as unknown as Document })
   const view = render(
     <WorkstreamContext
-      workstream={{
-        ...workstream,
-        workingLocation: 'worktrees',
-        repositoryWorkingLocations: [
-          {
-            repositoryId: 'repository-a',
-            repositoryName: 'Repository A',
-            kind: 'worktree',
-            availability: 'available',
-            workingPath: '/home/ozzy/projects/github.com/pi-workspace/.worktrees/workstream-a/repository-a',
-          },
-        ],
-      }}
+      workstream={workstream}
       onShowWorkingLocation={async (...ids) => {
         requests.push(ids)
       }}
@@ -77,9 +65,8 @@ test('shows recorded working locations and opens one in the native file manager'
     { container: browser.document.body as unknown as HTMLElement }
   )
 
-  assert.equal(view.queryByText('Separate worktrees'), null)
-  assert.ok(view.getByText('…/pi-workspace/.worktrees/workstream-a/repository-a'))
-  assert.ok(view.getByTitle('/home/ozzy/projects/github.com/pi-workspace/.worktrees/workstream-a/repository-a'))
+  assert.ok(view.getByText('/repositories/a'))
+  assert.ok(view.getByTitle('/repositories/a'))
 
   await user.click(view.getByRole('button', { name: 'Show Repository A in file manager' }))
 

--- a/src/renderer/components/workstream-context.tsx
+++ b/src/renderer/components/workstream-context.tsx
@@ -72,7 +72,7 @@ export function WorkstreamContext({
           <p className="mt-2 text-sm/6 text-content-muted-foreground">{workstream.goal}</p>
         </section>
         {workstream.repositoryWorkingLocations.length > 0 && (
-          <ContextSection icon={FolderGit2} title="Working location">
+          <ContextSection icon={FolderGit2} title="Repository checkouts">
             <RecordList>
               {workstream.repositoryWorkingLocations.map((location) => (
                 <li className="min-w-0" key={location.repositoryId}>

--- a/src/renderer/components/workstream-navigation-groups.tsx
+++ b/src/renderer/components/workstream-navigation-groups.tsx
@@ -486,11 +486,6 @@ export function WorkstreamGroup({
           {workstream.goal && <Workflow aria-hidden="true" className="size-4 shrink-0 text-sidebar-muted-foreground" />}
           <span className="min-w-0 flex-1 truncate">{label}</span>
           <WorkingSessionsIndicator count={workingCount} visible={!open && workingCount > 0} />
-          {workstream.workingLocation === 'worktrees' && (
-            <span aria-label="Uses separate worktrees" title="Uses separate worktrees">
-              <GitBranch aria-hidden="true" className="size-3.5 text-sidebar-muted-foreground" />
-            </span>
-          )}
           {unavailable ? (
             <span className="text-xs/4 font-normal text-sidebar-muted-foreground">Unavailable</span>
           ) : (

--- a/src/renderer/components/workstream-navigation.test.tsx
+++ b/src/renderer/components/workstream-navigation.test.tsx
@@ -220,14 +220,6 @@ test('keeps working state independent from Workstream selection', () => {
   assert.match(markup, /Pi is working/)
 })
 
-test('quietly identifies a Workstream that uses separate worktrees', () => {
-  const markup = renderToStaticMarkup(
-    createNavigation({ workstreams: [{ ...workstreams[0]!, workingLocation: 'worktrees' }] })
-  )
-
-  assert.match(markup, /Uses separate worktrees/)
-})
-
 test('replaces a working Quick Session mode icon with a spinner', () => {
   const quickWorkstream = {
     ...unavailableQuickWorkstream,
@@ -837,67 +829,11 @@ test('creates a Workstream with Implement selected by default', async () => {
 
   await openNewWorkstreamDialog(view, user)
   assert.equal(view.queryByText('Default'), null)
+  assert.equal(view.queryByRole('radiogroup', { name: 'Working location' }), null)
   await user.type(view.getByRole('textbox', { name: 'Goal' }), 'Ship cancellation reasons')
   await user.click(view.getByRole('button', { name: 'Create Workstream' }))
 
-  assert.deepEqual(creations, [
-    { goal: 'Ship cancellation reasons', mode: 'implement', workingLocation: 'current-checkouts' },
-  ])
-})
-
-test('previews exact worktree paths and creates the Workstream with that identity', async () => {
-  const creations: unknown[] = []
-  const user = createUser()
-  const view = renderInBrowser({
-    workstreams: [],
-    onPreviewWorktreeLocations: async () => ({
-      workstreamId: 'workstream-preview',
-      repositories: [
-        {
-          repositoryId: 'repository-a',
-          repositoryName: 'Repository A',
-          workingPath: '/repositories/.worktrees/workstream-preview/repository-a',
-          branch: 'pi-workspace/workstream-preview/repository-a',
-          baseCommit: 'abc123',
-        },
-      ],
-    }),
-    onCreateWorkstream: async (options) => {
-      creations.push(options)
-    },
-  })
-
-  await openNewWorkstreamDialog(view, user)
-  await user.type(view.getByRole('textbox', { name: 'Goal' }), 'Work separately')
-  await user.click(view.getByRole('radio', { name: /Current checkouts/ }))
-  await user.keyboard('{ArrowDown}')
-
-  await waitFor(() =>
-    assert.equal((view.getByRole('button', { name: 'Create Workstream' }) as HTMLButtonElement).disabled, false)
-  )
-  assert.equal(view.queryByText('.worktrees/workstream-preview/repository-a'), null)
-  await user.click(view.getByRole('button', { name: 'Create Workstream' }))
-
-  assert.deepEqual(creations, [
-    {
-      goal: 'Work separately',
-      mode: 'implement',
-      workingLocation: 'worktrees',
-      workstreamId: 'workstream-preview',
-    },
-  ])
-})
-
-test('selects Workstream working-location cards', async () => {
-  const user = createUser()
-  const view = renderInBrowser({ workstreams: [] })
-
-  await openNewWorkstreamDialog(view, user)
-  await user.click(view.getByText('Create a separate ordinary Git worktree for each available Repository.'))
-  assert.equal(view.getByRole('radio', { name: /New worktrees/ }).getAttribute('aria-checked'), 'true')
-
-  await user.click(view.getByText('Use each registered Repository’s existing checkout.'))
-  assert.equal(view.getByRole('radio', { name: /Current checkouts/ }).getAttribute('aria-checked'), 'true')
+  assert.deepEqual(creations, [{ goal: 'Ship cancellation reasons', mode: 'implement' }])
 })
 
 test('allows an explicit Brainstorm mode when creating a Workstream', async () => {
@@ -915,9 +851,7 @@ test('allows an explicit Brainstorm mode when creating a Workstream', async () =
   await user.click(view.getByRole('radio', { name: /Brainstorm/ }))
   await user.click(view.getByRole('button', { name: 'Create Workstream' }))
 
-  assert.deepEqual(creations, [
-    { goal: 'Understand current behavior', mode: 'brainstorm', workingLocation: 'current-checkouts' },
-  ])
+  assert.deepEqual(creations, [{ goal: 'Understand current behavior', mode: 'brainstorm' }])
 })
 
 test('keeps Workstream creation open and announces a failure', async () => {

--- a/src/renderer/components/workstream-navigation.tsx
+++ b/src/renderer/components/workstream-navigation.tsx
@@ -41,7 +41,7 @@ export type WorkstreamNavigationProperties = Readonly<{
   onCreateWorkstream(options: CreateWorkstreamOptions): Promise<void>
   onCreateQuickSession(options: CreateQuickSessionOptions): Promise<void>
   onCreateSession(workstreamId: string, options: CreateSessionOptions): Promise<void>
-  onPreviewWorktreeLocations(repositoryId?: string): Promise<WorktreeLocationsPreview>
+  onPreviewWorktreeLocations(repositoryId: string): Promise<WorktreeLocationsPreview>
   onSetWorkstreamLifecycle(workstreamId: string, lifecycle: WorkstreamLifecycle): Promise<void>
   onSelectWorkstream(workstreamId: string): void
   onToggleSessionPin(sessionId: SessionId): void
@@ -159,7 +159,7 @@ export function WorkstreamNavigation({
     if (createRequest !== undefined) openWorkstreamDialog()
   }, [createRequest])
 
-  const previewWorkingLocations = (repositoryId?: string) => {
+  const previewWorkingLocations = (repositoryId: string) => {
     const request = worktreePreviewRequest.current + 1
     worktreePreviewRequest.current = request
     setWorktreePreview(undefined)
@@ -180,7 +180,7 @@ export function WorkstreamNavigation({
       })
   }
 
-  const selectWorkingLocation = (location: WorkstreamWorkingLocation, repositoryId?: string) => {
+  const selectWorkingLocation = (location: WorkstreamWorkingLocation, repositoryId: string) => {
     setWorkingLocation(location)
     setError(undefined)
 
@@ -517,52 +517,6 @@ export function WorkstreamNavigation({
                   onChange={(event) => setGoal(event.target.value)}
                 />
               </Field>
-              <Field className="min-w-0">
-                <Label>Working location</Label>
-                <Description>
-                  Every Brainstorm and Implement Session in this Workstream uses these locations.
-                </Description>
-                <RadioGroup
-                  aria-label="Working location"
-                  className="space-y-2!"
-                  value={workingLocation}
-                  onChange={(value) => {
-                    if (value === 'current-checkouts' || value === 'worktrees') selectWorkingLocation(value)
-                  }}
-                >
-                  <RadioField
-                    className="rounded-lg border border-content-border bg-content-background p-2.5"
-                    onClick={(event) => {
-                      if (event.target instanceof Element && event.target.closest('[role="radio"]')) return
-
-                      event.preventDefault()
-                      event.stopPropagation()
-                      selectWorkingLocation('current-checkouts')
-                    }}
-                  >
-                    <Radio value="current-checkouts" />
-                    <Label>Current checkouts</Label>
-                    <Description>Use each registered Repository’s existing checkout.</Description>
-                  </RadioField>
-                  <RadioField
-                    className="rounded-lg border border-content-border bg-content-background p-2.5"
-                    onClick={(event) => {
-                      if (event.target instanceof Element && event.target.closest('[role="radio"]')) return
-
-                      event.preventDefault()
-                      event.stopPropagation()
-                      selectWorkingLocation('worktrees')
-                    }}
-                  >
-                    <Radio value="worktrees" />
-                    <Label className="flex items-center gap-2">
-                      <GitBranch aria-hidden="true" className="size-4 text-content-muted-foreground" />
-                      New worktrees
-                    </Label>
-                    <Description>Create a separate ordinary Git worktree for each available Repository.</Description>
-                  </RadioField>
-                </RadioGroup>
-              </Field>
               <Field>
                 <Label>First Session mode</Label>
                 <Description>The mode is permanent for this Session.</Description>
@@ -582,19 +536,8 @@ export function WorkstreamNavigation({
           </Button>
           <Button
             color="accent"
-            disabled={
-              saving || !goal.trim() || previewingWorktrees || (workingLocation === 'worktrees' && !worktreePreview)
-            }
-            onClick={() =>
-              void run(() =>
-                onCreateWorkstream({
-                  goal,
-                  mode,
-                  workingLocation,
-                  ...(worktreePreview ? { workstreamId: worktreePreview.workstreamId } : {}),
-                })
-              )
-            }
+            disabled={saving || !goal.trim()}
+            onClick={() => void run(() => onCreateWorkstream({ goal, mode }))}
           >
             {saving ? 'Creating…' : 'Create Workstream'}
           </Button>

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -300,7 +300,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     }
   }
 
-  const previewWorktreeLocations = (repositoryId?: string) => {
+  const previewWorktreeLocations = (repositoryId: string) => {
     const authorityToken = selectedWorkspaceAuthorityToken()
 
     return window.piWorkspace.workstreams.previewWorktreeLocations(authorityToken.workspaceId, repositoryId)

--- a/src/workstreams-ipc.test.ts
+++ b/src/workstreams-ipc.test.ts
@@ -18,24 +18,18 @@ test('parses Workstream creation with an omitted Session mode', () => {
   })
 })
 
-test('parses Workstream creation with a previewed worktree identity', () => {
-  const workstreamId = '00000000-0000-4000-8000-000000000052'
-
+test('parses Workstream creation with an explicit Session mode', () => {
   assert.deepEqual(
     parseCreateWorkstreamRequest({
       workspaceId: 'workspace-a',
       goal: 'Work separately',
       mode: 'implement',
-      workingLocation: 'worktrees',
-      workstreamId,
     }),
     {
       workspaceId: 'workspace-a',
       options: {
         goal: 'Work separately',
         mode: 'implement',
-        workingLocation: 'worktrees',
-        workstreamId,
       },
     }
   )
@@ -67,6 +61,10 @@ test('parses a worktree preview scoped to one Repository', () => {
     workspaceId: 'workspace-a',
     repositoryId: 'repository-a',
   })
+})
+
+test('rejects a worktree preview without a selected Repository', () => {
+  assert.equal(parsePreviewWorktreeLocationsRequest({ workspaceId: 'workspace-a' }), undefined)
 })
 
 test('rejects Default mode through Workstream creation', () => {

--- a/src/workstreams-ipc.ts
+++ b/src/workstreams-ipc.ts
@@ -19,17 +19,15 @@ export const workstreamsIpcChannels = {
 
 export function parsePreviewWorktreeLocationsRequest(
   value: unknown
-): Readonly<{ workspaceId: string; repositoryId?: string }> | undefined {
+): Readonly<{ workspaceId: string; repositoryId: string }> | undefined {
   if (typeof value !== 'object' || value === null) return undefined
 
   const workspaceId = (value as { workspaceId?: unknown }).workspaceId
   const repositoryId = (value as { repositoryId?: unknown }).repositoryId
 
-  if (typeof workspaceId !== 'string' || (repositoryId !== undefined && typeof repositoryId !== 'string')) {
-    return undefined
-  }
+  if (typeof workspaceId !== 'string' || typeof repositoryId !== 'string' || !repositoryId) return undefined
 
-  return { workspaceId, ...(repositoryId ? { repositoryId } : {}) }
+  return { workspaceId, repositoryId }
 }
 
 export function parseCreateWorkstreamRequest(
@@ -40,17 +38,8 @@ export function parseCreateWorkstreamRequest(
   const workspaceId = (value as { workspaceId?: unknown }).workspaceId
   const goal = (value as { goal?: unknown }).goal
   const mode = (value as { mode?: unknown }).mode
-  const workingLocation = (value as { workingLocation?: unknown }).workingLocation
-  const workstreamId = (value as { workstreamId?: unknown }).workstreamId
 
-  if (
-    typeof workspaceId !== 'string' ||
-    typeof goal !== 'string' ||
-    !isOptionalSessionMode(mode) ||
-    !isOptionalWorkingLocation(workingLocation) ||
-    (workingLocation === 'worktrees' && (typeof workstreamId !== 'string' || !isUuid(workstreamId))) ||
-    (workstreamId !== undefined && (typeof workstreamId !== 'string' || !isUuid(workstreamId)))
-  ) {
+  if (typeof workspaceId !== 'string' || typeof goal !== 'string' || !isOptionalSessionMode(mode)) {
     return undefined
   }
 
@@ -59,8 +48,6 @@ export function parseCreateWorkstreamRequest(
     options: {
       goal,
       ...(mode ? { mode } : {}),
-      ...(workingLocation ? { workingLocation } : {}),
-      ...(workstreamId ? { workstreamId } : {}),
     },
   }
 }
@@ -152,7 +139,7 @@ function isUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
 }
 
-function isOptionalWorkingLocation(value: unknown): value is CreateWorkstreamOptions['workingLocation'] {
+function isOptionalWorkingLocation(value: unknown): value is CreateQuickSessionOptions['workingLocation'] {
   return value === undefined || value === 'current-checkouts' || value === 'worktrees'
 }
 

--- a/src/workstreams.ts
+++ b/src/workstreams.ts
@@ -16,7 +16,7 @@ export type WorkstreamCreationOutcome = Readonly<{
 
 export interface WorkstreamsBridge {
   getSnapshot(workspaceId: string): Promise<WorkstreamsSnapshot>
-  previewWorktreeLocations(workspaceId: string, repositoryId?: string): Promise<WorktreeLocationsPreview>
+  previewWorktreeLocations(workspaceId: string, repositoryId: string): Promise<WorktreeLocationsPreview>
   createWorkstream(workspaceId: string, options: CreateWorkstreamOptions): Promise<WorkstreamCreationOutcome>
   createQuickSession(workspaceId: string, options: CreateQuickSessionOptions): Promise<WorkstreamCreationOutcome>
   createSession(workstreamId: string, options: CreateSessionOptions): Promise<WorkstreamCreationOutcome>


### PR DESCRIPTION
## Summary

- make goal-based Workstream creation metadata-only instead of eagerly creating shared Workstream worktrees
- add `prepare_repository` so each Implement Session lazily creates and reuses its own Repository worktree from the Repository's current local `HEAD`
- preserve source-checkout access for Brainstorm Sessions and existing worktree behavior for Quick Sessions
- reuse schema-v5 Session Repository locations and Session-level run leases while preserving migration and shared-checkout serialization
- recover interrupted or removed Session worktrees, keep managed runtime policy revisions current, and update documentation and focused coverage

## Related issue

None

## Validation

- [x] `bun run check` — passed after rebasing onto current `main` (format, lint, typecheck, 474 tests, and production build). Earlier validation exposed a Prettier issue and the rebase exposed missing Quick Session shared-checkout lease recording; both were fixed before the successful final run.
- [x] Focused rebase coverage: `bun test --max-concurrency=1 --preload ./src/renderer/test-dom.ts src/main/application-state/workstreams.test.ts --test-name-pattern 'allows concurrent Session Agent Runs|blocks concurrent Agent Runs|migrates prior application state'` — passed.
- [x] `bun run security:scan` — passed with no leaks or dependency issues.
- [x] `bun run release:validate` — passed for `v0.3.0-beta.1`.
- [x] `git diff --check` — passed.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] No new dependencies, copied or generated material, assets, or license implications.
- [x] I have read and will follow the Code of Conduct.
