### PR TITLE
chore(release): prepare v0.3.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-workspace",
-  "version": "0.2.0-beta.1",
+  "version": "0.3.0-beta.1",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.14",

--- a/scripts/release-note-markdown.test.ts
+++ b/scripts/release-note-markdown.test.ts
@@ -8,5 +8,8 @@ test('formats the latest bundled Release Note for a GitHub Release', () => {
 
   assert.match(markdown, new RegExp(`^${bundledReleaseNotes[0]!.summary}`, 'm'))
   assert.match(markdown, /^## New$/m)
-  assert.match(markdown, /^- Choose an available Skill from Composer autocomplete to guide Pi in a Session\./m)
+  assert.match(
+    markdown,
+    /^- See current Session context-window usage in Composer, including used and remaining capacity\./m
+  )
 })

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -20,6 +20,16 @@ export function isSemanticVersion(version: string): boolean {
 
 export const bundledReleaseNotes: readonly ReleaseNote[] = [
   {
+    version: '0.3.0-beta.1',
+    releaseDate: '2026-07-23',
+    summary: 'This beta makes it easier to keep track of available context during a Session.',
+    changes: {
+      new: ['See current Session context-window usage in Composer, including used and remaining capacity.'],
+      improved: [],
+      fixed: [],
+    },
+  },
+  {
     version: '0.2.0-beta.1',
     releaseDate: '2026-07-22',
     summary: 'This beta adds Skills to help guide Pi in a Session.',


### PR DESCRIPTION
## Summary

Prepare Pi Workspace v0.3.0-beta.1 for release. The bundled Release Note announces Session context-window usage in Composer and the package version matches it.

## Related issue

None

## Validation

- [ ] `bun run check` — `bun test` (469 passing), typecheck, lint, and formatting passed; build failed because renderer initial JavaScript is 1.07 MiB, exceeding the 0.88 MiB budget.
- [x] `bun run release:validate`
- [x] Focused release-note markdown coverage ran as part of `bun test`.
- [x] `bun run security:scan` was not run; this change does not affect dependencies or security-sensitive behavior.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed: none.
- [x] I have read and will follow the Code of Conduct.
