### PR TITLE
fix: isolate concurrent Session Agent Runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ These guidelines apply to all changes in this repository.
 ## Scope
 
 - Make focused changes that address only the requested behavior.
-- Pi Workspace is in active development. Do not add backwards-compatibility or data-migration support unless the human explicitly requests it.
+- Pi Workspace is in live beta. Preserve backwards compatibility for persisted state and add explicit data migrations when schema or stored contracts change.
 - Do not add speculative concepts, states, abstractions, or supporting features before their requirements are known.
 - Apply YAGNI and KISS. Apply DRY to repeated knowledge or behavior, not coincidentally similar code.
 - Reuse existing code when it is a natural fit, but do not introduce an abstraction solely to remove small amounts of duplication.

--- a/docs/renderer-bundle-budget.md
+++ b/docs/renderer-bundle-budget.md
@@ -4,11 +4,11 @@ The production build enforces budgets for the renderer so dependency or configur
 
 ## Baseline
 
-With Bun 1.3.14 and Vite 8.1.5, the renderer entry is 0.80 MiB minified and all renderer assets total 10.47 MiB. The packaged application input under `dist/` is 11.49 MiB before electron-builder creates the platform-specific artifact.
+With Bun 1.3.14 and Vite 8.1.5, the renderer entry is 1.07 MiB minified and all renderer assets total 10.78 MiB. The packaged application input under `dist/` is 12.20 MiB before electron-builder creates the platform-specific artifact.
 
 The budgets are:
 
-- Initial JavaScript: 900 KiB, measured from the generated `index-*.js` entry.
+- Initial JavaScript: 1100 KiB, measured from the generated `index-*.js` entry.
 - Total renderer assets: 13 MiB, measured from all files under `dist/renderer/assets`.
 
 ## Validation and overrides

--- a/scripts/check-renderer-bundle.mjs
+++ b/scripts/check-renderer-bundle.mjs
@@ -2,7 +2,7 @@ import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const rendererDirectory = 'dist/renderer'
-const initialJavaScriptBudget = 900 * 1024
+const initialJavaScriptBudget = 1100 * 1024
 const totalAssetBudget = 13 * 1024 * 1024
 
 async function filesIn(directory) {

--- a/src/application-state.ts
+++ b/src/application-state.ts
@@ -1,4 +1,4 @@
-export const applicationStateSchemaVersion = 3
+export const applicationStateSchemaVersion = 5
 
 export type InstallationMarker = Readonly<{
   generationId: string

--- a/src/main/application-state/application-state-store.ts
+++ b/src/main/application-state/application-state-store.ts
@@ -48,6 +48,69 @@ async function readMarker(markerPath: string): Promise<InstallationMarker | unde
   }
 }
 
+function tableExists(database: SqliteDatabase, name: string): boolean {
+  return Boolean(database.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name))
+}
+
+function migrateApplicationState(database: SqliteDatabase): void {
+  database.exec('PRAGMA foreign_keys = ON;')
+  const schemaVersion = Number(database.prepare("SELECT value FROM metadata WHERE key = 'schema_version'").get()?.value)
+
+  if (schemaVersion !== 3 && schemaVersion !== 4) return
+
+  database.exec('BEGIN IMMEDIATE;')
+
+  try {
+    if (tableExists(database, 'workstream_run_leases')) {
+      database.exec(`
+        CREATE TABLE session_run_leases_new (session_id TEXT PRIMARY KEY REFERENCES sessions(id), workstream_id TEXT NOT NULL REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL);
+        INSERT INTO session_run_leases_new (session_id, workstream_id, lease_id, purpose, acquired_at)
+        SELECT session_id, workstream_id, lease_id, purpose, acquired_at FROM workstream_run_leases;
+        DROP TABLE workstream_run_leases;
+        ALTER TABLE session_run_leases_new RENAME TO session_run_leases;
+      `)
+    } else if (!tableExists(database, 'session_run_leases')) {
+      database.exec(
+        'CREATE TABLE session_run_leases (session_id TEXT PRIMARY KEY REFERENCES sessions(id), workstream_id TEXT NOT NULL REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL);'
+      )
+    }
+
+    if (!tableExists(database, 'session_repository_locations')) {
+      database.exec(
+        `CREATE TABLE session_repository_locations (session_id TEXT NOT NULL REFERENCES sessions(id), repository_id TEXT NOT NULL REFERENCES repositories(id), kind TEXT NOT NULL, working_path TEXT NOT NULL, branch TEXT, base_commit TEXT, availability TEXT NOT NULL, PRIMARY KEY (session_id, repository_id));`
+      )
+    }
+
+    database.exec(`
+      INSERT INTO session_repository_locations
+        (session_id, repository_id, kind, working_path, branch, base_commit, availability)
+      SELECT session.id, location.repository_id, location.kind, location.working_path,
+             location.branch, location.base_commit, location.availability
+        FROM sessions session
+        JOIN workstream_repository_locations location ON location.workstream_id = session.workstream_id
+       WHERE (
+               session.access_kind = 'managed' AND session.id = (
+                 SELECT first_session.id
+                   FROM sessions first_session
+                  WHERE first_session.workstream_id = session.workstream_id
+                  ORDER BY first_session.created_at, first_session.rowid
+                  LIMIT 1
+               )
+             )
+          OR session.repository_id = location.repository_id
+      ON CONFLICT (session_id, repository_id) DO NOTHING;
+    `)
+    database
+      .prepare("UPDATE metadata SET value = ? WHERE key = 'schema_version'")
+      .run(String(applicationStateSchemaVersion))
+    incrementRevision(database)
+    database.exec('COMMIT;')
+  } catch (error) {
+    database.exec('ROLLBACK;')
+    throw error
+  }
+}
+
 function initializeSchema(database: SqliteDatabase, generationId: string): void {
   database.exec(`
     PRAGMA foreign_keys = ON;
@@ -60,7 +123,8 @@ function initializeSchema(database: SqliteDatabase, generationId: string): void 
     CREATE TABLE workstreams (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL REFERENCES workspaces(id), goal TEXT, lifecycle TEXT NOT NULL, working_location TEXT NOT NULL, working_location_revision INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL);
     CREATE TABLE sessions (id TEXT PRIMARY KEY, workstream_id TEXT NOT NULL REFERENCES workstreams(id), title TEXT NOT NULL, mode TEXT NOT NULL, availability TEXT NOT NULL, access_kind TEXT NOT NULL, repository_id TEXT REFERENCES repositories(id), pi_session_id TEXT NOT NULL UNIQUE, expected_jsonl_path TEXT NOT NULL UNIQUE, creation_status TEXT NOT NULL, created_at INTEGER NOT NULL);
     CREATE TABLE workstream_repository_locations (workstream_id TEXT NOT NULL REFERENCES workstreams(id), repository_id TEXT NOT NULL REFERENCES repositories(id), kind TEXT NOT NULL, working_path TEXT NOT NULL, branch TEXT, base_commit TEXT, availability TEXT NOT NULL, PRIMARY KEY (workstream_id, repository_id));
-    CREATE TABLE workstream_run_leases (workstream_id TEXT PRIMARY KEY REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, session_id TEXT NOT NULL REFERENCES sessions(id), purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL);
+    CREATE TABLE session_run_leases (session_id TEXT PRIMARY KEY REFERENCES sessions(id), workstream_id TEXT NOT NULL REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL);
+    CREATE TABLE session_repository_locations (session_id TEXT NOT NULL REFERENCES sessions(id), repository_id TEXT NOT NULL REFERENCES repositories(id), kind TEXT NOT NULL, working_path TEXT NOT NULL, branch TEXT, base_commit TEXT, availability TEXT NOT NULL, PRIMARY KEY (session_id, repository_id));
     CREATE TABLE external_side_effect_intents (id TEXT PRIMARY KEY, kind TEXT NOT NULL, status TEXT NOT NULL, session_id TEXT NOT NULL REFERENCES sessions(id), pi_session_id TEXT NOT NULL, directory_path TEXT NOT NULL, session_path TEXT NOT NULL);
     ${workstreamKnowledgeSchemaSql}
     INSERT INTO metadata (key, value) VALUES ('generation_id', '${generationId}'), ('schema_version', '${applicationStateSchemaVersion}'), ('revision', '0');
@@ -71,6 +135,9 @@ function initializeSchema(database: SqliteDatabase, generationId: string): void 
 function readMetadata(database: SqliteDatabase): ApplicationStateMetadata | undefined {
   try {
     database.exec('PRAGMA foreign_keys = ON;')
+    const schemaVersion = database.prepare("SELECT value FROM metadata WHERE key = 'schema_version'").get()?.value
+    const schemaVersionNumber = typeof schemaVersion === 'string' ? Number(schemaVersion) : Number.NaN
+
     for (const table of [
       'repositories',
       'workspace_repositories',
@@ -95,10 +162,18 @@ function readMetadata(database: SqliteDatabase): ApplicationStateMetadata | unde
         'SELECT session_id, pi_session_id, directory_path, session_path FROM external_side_effect_intents LIMIT 1'
       )
       .get()
-    database.prepare('SELECT workstream_id, lease_id, session_id, purpose FROM workstream_run_leases LIMIT 1').get()
+    const leaseTable = tableExists(database, 'session_run_leases')
+      ? 'session_run_leases'
+      : tableExists(database, 'workstream_run_leases')
+        ? 'workstream_run_leases'
+        : undefined
+    if (!leaseTable) throw new Error('The application database has no Agent Run lease table.')
+    if (schemaVersionNumber >= 5 && !tableExists(database, 'session_repository_locations')) {
+      throw new Error('The application database has no Session Repository location table.')
+    }
+    database.prepare(`SELECT workstream_id, lease_id, session_id, purpose FROM ${leaseTable} LIMIT 1`).get()
     const integrity = database.prepare('PRAGMA integrity_check').get()?.integrity_check
     const generationId = database.prepare("SELECT value FROM metadata WHERE key = 'generation_id'").get()?.value
-    const schemaVersion = database.prepare("SELECT value FROM metadata WHERE key = 'schema_version'").get()?.value
 
     return typeof generationId === 'string' && typeof schemaVersion === 'string'
       ? { generationId, schemaVersion: Number(schemaVersion), integrity: integrity === 'ok' ? 'ok' : 'failed' }
@@ -139,6 +214,17 @@ export async function initializeApplicationStateStore(storageDirectory: string, 
 
     try {
       database = hasDatabase ? new sqlite.DatabaseSync(databasePath) : undefined
+      const metadata = database ? readMetadata(database) : undefined
+      if (
+        database &&
+        metadata &&
+        marker &&
+        metadata.integrity === 'ok' &&
+        metadata.generationId === marker.generationId &&
+        (metadata.schemaVersion === 3 || metadata.schemaVersion === 4)
+      ) {
+        migrateApplicationState(database)
+      }
       startup = classifyApplicationState(marker, database ? readMetadata(database) : undefined)
     } catch {
       startup = { status: 'recovery-only', diagnostic: 'The application database is unreadable.' }
@@ -152,10 +238,10 @@ export async function initializeApplicationStateStore(storageDirectory: string, 
 
     try {
       database.exec('BEGIN IMMEDIATE;')
-      const leases = database.prepare("SELECT lease_id FROM workstream_run_leases WHERE purpose = 'agent-run'").all()
+      const leases = database.prepare("SELECT lease_id FROM session_run_leases WHERE purpose = 'agent-run'").all()
 
       if (leases.length > 0) {
-        database.prepare("DELETE FROM workstream_run_leases WHERE purpose = 'agent-run'").run()
+        database.prepare("DELETE FROM session_run_leases WHERE purpose = 'agent-run'").run()
         incrementRevision(database)
       }
 

--- a/src/main/application-state/run-lease-store.ts
+++ b/src/main/application-state/run-lease-store.ts
@@ -27,8 +27,27 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
       }
       if (
         database
-          .prepare('SELECT lease_id FROM workstream_run_leases WHERE workstream_id = ?')
-          .get(session.workstream_id)
+          .prepare("SELECT lease_id FROM session_run_leases WHERE session_id = ? AND purpose = 'agent-run'")
+          .get(sessionId)
+      ) {
+        database.exec('ROLLBACK;')
+        return false
+      }
+      if (
+        database
+          .prepare(
+            `SELECT 1
+               FROM session_run_leases held
+               JOIN session_repository_locations held_location
+                 ON held_location.session_id = held.session_id
+               JOIN session_repository_locations requested_location
+                 ON requested_location.session_id = ?
+              WHERE held.purpose = 'agent-run'
+                AND held.session_id <> ?
+                AND held_location.working_path = requested_location.working_path
+              LIMIT 1`
+          )
+          .get(sessionId, sessionId)
       ) {
         database.exec('ROLLBACK;')
         return false
@@ -36,7 +55,7 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
 
       database
         .prepare(
-          `INSERT INTO workstream_run_leases (workstream_id, lease_id, session_id, purpose, acquired_at)
+          `INSERT INTO session_run_leases (workstream_id, lease_id, session_id, purpose, acquired_at)
            VALUES (?, ?, ?, 'agent-run', ?)`
         )
         .run(session.workstream_id, randomUUID(), sessionId, Date.now())
@@ -59,9 +78,7 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
 
     try {
       database.exec('BEGIN IMMEDIATE;')
-      database
-        .prepare("DELETE FROM workstream_run_leases WHERE session_id = ? AND purpose = 'agent-run'")
-        .run(sessionId)
+      database.prepare("DELETE FROM session_run_leases WHERE session_id = ? AND purpose = 'agent-run'").run(sessionId)
       database.exec('COMMIT;')
       return true
     } catch (error) {

--- a/src/main/application-state/workstream-session-store.ts
+++ b/src/main/application-state/workstream-session-store.ts
@@ -385,12 +385,11 @@ export function createWorkstreamSessionStore({
   }
 
   async function prepareDedicatedSessionWorktreesNow(sessionId: SessionId): Promise<void> {
-    const database = openDatabase()
-    let workspaceId: string
-    let workstreamId: string
+    const sessionDatabase = openDatabase()
+    let session: Readonly<{ workstreamId: string; workspaceId: string }> | undefined
 
     try {
-      const session = database
+      const row = sessionDatabase
         .prepare(
           `SELECT session.workstream_id, workstream.workspace_id
              FROM sessions session
@@ -401,19 +400,18 @@ export function createWorkstreamSessionStore({
               AND workstream.lifecycle = 'active'`
         )
         .get(sessionId)
-      if (!session) return
-
-      workstreamId = String(session.workstream_id)
-      workspaceId = String(session.workspace_id)
+      session = row ? { workstreamId: String(row.workstream_id), workspaceId: String(row.workspace_id) } : undefined
     } finally {
-      database.close()
+      sessionDatabase.close()
     }
 
-    const repositories = openDatabase()
-    let repositoryRows: readonly Readonly<{ id: string; directoryPath: string }>[]
+    if (!session) return
+
+    const repositoryDatabase = openDatabase()
+    let repositories: readonly Readonly<{ id: string; directoryPath: string }>[]
 
     try {
-      repositoryRows = repositories
+      repositories = repositoryDatabase
         .prepare(
           `SELECT repository.id, repository.directory_path
              FROM workspace_repositories membership
@@ -421,126 +419,123 @@ export function createWorkstreamSessionStore({
             WHERE membership.workspace_id = ? AND repository.availability = 'available'
             ORDER BY membership.rowid`
         )
-        .all(workspaceId)
+        .all(session.workspaceId)
         .map((row) => ({ id: String(row.id), directoryPath: String(row.directory_path) }))
     } finally {
-      repositories.close()
+      repositoryDatabase.close()
     }
 
-    for (const repository of repositoryRows) {
-      const existing = openDatabase()
-      let existingLocation: Readonly<{ kind: string; availability: string }> | undefined
+    for (const repository of repositories) {
+      await prepareDedicatedSessionRepositoryWorktree(sessionId, session.workstreamId, repository)
+    }
+  }
 
+  async function prepareDedicatedSessionRepositoryWorktree(
+    sessionId: SessionId,
+    workstreamId: string,
+    repository: Readonly<{ id: string; directoryPath: string }>
+  ): Promise<void> {
+    const existing = openDatabase()
+
+    try {
+      const location = existing
+        .prepare('SELECT 1 FROM session_repository_locations WHERE session_id = ? AND repository_id = ?')
+        .get(sessionId, repository.id)
+      if (location) return
+    } finally {
+      existing.close()
+    }
+
+    let proposal: WorktreeProposal
+
+    try {
+      proposal = await proposeWorktree({
+        repositoryId: repository.id,
+        repositoryPath: repository.directoryPath,
+        workstreamId: sessionId,
+      })
+    } catch {
+      const fallback = openDatabase()
       try {
-        const location = existing
-          .prepare(
-            'SELECT kind, availability FROM session_repository_locations WHERE session_id = ? AND repository_id = ?'
-          )
-          .get(sessionId, repository.id)
-        existingLocation = location
-          ? { kind: String(location.kind), availability: String(location.availability) }
-          : undefined
-      } finally {
-        existing.close()
-      }
-
-      if (existingLocation) continue
-
-      let proposal: WorktreeProposal
-
-      try {
-        proposal = await proposeWorktree({
-          repositoryId: repository.id,
-          repositoryPath: repository.directoryPath,
-          workstreamId: sessionId,
-        })
-      } catch {
-        const fallback = openDatabase()
-        try {
-          fallback.exec('BEGIN IMMEDIATE;')
-          fallback
-            .prepare(
-              `INSERT INTO session_repository_locations
-                (session_id, repository_id, kind, working_path, availability)
-               VALUES (?, ?, 'current-checkout', ?, 'available')
-               ON CONFLICT (session_id, repository_id) DO NOTHING`
-            )
-            .run(sessionId, repository.id, repository.directoryPath)
-          fallback.exec('COMMIT;')
-        } catch {
-          try {
-            fallback.exec('ROLLBACK;')
-          } catch {
-            // The transaction may already have rolled back.
-          }
-        } finally {
-          fallback.close()
-        }
-        continue
-      }
-
-      const recorded = openDatabase()
-      try {
-        recorded.exec('BEGIN IMMEDIATE;')
-        recorded
+        fallback.exec('BEGIN IMMEDIATE;')
+        fallback
           .prepare(
             `INSERT INTO session_repository_locations
-              (session_id, repository_id, kind, working_path, branch, base_commit, availability)
-             VALUES (?, ?, 'worktree', ?, ?, ?, 'unavailable')
+              (session_id, repository_id, kind, working_path, availability)
+             VALUES (?, ?, 'current-checkout', ?, 'available')
              ON CONFLICT (session_id, repository_id) DO NOTHING`
           )
-          .run(sessionId, repository.id, proposal.worktreePath, proposal.branch, proposal.baseCommit)
-        recorded.exec('COMMIT;')
+          .run(sessionId, repository.id, repository.directoryPath)
+        fallback.exec('COMMIT;')
       } catch {
         try {
-          recorded.exec('ROLLBACK;')
-        } catch {
-          // The transaction may already have rolled back.
-        }
-        recorded.close()
-        continue
-      }
-      recorded.close()
-
-      const available = await (async () => {
-        try {
-          const exists =
-            (await inspectWorktree({
-              worktreePath: proposal.worktreePath,
-              commonDirectoryPath: proposal.commonDirectoryPath,
-              expectedBranch: proposal.branch,
-            })) === 'available'
-
-          if (!exists) await createWorktree(proposal)
-
-          return true
-        } catch {
-          return false
-        }
-      })()
-
-      const updated = openDatabase()
-      try {
-        updated.exec('BEGIN IMMEDIATE;')
-        updated
-          .prepare(
-            'UPDATE session_repository_locations SET availability = ? WHERE session_id = ? AND repository_id = ?'
-          )
-          .run(available ? 'available' : 'unavailable', sessionId, repository.id)
-        updated
-          .prepare('UPDATE workstreams SET working_location_revision = working_location_revision + 1 WHERE id = ?')
-          .run(workstreamId)
-        incrementRevision(updated)
-        updated.exec('COMMIT;')
-      } catch {
-        try {
-          updated.exec('ROLLBACK;')
+          fallback.exec('ROLLBACK;')
         } catch {
           // The transaction may already have rolled back.
         }
       } finally {
-        updated.close()
+        fallback.close()
       }
+      return
+    }
+
+    const recorded = openDatabase()
+    try {
+      recorded.exec('BEGIN IMMEDIATE;')
+      recorded
+        .prepare(
+          `INSERT INTO session_repository_locations
+            (session_id, repository_id, kind, working_path, branch, base_commit, availability)
+           VALUES (?, ?, 'worktree', ?, ?, ?, 'unavailable')
+           ON CONFLICT (session_id, repository_id) DO NOTHING`
+        )
+        .run(sessionId, repository.id, proposal.worktreePath, proposal.branch, proposal.baseCommit)
+      recorded.exec('COMMIT;')
+    } catch {
+      try {
+        recorded.exec('ROLLBACK;')
+      } catch {
+        // The transaction may already have rolled back.
+      }
+      return
+    } finally {
+      recorded.close()
+    }
+
+    let available: boolean
+
+    try {
+      const exists =
+        (await inspectWorktree({
+          worktreePath: proposal.worktreePath,
+          commonDirectoryPath: proposal.commonDirectoryPath,
+          expectedBranch: proposal.branch,
+        })) === 'available'
+      if (!exists) await createWorktree(proposal)
+      available = true
+    } catch {
+      available = false
+    }
+
+    const updated = openDatabase()
+    try {
+      updated.exec('BEGIN IMMEDIATE;')
+      updated
+        .prepare('UPDATE session_repository_locations SET availability = ? WHERE session_id = ? AND repository_id = ?')
+        .run(available ? 'available' : 'unavailable', sessionId, repository.id)
+      updated
+        .prepare('UPDATE workstreams SET working_location_revision = working_location_revision + 1 WHERE id = ?')
+        .run(workstreamId)
+      incrementRevision(updated)
+      updated.exec('COMMIT;')
+    } catch {
+      try {
+        updated.exec('ROLLBACK;')
+      } catch {
+        // The transaction may already have rolled back.
+      }
+    } finally {
+      updated.close()
     }
   }
 

--- a/src/main/application-state/workstream-session-store.ts
+++ b/src/main/application-state/workstream-session-store.ts
@@ -350,6 +350,200 @@ export function createWorkstreamSessionStore({
     return sessionId
   }
 
+  function insertSessionWorkingLocationsFromWorkstream(
+    database: SqliteDatabase,
+    sessionId: SessionId,
+    workstreamId: string,
+    repositoryId?: string
+  ): void {
+    database
+      .prepare(
+        `INSERT INTO session_repository_locations
+          (session_id, repository_id, kind, working_path, branch, base_commit, availability)
+         SELECT ?, repository_id, kind, working_path, branch, base_commit, availability
+           FROM workstream_repository_locations
+          WHERE workstream_id = ? AND (? IS NULL OR repository_id = ?)
+         ON CONFLICT (session_id, repository_id) DO NOTHING`
+      )
+      .run(sessionId, workstreamId, repositoryId ?? null, repositoryId ?? null)
+  }
+
+  const sessionLocationPreparations = new Map<SessionId, Promise<void>>()
+
+  async function prepareDedicatedSessionWorktrees(sessionId: SessionId): Promise<void> {
+    const ongoing = sessionLocationPreparations.get(sessionId)
+    if (ongoing) return ongoing
+
+    const preparation = prepareDedicatedSessionWorktreesNow(sessionId)
+    sessionLocationPreparations.set(sessionId, preparation)
+
+    try {
+      await preparation
+    } finally {
+      if (sessionLocationPreparations.get(sessionId) === preparation) sessionLocationPreparations.delete(sessionId)
+    }
+  }
+
+  async function prepareDedicatedSessionWorktreesNow(sessionId: SessionId): Promise<void> {
+    const database = openDatabase()
+    let workspaceId: string
+    let workstreamId: string
+
+    try {
+      const session = database
+        .prepare(
+          `SELECT session.workstream_id, workstream.workspace_id
+             FROM sessions session
+             JOIN workstreams workstream ON workstream.id = session.workstream_id
+            WHERE session.id = ?
+              AND session.access_kind = 'managed'
+              AND session.mode IN ('brainstorm', 'implement')
+              AND workstream.lifecycle = 'active'`
+        )
+        .get(sessionId)
+      if (!session) return
+
+      workstreamId = String(session.workstream_id)
+      workspaceId = String(session.workspace_id)
+    } finally {
+      database.close()
+    }
+
+    const repositories = openDatabase()
+    let repositoryRows: readonly Readonly<{ id: string; directoryPath: string }>[]
+
+    try {
+      repositoryRows = repositories
+        .prepare(
+          `SELECT repository.id, repository.directory_path
+             FROM workspace_repositories membership
+             JOIN repositories repository ON repository.id = membership.repository_id
+            WHERE membership.workspace_id = ? AND repository.availability = 'available'
+            ORDER BY membership.rowid`
+        )
+        .all(workspaceId)
+        .map((row) => ({ id: String(row.id), directoryPath: String(row.directory_path) }))
+    } finally {
+      repositories.close()
+    }
+
+    for (const repository of repositoryRows) {
+      const existing = openDatabase()
+      let existingLocation: Readonly<{ kind: string; availability: string }> | undefined
+
+      try {
+        const location = existing
+          .prepare(
+            'SELECT kind, availability FROM session_repository_locations WHERE session_id = ? AND repository_id = ?'
+          )
+          .get(sessionId, repository.id)
+        existingLocation = location
+          ? { kind: String(location.kind), availability: String(location.availability) }
+          : undefined
+      } finally {
+        existing.close()
+      }
+
+      if (existingLocation) continue
+
+      let proposal: WorktreeProposal
+
+      try {
+        proposal = await proposeWorktree({
+          repositoryId: repository.id,
+          repositoryPath: repository.directoryPath,
+          workstreamId: sessionId,
+        })
+      } catch {
+        const fallback = openDatabase()
+        try {
+          fallback.exec('BEGIN IMMEDIATE;')
+          fallback
+            .prepare(
+              `INSERT INTO session_repository_locations
+                (session_id, repository_id, kind, working_path, availability)
+               VALUES (?, ?, 'current-checkout', ?, 'available')
+               ON CONFLICT (session_id, repository_id) DO NOTHING`
+            )
+            .run(sessionId, repository.id, repository.directoryPath)
+          fallback.exec('COMMIT;')
+        } catch {
+          try {
+            fallback.exec('ROLLBACK;')
+          } catch {
+            // The transaction may already have rolled back.
+          }
+        } finally {
+          fallback.close()
+        }
+        continue
+      }
+
+      const recorded = openDatabase()
+      try {
+        recorded.exec('BEGIN IMMEDIATE;')
+        recorded
+          .prepare(
+            `INSERT INTO session_repository_locations
+              (session_id, repository_id, kind, working_path, branch, base_commit, availability)
+             VALUES (?, ?, 'worktree', ?, ?, ?, 'unavailable')
+             ON CONFLICT (session_id, repository_id) DO NOTHING`
+          )
+          .run(sessionId, repository.id, proposal.worktreePath, proposal.branch, proposal.baseCommit)
+        recorded.exec('COMMIT;')
+      } catch {
+        try {
+          recorded.exec('ROLLBACK;')
+        } catch {
+          // The transaction may already have rolled back.
+        }
+        recorded.close()
+        continue
+      }
+      recorded.close()
+
+      const available = await (async () => {
+        try {
+          const exists =
+            (await inspectWorktree({
+              worktreePath: proposal.worktreePath,
+              commonDirectoryPath: proposal.commonDirectoryPath,
+              expectedBranch: proposal.branch,
+            })) === 'available'
+
+          if (!exists) await createWorktree(proposal)
+
+          return true
+        } catch {
+          return false
+        }
+      })()
+
+      const updated = openDatabase()
+      try {
+        updated.exec('BEGIN IMMEDIATE;')
+        updated
+          .prepare(
+            'UPDATE session_repository_locations SET availability = ? WHERE session_id = ? AND repository_id = ?'
+          )
+          .run(available ? 'available' : 'unavailable', sessionId, repository.id)
+        updated
+          .prepare('UPDATE workstreams SET working_location_revision = working_location_revision + 1 WHERE id = ?')
+          .run(workstreamId)
+        incrementRevision(updated)
+        updated.exec('COMMIT;')
+      } catch {
+        try {
+          updated.exec('ROLLBACK;')
+        } catch {
+          // The transaction may already have rolled back.
+        }
+      } finally {
+        updated.close()
+      }
+    }
+  }
+
   async function previewWorktreeProposal(
     workspaceId: string,
     workstreamId: string,
@@ -574,6 +768,7 @@ export function createWorkstreamSessionStore({
       try {
         finalized.exec('BEGIN IMMEDIATE;')
         sessionId = insertOwnedSession(finalized, options.workstreamId, { mode: normalizeSessionMode(options.mode) })
+        insertSessionWorkingLocationsFromWorkstream(finalized, sessionId, options.workstreamId)
         incrementRevision(finalized)
         finalized.exec('COMMIT;')
       } catch (error) {
@@ -645,6 +840,7 @@ export function createWorkstreamSessionStore({
       initializeStoredWorkstreamKnowledge(database, workstreamId)
       insertCurrentCheckoutLocations(database, workspaceId, workstreamId)
       sessionId = insertOwnedSession(database, workstreamId, { mode: normalizeSessionMode(options.mode) })
+      insertSessionWorkingLocationsFromWorkstream(database, sessionId, workstreamId)
       incrementRevision(database)
       database.exec('COMMIT;')
     } catch (error) {
@@ -748,6 +944,7 @@ export function createWorkstreamSessionStore({
         title: 'Quick Session',
         repositoryId: options.repositoryId,
       })
+      insertSessionWorkingLocationsFromWorkstream(database, sessionId, workstreamId, options.repositoryId)
       incrementRevision(database)
       database.exec('COMMIT;')
     } catch (error) {
@@ -801,6 +998,7 @@ export function createWorkstreamSessionStore({
       database.close()
     }
 
+    await prepareDedicatedSessionWorktrees(sessionId)
     const status = await reconcileCommittedSession(sessionId)
 
     return { status, sessionId, snapshot: await getWorkstreamSnapshot(workspaceId, false) }
@@ -828,7 +1026,7 @@ export function createWorkstreamSessionStore({
       } else {
         if (
           lifecycle === 'archived' &&
-          database.prepare('SELECT lease_id FROM workstream_run_leases WHERE workstream_id = ?').get(workstreamId)
+          database.prepare('SELECT lease_id FROM session_run_leases WHERE workstream_id = ?').get(workstreamId)
         ) {
           throw new TypeError('A Workstream can be archived only while every Session is idle.')
         }
@@ -883,6 +1081,7 @@ export function createWorkstreamSessionStore({
   }
 
   async function resolveOwnedSession(sessionId: SessionId): Promise<OwnedSessionResolution | undefined> {
+    await prepareDedicatedSessionWorktrees(sessionId)
     const database = openDatabase()
 
     try {
@@ -990,12 +1189,12 @@ export function createWorkstreamSessionStore({
                   location.availability AS location_availability
              FROM workspace_repositories membership
              JOIN repositories repository ON repository.id = membership.repository_id
-             LEFT JOIN workstream_repository_locations location
-               ON location.workstream_id = ? AND location.repository_id = repository.id
+             LEFT JOIN session_repository_locations location
+               ON location.session_id = ? AND location.repository_id = repository.id
             WHERE membership.workspace_id = ?
             ORDER BY membership.rowid`
             )
-            .all(row.workstream_id, row.workspace_id)
+            .all(sessionId, row.workspace_id)
           const repositoryIdByMembershipId = new Map(
             repositoryRows.map((repository) => [String(repository.membership_id), String(repository.id)])
           )
@@ -1004,18 +1203,13 @@ export function createWorkstreamSessionStore({
               const repositoryAvailability = parseSessionAvailability(repository.availability)
               const locationKind =
                 repository.location_kind === undefined || repository.location_kind === null
-                  ? row.working_location === 'current-checkouts'
-                    ? 'current-checkout'
-                    : undefined
+                  ? undefined
                   : parseWorkstreamRepositoryLocationKind(repository.location_kind)
-              const workingPath =
-                locationKind === 'current-checkout' ? repository.directory_path : repository.working_path
+              const workingPath = repository.working_path
               let locationAvailability =
-                locationKind === 'current-checkout'
-                  ? repositoryAvailability
-                  : repository.location_availability === undefined || repository.location_availability === null
-                    ? 'unavailable'
-                    : parseSessionAvailability(repository.location_availability)
+                repository.location_availability === undefined || repository.location_availability === null
+                  ? 'unavailable'
+                  : parseSessionAvailability(repository.location_availability)
 
               if (
                 locationKind === 'worktree' &&
@@ -1031,9 +1225,9 @@ export function createWorkstreamSessionStore({
                   locationAvailability = observedAvailability
                   database
                     .prepare(
-                      'UPDATE workstream_repository_locations SET availability = ? WHERE workstream_id = ? AND repository_id = ?'
+                      'UPDATE session_repository_locations SET availability = ? WHERE session_id = ? AND repository_id = ?'
                     )
-                    .run(locationAvailability, row.workstream_id, repository.id)
+                    .run(locationAvailability, sessionId, repository.id)
                   database
                     .prepare(
                       'UPDATE workstreams SET working_location_revision = working_location_revision + 1 WHERE id = ?'
@@ -1065,9 +1259,7 @@ export function createWorkstreamSessionStore({
                 : { ...properties, availability: 'unavailable' as const }
             })
           )
-          const lease = database
-            .prepare('SELECT lease_id FROM workstream_run_leases WHERE workstream_id = ? AND session_id = ?')
-            .get(row.workstream_id, sessionId)
+          const lease = database.prepare('SELECT lease_id FROM session_run_leases WHERE session_id = ?').get(sessionId)
 
           managedPolicy = {
             workspaceId: String(row.workspace_id),

--- a/src/main/application-state/workstreams.test.ts
+++ b/src/main/application-state/workstreams.test.ts
@@ -118,7 +118,7 @@ test('creates a Workstream with exactly one default Implement Session', async ()
   assert.equal(workstream?.sessions[0]?.availability, 'available')
 })
 
-test('creates and reopens Workstream worktrees as every managed Session working location', async () => {
+test('gives each managed Session an isolated worktree', async () => {
   const { authority, storageDirectory, workspace } = await createFixture()
   const repository = workspace.repositories[0]!
   await writeFile(join(repository.directoryPath, 'tracked.txt'), 'committed')
@@ -163,8 +163,10 @@ test('creates and reopens Workstream worktrees as every managed Session working 
 
   const second = await authority.createWorkstreamSession(workstream.id, { mode: 'brainstorm' })
   const secondRepository = (await authority.resolveOwnedSession(second.sessionId))?.managedPolicy?.repositories[0]
+  const secondExpectedPath = join(storageDirectory, '.worktrees', worktreeName(second.sessionId), repository.id)
   assert.equal(secondRepository?.availability, 'available')
-  if (secondRepository?.availability === 'available') assert.equal(secondRepository.workingPath, expectedPath)
+  if (secondRepository?.availability === 'available') assert.equal(secondRepository.workingPath, secondExpectedPath)
+  assert.notEqual(secondRepository?.workingPath, expectedPath)
 
   const restarted = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
   const reopenedRepository = (await restarted.resolveOwnedSession(created.sessionId))?.managedPolicy?.repositories[0]
@@ -1527,9 +1529,43 @@ test('renaming a Session cannot change its permanent owner or mode', async () =>
   assert.equal(after?.mode, before.mode)
 })
 
-test('allows only one Session Agent Run per Workstream', async () => {
+test('allows concurrent Session Agent Runs in isolated Session worktrees', async () => {
   const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await writeFile(join(repository.directoryPath, 'tracked.txt'), 'committed')
+  await exec('git', ['-C', repository.directoryPath, 'add', 'tracked.txt'])
+  await exec('git', [
+    '-C',
+    repository.directoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    'Initial commit',
+  ])
+
   const created = await authority.createWorkstream(workspace.id, { goal: 'Coordinate the work' })
+  const workstream = created.snapshot.workstreams[0]!
+  const second = await authority.createWorkstreamSession(workstream.id, { mode: 'implement' })
+
+  assert.equal(await authority.acquireSessionRunLease(created.sessionId), true)
+  assert.equal(await authority.acquireSessionRunLease(second.sessionId), true)
+
+  await authority.settleSessionRunLease(created.sessionId)
+  assert.equal(await authority.acquireSessionRunLease(created.sessionId), true)
+
+  await authority.settleSessionRunLease(created.sessionId)
+  assert.equal(await authority.acquireSessionRunLease(second.sessionId), false)
+
+  await authority.settleSessionRunLease(second.sessionId)
+  assert.equal(await authority.acquireSessionRunLease(second.sessionId), true)
+})
+
+test('blocks concurrent Agent Runs that share a Repository working path', async () => {
+  const { authority, workspace } = await createFixture()
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Protect shared checkouts' })
   const workstream = created.snapshot.workstreams[0]!
   const second = await authority.createWorkstreamSession(workstream.id, { mode: 'brainstorm' })
 
@@ -1537,8 +1573,34 @@ test('allows only one Session Agent Run per Workstream', async () => {
   assert.equal(await authority.acquireSessionRunLease(second.sessionId), false)
 
   await authority.settleSessionRunLease(created.sessionId)
+})
 
-  assert.equal(await authority.acquireSessionRunLease(second.sessionId), true)
+test('migrates prior application state to Session work locations', async () => {
+  const { authority, storageDirectory, workspace } = await createFixture()
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Migrate Session locations' })
+  const database = new Database(join(storageDirectory, 'application-state.sqlite'))
+  database.exec('ALTER TABLE session_run_leases RENAME TO workstream_run_leases')
+  database.exec('DROP TABLE workstream_run_leases')
+  database.exec(
+    'CREATE TABLE workstream_run_leases (workstream_id TEXT PRIMARY KEY REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, session_id TEXT NOT NULL REFERENCES sessions(id), purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL)'
+  )
+  database.exec('DROP TABLE session_repository_locations')
+  database
+    .prepare(
+      `INSERT INTO workstream_run_leases (workstream_id, lease_id, session_id, purpose, acquired_at)
+       SELECT workstream_id, ?, id, 'agent-run', ? FROM sessions WHERE id = ?`
+    )
+    .run('interrupted-agent-run', Date.now(), created.sessionId)
+  database.prepare("UPDATE metadata SET value = '3' WHERE key = 'schema_version'").run()
+  database.close()
+
+  const restarted = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
+
+  assert.equal(restarted.startup.status, 'ready')
+  assert.equal((await restarted.resolveOwnedSession(created.sessionId))?.canSubmit, true)
+  assert.equal(await restarted.acquireSessionRunLease(created.sessionId), true)
+
+  await restarted.settleSessionRunLease(created.sessionId)
 })
 
 test('releases an interrupted ordinary Agent Run lease during startup', async () => {
@@ -1639,8 +1701,8 @@ test('does not reject Session lookup for a malformed recorded working location',
   const database = new Database(join(storageDirectory, 'application-state.sqlite'))
   database.prepare("UPDATE workstreams SET working_location = 'worktrees' WHERE id = ?").run(workstream.id)
   database
-    .prepare("UPDATE workstream_repository_locations SET kind = 'unknown' WHERE workstream_id = ?")
-    .run(workstream.id)
+    .prepare("UPDATE session_repository_locations SET kind = 'unknown' WHERE session_id = ?")
+    .run(created.sessionId)
   database.close()
 
   assert.equal(await authority.resolveOwnedSession(created.sessionId), undefined)


### PR DESCRIPTION
## Summary

- Allow parallel Agent Runs for Sessions with isolated Repository worktrees.
- Keep conflicting Sessions serialized when they share a Repository working path.
- Persist Session Repository locations and migrate existing v3/v4 application state to schema v5.
- Update repository guidance for live-beta persistence compatibility.

## Related issue

None.

## Validation

- `bun test --max-concurrency=1 --preload ./src/renderer/test-dom.ts src/main/application-state/workstreams.test.ts` — passed, 72 tests.
- `bun test --max-concurrency=1 --preload ./src/renderer/test-dom.ts` — 431 passed, 5 existing TypeScript 7 compatibility failures in architecture tests.
- `bun run format:check` — passed.
- `bun run build` — passed.
- `bun run typecheck` — blocked by the installed TypeScript 7 removal of `baseUrl`/non-relative paths.
- `bun run lint` — blocked because `typescript-eslint` does not support TypeScript 7.0.
- `bun run security:scan` — not run; no dependency or IPC boundary changes.
