### PR TITLE
chore(release): prepare v0.4.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-workspace",
-  "version": "0.3.0-beta.1",
+  "version": "0.4.0-beta.1",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.14",

--- a/scripts/release-note-markdown.test.ts
+++ b/scripts/release-note-markdown.test.ts
@@ -10,6 +10,6 @@ test('formats the latest bundled Release Note for a GitHub Release', () => {
   assert.match(markdown, /^## New$/m)
   assert.match(
     markdown,
-    /^- See current Session context-window usage in Composer, including used and remaining capacity\./m
+    /^- Implement Sessions now create a separate Repository worktree only when Pi prepares that Repository for changes\./m
   )
 })

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -20,6 +20,20 @@ export function isSemanticVersion(version: string): boolean {
 
 export const bundledReleaseNotes: readonly ReleaseNote[] = [
   {
+    version: '0.4.0-beta.1',
+    releaseDate: '2026-07-23',
+    summary: 'This beta makes it easier to prepare changes in different Repositories at the same time.',
+    changes: {
+      new: [
+        'Implement Sessions now create a separate Repository worktree only when Pi prepares that Repository for changes.',
+      ],
+      improved: [],
+      fixed: [
+        'Sessions with separate Repository worktrees can now run at the same time while shared working paths remain protected.',
+      ],
+    },
+  },
+  {
     version: '0.3.0-beta.1',
     releaseDate: '2026-07-23',
     summary: 'This beta makes it easier to keep track of available context during a Session.',


### PR DESCRIPTION
## Summary

- Prepare Pi Workspace v0.4.0-beta.1.
- Add Release Notes for lazy Implement Session worktrees and concurrent Agent Runs in isolated Repository worktrees.

## Validation

- [x] `bun run release:validate`
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build`