### PR TITLE
feat: add application appearance settings

### DIFF
--- a/components/ui-kit/dialog.tsx
+++ b/components/ui-kit/dialog.tsx
@@ -17,10 +17,11 @@ const sizes = {
 
 export function Dialog({
   size = 'lg',
+  scrollable = false,
   className,
   children,
   ...props
-}: { size?: keyof typeof sizes; className?: string; children: React.ReactNode } & Omit<
+}: { size?: keyof typeof sizes; scrollable?: boolean; className?: string; children: React.ReactNode } & Omit<
   Headless.DialogProps,
   'as' | 'className'
 >) {
@@ -28,17 +29,29 @@ export function Dialog({
     <Headless.Dialog {...props}>
       <Headless.DialogBackdrop
         transition
-        className="fixed inset-0 flex w-screen justify-center overflow-y-auto bg-overlay-background px-2 py-2 transition duration-100 focus:outline-0 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in sm:px-6 sm:py-8 lg:px-8 lg:py-16"
+        className="fixed inset-0 flex w-screen justify-center overflow-hidden bg-overlay-background px-2 py-2 transition duration-100 focus:outline-0 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in sm:px-6 sm:py-8 lg:px-8 lg:py-16"
       />
 
-      <div className="fixed inset-0 w-screen overflow-y-auto pt-6 sm:pt-0">
-        <div className="grid min-h-full grid-rows-[1fr_auto] justify-items-center sm:grid-rows-[1fr_auto_3fr] sm:p-4">
+      <div
+        className={clsx(
+          'fixed inset-0 w-screen',
+          scrollable ? 'overflow-hidden p-2 sm:p-8 lg:p-16' : 'overflow-y-auto pt-6 sm:pt-0'
+        )}
+      >
+        <div
+          className={clsx(
+            scrollable
+              ? 'flex h-full items-center justify-center'
+              : 'grid min-h-full grid-rows-[1fr_auto] justify-items-center sm:grid-rows-[1fr_auto_3fr] sm:p-4'
+          )}
+        >
           <Headless.DialogPanel
             transition
             className={clsx(
               className,
               sizes[size],
               'row-start-2 w-full min-w-0 rounded-t-3xl bg-content-background p-(--gutter) shadow-lg ring-1 ring-content-border [--gutter:--spacing(8)] sm:mb-auto sm:rounded-2xl forced-colors:outline',
+              scrollable && 'max-h-full overflow-y-auto overscroll-contain',
               'transition duration-100 will-change-transform data-closed:translate-y-12 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in sm:data-closed:translate-y-0 sm:data-closed:data-enter:scale-95'
             )}
           >

--- a/components/ui-kit/sidebar.tsx
+++ b/components/ui-kit/sidebar.tsx
@@ -79,17 +79,15 @@ export const SidebarItem = forwardRef(function SidebarItem(
     // Base
     'flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left text-base/6 font-medium text-sidebar-foreground sm:py-2 sm:text-sm/5',
     // Leading icon/icon-only
-    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-sidebar-icon sm:*:data-[slot=icon]:size-5',
+    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 sm:*:data-[slot=icon]:size-5',
     // Trailing icon (down chevron or similar)
     '*:last:data-[slot=icon]:ml-auto *:last:data-[slot=icon]:size-5 sm:*:last:data-[slot=icon]:size-4',
     // Avatar
     '*:data-[slot=avatar]:-m-0.5 *:data-[slot=avatar]:size-7 sm:*:data-[slot=avatar]:size-6',
     // Hover
-    'data-hover:bg-sidebar-interaction data-hover:*:data-[slot=icon]:fill-sidebar-foreground',
+    'data-hover:bg-sidebar-interaction',
     // Active
-    'data-active:bg-sidebar-interaction data-active:*:data-[slot=icon]:fill-sidebar-foreground',
-    // Current
-    'data-current:*:data-[slot=icon]:fill-sidebar-foreground'
+    'data-active:bg-sidebar-interaction'
   )
 
   return (

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -69,7 +69,7 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       return
     }
 
-    settingsSnapshot = createSettingsSnapshot(defaultSettings, event.matches)
+    settingsSnapshot = createSettingsSnapshot({ ...settingsSnapshot, appearance: 'system' }, event.matches)
 
     for (const listener of settingsListeners) {
       listener(settingsSnapshot)
@@ -370,10 +370,10 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
         return settingsSnapshot
       },
       async update(update) {
-        const appearance = update.appearance ?? settingsSnapshot.appearance
-
-        const usesDarkColors = appearance === 'system' ? colorSchemeMediaQuery.matches : appearance === 'dark'
-        settingsSnapshot = createSettingsSnapshot({ appearance }, usesDarkColors)
+        const nextSettings = { ...settingsSnapshot, ...update }
+        const usesDarkColors =
+          nextSettings.appearance === 'system' ? colorSchemeMediaQuery.matches : nextSettings.appearance === 'dark'
+        settingsSnapshot = createSettingsSnapshot(nextSettings, usesDarkColors)
 
         for (const listener of settingsListeners) {
           listener(settingsSnapshot)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,8 +6,8 @@ import { initializeApplicationStateIpc } from '@/src/main/application-state-ipc'
 import { initializeComposer } from '@/src/main/composer-ipc'
 import {
   applicationProtocolScheme,
-  denyBrowserPermissionCheck,
-  denyBrowserPermissionRequest,
+  allowBrowserPermissionCheck,
+  allowBrowserPermissionRequest,
   denyWindowOpen,
   preventUntrustedRendererNavigation,
   productionRendererUrl,
@@ -15,11 +15,11 @@ import {
   resolveRendererUrl,
 } from '@/src/main/renderer-security'
 import { createStartupFailureUrl, startupRetryUrl } from '@/src/main/startup-failure'
-import { initializeSettings } from '@/src/main/settings'
+import { initializeSettings, subscribeToSettings } from '@/src/main/settings'
 import { initializeWorkstreams } from '@/src/main/workstreams-ipc'
 import { initializeWorkstreamKnowledge } from '@/src/main/workstream-knowledge-ipc'
 import { configureTrustedRendererUrl, registerTrustedRendererWindow } from '@/src/main/trusted-ipc'
-import { activeTheme } from '@/src/theme'
+import { getThemeWindowBackgroundColor } from '@/src/theme'
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -44,7 +44,7 @@ const trustedRendererUrl = resolveRendererUrl({
 })
 configureTrustedRendererUrl(trustedRendererUrl)
 
-let windowBackgroundColor: string = activeTheme.windowBackgroundColor.light
+let windowBackgroundColor: string = getThemeWindowBackgroundColor('pi-workspace', 'light')
 let initializationFailed = false
 
 async function initializeApplication(): Promise<void> {
@@ -55,8 +55,8 @@ async function initializeApplication(): Promise<void> {
 
     return net.fetch(pathToFileURL(assetPath).href)
   })
-  session.defaultSession.setPermissionCheckHandler(denyBrowserPermissionCheck)
-  session.defaultSession.setPermissionRequestHandler(denyBrowserPermissionRequest)
+  session.defaultSession.setPermissionCheckHandler(allowBrowserPermissionCheck)
+  session.defaultSession.setPermissionRequestHandler(allowBrowserPermissionRequest)
 
   try {
     const authority = await initializeApplicationAuthority(app.getPath('userData'))
@@ -65,7 +65,7 @@ async function initializeApplication(): Promise<void> {
     initializeWorkstreamKnowledge(authority)
     const settings = await initializeSettings()
     initializeComposer(authority)
-    windowBackgroundColor = activeTheme.windowBackgroundColor[settings.resolvedColorScheme]
+    windowBackgroundColor = getThemeWindowBackgroundColor(settings.theme, settings.resolvedColorScheme)
   } catch (error) {
     initializationFailed = true
     console.error('Pi Workspace initialization failed.', error)
@@ -95,7 +95,13 @@ function createWindow(): ApplicationWindow {
   })
 
   const unregisterTrustedRenderer = registerTrustedRendererWindow(window)
-  window.once('closed', unregisterTrustedRenderer)
+  const unsubscribeFromSettings = subscribeToSettings((settings) => {
+    window.setBackgroundColor(getThemeWindowBackgroundColor(settings.theme, settings.resolvedColorScheme))
+  })
+  window.once('closed', () => {
+    unregisterTrustedRenderer()
+    unsubscribeFromSettings()
+  })
 
   let allowedFailureUrl: string | undefined
   const showFailure = (kind: 'initialization' | 'renderer-load') => {

--- a/src/main/renderer-security.test.ts
+++ b/src/main/renderer-security.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import {
-  denyBrowserPermissionCheck,
-  denyBrowserPermissionRequest,
+  allowBrowserPermissionCheck,
+  allowBrowserPermissionRequest,
   denyWindowOpen,
   isTrustedRendererSource,
   isTrustedRendererUrl,
@@ -113,14 +113,22 @@ test('new renderer windows are denied', () => {
   assert.deepEqual(denyWindowOpen(), { action: 'deny' })
 })
 
-test('browser permission checks are denied', () => {
-  assert.equal(denyBrowserPermissionCheck(), false)
+test('allows sanitized clipboard writes', () => {
+  assert.equal(allowBrowserPermissionCheck({}, 'clipboard-sanitized-write'), true)
+
+  let permissionGranted: boolean | undefined
+  allowBrowserPermissionRequest({}, 'clipboard-sanitized-write', (granted) => {
+    permissionGranted = granted
+  })
+
+  assert.equal(permissionGranted, true)
 })
 
-test('browser permission requests are denied', () => {
-  let permissionGranted: boolean | undefined
+test('denies browser permissions other than sanitized clipboard writes', () => {
+  assert.equal(allowBrowserPermissionCheck({}, 'media'), false)
 
-  denyBrowserPermissionRequest({}, 'media', (granted) => {
+  let permissionGranted: boolean | undefined
+  allowBrowserPermissionRequest({}, 'media', (granted) => {
     permissionGranted = granted
   })
 

--- a/src/main/renderer-security.ts
+++ b/src/main/renderer-security.ts
@@ -33,16 +33,16 @@ export function denyWindowOpen(): Readonly<{ action: 'deny' }> {
   return { action: 'deny' }
 }
 
-export function denyBrowserPermissionCheck(): boolean {
-  return false
+export function allowBrowserPermissionCheck(_webContents: unknown, permission: unknown): boolean {
+  return permission === 'clipboard-sanitized-write'
 }
 
-export function denyBrowserPermissionRequest(
+export function allowBrowserPermissionRequest(
   _webContents: unknown,
-  _permission: unknown,
+  permission: unknown,
   callback: (permissionGranted: boolean) => void
 ): void {
-  callback(false)
+  callback(permission === 'clipboard-sanitized-write')
 }
 
 export function resolveRendererAssetPath(requestUrl: string, rendererDirectory: string): string | undefined {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -17,9 +17,11 @@ let settings: Settings = defaultSettings
 let settingsWarning: string | undefined
 let initialized = false
 let lastBroadcastSnapshot: SettingsSnapshot | undefined
+const settingsListeners = new Set<(snapshot: SettingsSnapshot) => void>()
 
 const loadWarning =
   'Settings could not be loaded. Default appearance is in use. Fix or remove settings.json, then restart Pi Workspace.'
+const migrationWarning = 'Settings could not be updated. The default theme is in use.'
 const saveWarning = 'Settings could not be saved. Your appearance change was not applied.'
 
 function getSettingsPath(): string {
@@ -33,11 +35,21 @@ async function saveSettings(nextSettings: Settings): Promise<void> {
 async function loadSettings(): Promise<Readonly<{ settings: Settings; warning?: string }>> {
   try {
     const contents = await readPrivateTextFile(getSettingsPath())
-    const parsed = parseSettings(JSON.parse(contents))
+    const savedSettings: unknown = JSON.parse(contents)
+    const parsed = parseSettings(savedSettings)
 
     if (!parsed) {
       console.warn('Saved settings are malformed.')
       return { settings: defaultSettings, warning: loadWarning }
+    }
+
+    if (typeof savedSettings === 'object' && savedSettings !== null && !Object.hasOwn(savedSettings, 'theme')) {
+      try {
+        await saveSettings(parsed)
+      } catch (error) {
+        console.warn('Unable to update saved settings.', error)
+        return { settings: parsed, warning: migrationWarning }
+      }
     }
 
     return { settings: parsed }
@@ -65,6 +77,7 @@ function getSnapshot(): SettingsSnapshot {
 function hasSameSnapshot(first: SettingsSnapshot, second: SettingsSnapshot): boolean {
   return (
     first.appearance === second.appearance &&
+    first.theme === second.theme &&
     first.resolvedColorScheme === second.resolvedColorScheme &&
     first.warning === second.warning
   )
@@ -80,6 +93,8 @@ function broadcastSnapshot(): void {
   lastBroadcastSnapshot = snapshot
 
   broadcastToTrustedRenderers(settingsIpcChannels.changed, snapshot)
+
+  for (const listener of settingsListeners) listener(snapshot)
 }
 
 async function updateSettings(update: SettingsUpdate): Promise<SettingsSnapshot> {
@@ -95,6 +110,12 @@ async function updateSettings(update: SettingsUpdate): Promise<SettingsSnapshot>
   broadcastSnapshot()
 
   return getSnapshot()
+}
+
+export function subscribeToSettings(listener: (snapshot: SettingsSnapshot) => void): () => void {
+  settingsListeners.add(listener)
+
+  return () => settingsListeners.delete(listener)
 }
 
 export async function initializeSettings(): Promise<SettingsSnapshot> {

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -106,9 +106,10 @@ function createBridge(
       subscribe: () => () => {},
     },
     settings: {
-      getSnapshot: async () => ({ appearance: 'system', resolvedColorScheme: 'light' }),
+      getSnapshot: async () => ({ appearance: 'system', theme: 'pi-workspace', resolvedColorScheme: 'light' }),
       update: async (update: SettingsUpdate) => ({
         appearance: update.appearance ?? 'system',
+        theme: update.theme ?? 'pi-workspace',
         resolvedColorScheme: 'light',
       }),
       subscribe: () => () => {},
@@ -164,6 +165,47 @@ function renderApp(bridge: PiWorkspaceBridge) {
 }
 
 afterEach(cleanup)
+
+test('updates theme immediately from global Settings', async () => {
+  const updates: SettingsUpdate[] = []
+  const bridge = createBridge()
+  Object.assign(bridge.settings, {
+    update: async (update: SettingsUpdate) => {
+      updates.push(update)
+      return { appearance: 'system', theme: update.theme ?? 'pi-workspace', resolvedColorScheme: 'light' }
+    },
+  })
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(bridge)
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  await user.click(view.getByRole('radio', { name: 'One' }))
+
+  await waitFor(() => assert.deepEqual(updates, [{ theme: 'one' }]))
+})
+
+test('closes Settings from its close button', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(createBridge())
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  assert.ok(view.getByRole('dialog', { name: 'Settings' }))
+
+  await user.click(view.getByRole('button', { name: 'Close settings' }))
+  await waitFor(() => assert.equal(view.queryByRole('dialog', { name: 'Settings' }), null))
+})
+
+test('opens the Changelog from the footer release notes action', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(createBridge())
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: /Release notes/ }))
+
+  await view.findByRole('heading', { name: 'Changelog' })
+})
 
 test('renders a named accessible state while startup is pending', async () => {
   const startup = deferred<Awaited<ReturnType<PiWorkspaceBridge['applicationState']['getStartup']>>>()

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -233,7 +233,7 @@ export function Composer({
     <div className="composer-tray shrink-0 border-t border-content-border p-3">
       <div
         aria-busy={agentRunDisabled ? 'true' : undefined}
-        className="group flex min-h-[52px] flex-col rounded-xl border border-composer-border bg-composer-background transition-colors motion-reduce:transition-none hover:border-composer-interaction focus-within:border-composer-interaction"
+        className="group flex min-h-[52px] flex-col rounded-xl bg-composer-background"
         onClick={onActivate}
       >
         <ComposerEditor

--- a/src/renderer/components/settings-dialog.tsx
+++ b/src/renderer/components/settings-dialog.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import { Palette, X } from 'lucide-react'
+import { Button } from '@/components/ui-kit/button'
+import { Dialog, DialogBody, DialogDescription, DialogTitle } from '@/components/ui-kit/dialog'
+import { Description, Field, Fieldset, Label } from '@/components/ui-kit/fieldset'
+import { Radio, RadioField, RadioGroup } from '@/components/ui-kit/radio'
+import { getTheme, isThemeId, themes, type AppearancePreference } from '@/src/theme'
+import { useTheme } from '@/src/renderer/theme'
+
+type SettingsDialogProperties = Readonly<{
+  open: boolean
+  onClose(): void
+}>
+
+type SettingsSection = 'appearance'
+
+export function SettingsDialog({ open, onClose }: SettingsDialogProperties) {
+  const [section, setSection] = useState<SettingsSection>('appearance')
+  const { appearance, resolvedColorScheme, theme, setAppearance, setTheme } = useTheme()
+  const selectedTheme = getTheme(theme)
+  const isDarkOnlyTheme = selectedTheme.colorSchemes.length === 1 && selectedTheme.colorSchemes[0] === 'dark'
+
+  return (
+    <Dialog className="p-0!" open={open} onClose={onClose} scrollable size="4xl">
+      <div className="grid min-h-136 grid-cols-[12rem_minmax(0,1fr)]">
+        <aside className="border-r border-content-border px-3 py-4">
+          <div className="px-3 py-2">
+            <DialogTitle>Settings</DialogTitle>
+          </div>
+          <nav aria-label="Settings sections" className="mt-4">
+            <button
+              type="button"
+              aria-current={section === 'appearance' ? 'page' : undefined}
+              className="flex w-full items-center gap-2 rounded-md bg-content-interaction px-3 py-2 text-left text-sm/5 font-medium text-content-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
+              onClick={() => setSection('appearance')}
+            >
+              <Palette aria-hidden="true" className="size-4" />
+              Appearance
+            </button>
+          </nav>
+        </aside>
+        <div className="flex min-w-0 flex-col">
+          <header className="flex items-start justify-between gap-6 border-b border-content-border px-8 py-6">
+            <div>
+              <h2 className="text-xl/7 font-semibold tracking-tight text-content-foreground">Appearance</h2>
+              <DialogDescription className="mt-1">Choose how Pi Workspace looks on this device.</DialogDescription>
+            </div>
+            <Button plain aria-label="Close settings" className="-mt-2 -mr-2 shrink-0 px-3! py-2!" onClick={onClose}>
+              <X aria-hidden="true" data-slot="icon" />
+            </Button>
+          </header>
+          <DialogBody className="mt-0! flex-1 px-8 py-7">
+            {section === 'appearance' && (
+              <Fieldset className="max-w-xl space-y-8">
+                <Field>
+                  <Label>Theme</Label>
+                  <Description>Choose Pi Workspace’s visual language.</Description>
+                  <RadioGroup
+                    aria-label="Theme"
+                    className="mt-4 divide-y divide-content-border overflow-hidden rounded-lg border border-content-border space-y-0!"
+                    value={theme}
+                    onChange={(value) => {
+                      if (isThemeId(value)) void setTheme(value)
+                    }}
+                  >
+                    {themes.map((candidate) => (
+                      <RadioField className="px-4 py-3.5" key={candidate.id}>
+                        <Radio value={candidate.id} />
+                        <Label>{candidate.name}</Label>
+                      </RadioField>
+                    ))}
+                  </RadioGroup>
+                </Field>
+                <Field>
+                  <Label>Color mode</Label>
+                  {isDarkOnlyTheme ? (
+                    <div className="mt-4 rounded-lg border border-content-border bg-content-subtle-background px-4 py-3.5">
+                      <p className="text-sm/5 font-medium text-content-foreground">Dark mode only</p>
+                      <Description className="mt-1">
+                        {selectedTheme.name} is available in dark mode only. Your color-mode preference will apply again
+                        if you select another theme.
+                      </Description>
+                    </div>
+                  ) : (
+                    <>
+                      <Description>Follow your system preference or choose a fixed mode.</Description>
+                      <RadioGroup
+                        aria-label="Color mode"
+                        className="mt-4 divide-y divide-content-border overflow-hidden rounded-lg border border-content-border space-y-0!"
+                        value={appearance}
+                        onChange={(value) => {
+                          if (value === 'system' || value === 'light' || value === 'dark')
+                            void setAppearance(value as AppearancePreference)
+                        }}
+                      >
+                        <RadioField className="px-4 py-3.5">
+                          <Radio value="system" />
+                          <Label>System</Label>
+                          <Description>Currently using {resolvedColorScheme} mode.</Description>
+                        </RadioField>
+                        <RadioField className="px-4 py-3.5">
+                          <Radio value="light" />
+                          <Label>Light</Label>
+                        </RadioField>
+                        <RadioField className="px-4 py-3.5">
+                          <Radio value="dark" />
+                          <Label>Dark</Label>
+                        </RadioField>
+                      </RadioGroup>
+                    </>
+                  )}
+                </Field>
+              </Fieldset>
+            )}
+          </DialogBody>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/workspace-navigation.test.tsx
+++ b/src/renderer/components/workspace-navigation.test.tsx
@@ -67,13 +67,13 @@ afterEach(() => {
   cleanup()
 })
 
-test('exposes the Workspace and Repository navigation actions', () => {
+test('keeps Repository controls out of the Workspace sidebar', () => {
   const markup = renderToStaticMarkup(createNavigation())
 
   assert.match(markup, /aria-label="Switch Workspace"/)
   assert.match(markup, /aria-label="New Workspace"/)
-  assert.match(markup, /aria-label="Add Repositories"/)
-  assert.match(markup, /aria-label="Repository A settings"/)
+  assert.doesNotMatch(markup, /aria-label="Add Repositories"/)
+  assert.doesNotMatch(markup, /aria-label="Repository A settings"/)
 })
 
 test('keeps membership changes behind Repository settings', () => {
@@ -84,8 +84,14 @@ test('keeps membership changes behind Repository settings', () => {
   assert.doesNotMatch(markup, />Remove Repository</)
 })
 
-test('labels an unavailable Repository', () => {
-  assert.match(renderToStaticMarkup(createNavigation()), /Repository B \(unavailable\)/)
+test('identifies unavailable Repositories in Workspace settings', async () => {
+  const user = createUser()
+  const view = renderInBrowser()
+
+  await user.click(view.getByRole('button', { name: 'Switch Workspace' }))
+  await user.click(await view.findByRole('menuitem', { name: 'Workspace settings' }))
+
+  assert.ok(view.getByText('Unavailable', { exact: true }))
 })
 
 test('creates a Workspace from the dialog', async () => {
@@ -131,7 +137,7 @@ test('opens Workspace creation with the keyboard', async () => {
   assert.ok(view.getByRole('dialog', { name: 'Create Workspace' }))
 })
 
-test('adds Repositories to the selected Workspace', async () => {
+test('adds Repositories from Workspace settings', async () => {
   const addedWorkspaceIds: string[] = []
   const user = createUser()
   const view = renderInBrowser({
@@ -140,9 +146,12 @@ test('adds Repositories to the selected Workspace', async () => {
     },
   })
 
+  await user.click(view.getByRole('button', { name: 'Switch Workspace' }))
+  await user.click(await view.findByRole('menuitem', { name: 'Workspace settings' }))
   await user.click(view.getByRole('button', { name: 'Add Repositories' }))
 
   assert.deepEqual(addedWorkspaceIds, ['workspace-a'])
+  assert.ok(view.getByRole('dialog', { name: 'Workspace settings' }))
 })
 
 test('renames the selected Workspace', async () => {
@@ -164,6 +173,18 @@ test('renames the selected Workspace', async () => {
   assert.deepEqual(renames, [['workspace-a', 'Renamed Workspace']])
 })
 
+test('returns to Workspace settings when Repository settings are cancelled', async () => {
+  const user = createUser()
+  const view = renderInBrowser()
+
+  await user.click(view.getByRole('button', { name: 'Switch Workspace' }))
+  await user.click(await view.findByRole('menuitem', { name: 'Workspace settings' }))
+  await user.click(view.getByRole('button', { name: 'Repository A settings' }))
+  await user.click(view.getByRole('button', { name: 'Cancel' }))
+
+  assert.ok(view.getByRole('dialog', { name: 'Workspace settings' }))
+})
+
 test('updates membership metadata from Repository settings', async () => {
   const updates: Parameters<WorkspaceNavigationProperties['onUpdateMembership']>[] = []
   const user = createUser()
@@ -173,6 +194,8 @@ test('updates membership metadata from Repository settings', async () => {
     },
   })
 
+  await user.click(view.getByRole('button', { name: 'Switch Workspace' }))
+  await user.click(await view.findByRole('menuitem', { name: 'Workspace settings' }))
   await user.click(view.getByRole('button', { name: 'Repository A settings' }))
   await user.type(view.getByRole('textbox', { name: 'Role in this Workspace' }), 'Desktop application')
   await user.click(view.getByRole('checkbox', { name: 'Repository B' }))
@@ -190,6 +213,7 @@ test('updates membership metadata from Repository settings', async () => {
       },
     ],
   ])
+  assert.ok(view.getByRole('dialog', { name: 'Workspace settings' }))
 })
 
 test('removes a membership from Repository settings', async () => {
@@ -201,8 +225,11 @@ test('removes a membership from Repository settings', async () => {
     },
   })
 
+  await user.click(view.getByRole('button', { name: 'Switch Workspace' }))
+  await user.click(await view.findByRole('menuitem', { name: 'Workspace settings' }))
   await user.click(view.getByRole('button', { name: 'Repository A settings' }))
   await user.click(view.getByRole('button', { name: 'Remove Repository' }))
 
   await waitFor(() => assert.deepEqual(removals, [['workspace-a', 'membership-a']]))
+  assert.ok(view.getByRole('dialog', { name: 'Workspace settings' }))
 })

--- a/src/renderer/components/workspace-navigation.tsx
+++ b/src/renderer/components/workspace-navigation.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react'
-import { ChevronDown, Folder, Layers3, Plus, Settings2 } from 'lucide-react'
+import { ChevronDown, Folder, Layers3, Plus, Settings, Settings2 } from 'lucide-react'
 import type { WorkspaceMembershipUpdate, WorkspacesSnapshot } from '@/src/application-state'
 import { Button } from '@/components/ui-kit/button'
 import { Checkbox, CheckboxField, CheckboxGroup } from '@/components/ui-kit/checkbox'
@@ -19,12 +19,11 @@ import {
   SidebarBody,
   SidebarFooter,
   SidebarHeader,
-  SidebarHeading,
   SidebarItem,
   SidebarLabel,
-  SidebarSection,
 } from '@/components/ui-kit/sidebar'
 import { Textarea } from '@/components/ui-kit/textarea'
+import { SettingsDialog } from '@/src/renderer/components/settings-dialog'
 
 type WorkspaceNavigationProperties = Readonly<{
   children: ReactNode
@@ -36,6 +35,8 @@ type WorkspaceNavigationProperties = Readonly<{
   onAddRepositories(workspaceId: string): Promise<void>
   onRemoveRepository(workspaceId: string, membershipId: string): Promise<void>
   onUpdateMembership(workspaceId: string, membershipId: string, update: WorkspaceMembershipUpdate): Promise<void>
+  applicationVersion?: string
+  onOpenChangelog?(): void
 }>
 
 type DialogState =
@@ -66,6 +67,8 @@ export function WorkspaceNavigation({
   onAddRepositories,
   onRemoveRepository,
   onUpdateMembership,
+  applicationVersion = 'Unknown',
+  onOpenChangelog = () => {},
 }: WorkspaceNavigationProperties) {
   const selectedWorkspace = workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? workspaces[0]
   const [dialog, setDialog] = useState<DialogState>()
@@ -76,21 +79,22 @@ export function WorkspaceNavigation({
   const [editingMembershipId, setEditingMembershipId] = useState<string>()
   const [error, setError] = useState<string>()
   const [saving, setSaving] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
 
   const closeDialog = () => {
-    if (!saving) {
-      setDialog(undefined)
-      setError(undefined)
-    }
+    if (saving) return
+
+    setDialog(dialog?.type === 'membership-settings' ? { type: 'workspace-settings' } : undefined)
+    setError(undefined)
   }
 
-  const run = async (operation: () => Promise<void>) => {
+  const run = async (operation: () => Promise<void>, onSuccess: () => void = () => setDialog(undefined)) => {
     setSaving(true)
     setError(undefined)
 
     try {
       await operation()
-      setDialog(undefined)
+      onSuccess()
     } catch (operationError) {
       setError(operationError instanceof Error ? operationError.message : 'Could not update the Workspace.')
     } finally {
@@ -179,52 +183,33 @@ export function WorkspaceNavigation({
 
         <SidebarBody>{children}</SidebarBody>
         <SidebarFooter className="shrink-0">
-          <SidebarSection>
-            <div className="flex items-center gap-1">
-              <SidebarHeading className="mb-0 min-w-0 flex-1">Repositories</SidebarHeading>
-              <button
-                type="button"
-                aria-label="Add Repositories"
-                className="shrink-0 rounded-sm p-1.5 text-sidebar-muted-foreground hover:bg-sidebar-interaction hover:text-sidebar-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
-                onClick={() => void run(() => onAddRepositories(selectedWorkspace.id))}
-              >
-                <Plus aria-hidden="true" className="size-4" />
-              </button>
-            </div>
-            <div aria-label="Workspace Repositories" className="max-h-48 overflow-y-auto">
-              {selectedWorkspace.repositories.map((repository) => (
-                <div className="relative" key={repository.membershipId}>
-                  <SidebarItem
-                    className="[&>button]:pr-10"
-                    onClick={() => openMembershipSettings(repository.membershipId)}
-                  >
-                    <Folder aria-hidden="true" className="size-4 shrink-0 text-sidebar-muted-foreground" />
-                    <SidebarLabel>
-                      {repository.name}
-                      {repository.availability === 'unavailable' && ' (unavailable)'}
-                    </SidebarLabel>
-                  </SidebarItem>
-                  <div className="absolute top-1/2 right-1 z-10 -translate-y-1/2">
-                    <button
-                      type="button"
-                      aria-label={`${repository.name} settings`}
-                      className="rounded-sm p-1.5 text-sidebar-muted-foreground hover:bg-sidebar-interaction hover:text-sidebar-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
-                      onClick={() => openMembershipSettings(repository.membershipId)}
-                    >
-                      <Settings2 aria-hidden="true" className="size-4" />
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-            {error && !dialog && (
-              <p className="px-2 pt-2 text-xs/5 text-form-error-foreground" role="alert">
-                {error}
-              </p>
-            )}
-          </SidebarSection>
+          <div className="flex items-stretch rounded-lg border border-sidebar-border">
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-3 rounded-l-lg px-2 py-2 text-left hover:bg-sidebar-interaction focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
+              onClick={onOpenChangelog}
+            >
+              <img alt="" className="size-7 shrink-0" src="./pi-workspace-mark.svg" />
+              <span className="min-w-0">
+                <span className="block truncate text-sm/5 font-medium text-sidebar-foreground">Pi Workspace</span>
+                <span className="block truncate text-xs/5 text-sidebar-muted-foreground">
+                  v{applicationVersion} · Release notes
+                </span>
+              </span>
+            </button>
+            <Button
+              plain
+              aria-label="Settings"
+              className="shrink-0 self-stretch rounded-l-none! rounded-r-lg! border-0! border-l! border-sidebar-border! px-3! py-2! text-sidebar-foreground [--btn-icon:var(--theme-sidebar-muted-foreground)] data-hover:bg-sidebar-interaction data-hover:[--btn-icon:var(--theme-sidebar-foreground)]"
+              onClick={() => setSettingsOpen(true)}
+            >
+              <Settings aria-hidden="true" data-slot="icon" />
+            </Button>
+          </div>
         </SidebarFooter>
       </Sidebar>
+
+      {settingsOpen && <SettingsDialog open onClose={() => setSettingsOpen(false)} />}
 
       <Dialog open={dialog?.type === 'create-workspace'} onClose={closeDialog}>
         <DialogTitle>Create Workspace</DialogTitle>
@@ -248,15 +233,62 @@ export function WorkspaceNavigation({
         </DialogActions>
       </Dialog>
 
-      <Dialog open={dialog?.type === 'workspace-settings'} onClose={closeDialog}>
+      <Dialog open={dialog?.type === 'workspace-settings'} onClose={closeDialog} size="xl">
         <DialogTitle>Workspace settings</DialogTitle>
         <DialogDescription>Change how this Workspace appears in Pi Workspace.</DialogDescription>
         <DialogBody>
           <Fieldset>
-            <Field>
-              <Label>Workspace name</Label>
-              <Input autoFocus onChange={(event) => setName(event.target.value)} value={name} />
-            </Field>
+            <FieldGroup>
+              <Field>
+                <Label>Workspace name</Label>
+                <Input autoFocus onChange={(event) => setName(event.target.value)} value={name} />
+              </Field>
+              <Field>
+                <div className="flex items-center gap-3">
+                  <Label className="flex-1">Repositories</Label>
+                  <Button
+                    plain
+                    className="-my-1"
+                    disabled={saving}
+                    onClick={() =>
+                      void run(
+                        () => onAddRepositories(selectedWorkspace.id),
+                        () => {}
+                      )
+                    }
+                  >
+                    <Plus aria-hidden="true" data-slot="icon" />
+                    Add Repositories
+                  </Button>
+                </div>
+                <Description>Manage the local Git Repositories available to this Workspace.</Description>
+                <div
+                  aria-label="Workspace Repositories"
+                  className="mt-4 divide-y divide-content-border overflow-hidden rounded-lg border border-content-border"
+                >
+                  {selectedWorkspace.repositories.map((repository) => (
+                    <button
+                      type="button"
+                      aria-label={`${repository.name} settings`}
+                      className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-content-interaction focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring"
+                      key={repository.membershipId}
+                      onClick={() => openMembershipSettings(repository.membershipId)}
+                    >
+                      <Folder aria-hidden="true" className="size-4 shrink-0 text-content-muted-foreground" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm/5 font-medium text-content-foreground">
+                          {repository.name}
+                        </span>
+                        <span className="block truncate text-xs/5 text-content-muted-foreground">
+                          {repository.availability === 'unavailable' ? 'Unavailable' : repository.directoryPath}
+                        </span>
+                      </span>
+                      <Settings2 aria-hidden="true" className="size-4 shrink-0 text-content-muted-foreground" />
+                    </button>
+                  ))}
+                </div>
+              </Field>
+            </FieldGroup>
           </Fieldset>
           <WorkspaceDialogError message={error} />
         </DialogBody>
@@ -319,7 +351,7 @@ export function WorkspaceNavigation({
               disabled={saving}
               onClick={() => {
                 if (!editingMembershipId) return
-                void run(() => onRemoveRepository(selectedWorkspace.id, editingMembershipId))
+                void run(() => onRemoveRepository(selectedWorkspace.id, editingMembershipId), openWorkspaceSettings)
               }}
             >
               Remove Repository
@@ -332,12 +364,14 @@ export function WorkspaceNavigation({
             disabled={saving}
             onClick={() => {
               if (!editingMembershipId) return
-              void run(() =>
-                onUpdateMembership(selectedWorkspace.id, editingMembershipId, {
-                  role,
-                  relationships,
-                  validationCommands: validationCommands.split('\n'),
-                })
+              void run(
+                () =>
+                  onUpdateMembership(selectedWorkspace.id, editingMembershipId, {
+                    role,
+                    relationships,
+                    validationCommands: validationCommands.split('\n'),
+                  }),
+                openWorkspaceSettings
               )
             }}
           >

--- a/src/renderer/screens/changelog-screen.tsx
+++ b/src/renderer/screens/changelog-screen.tsx
@@ -31,7 +31,7 @@ export function ChangelogScreen({ releaseNotes, onBack }: ChangelogScreenPropert
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-content-background text-content-foreground">
-      <header className="flex shrink-0 items-center gap-2 border-b border-content-border px-3 py-2">
+      <header className="flex h-18 shrink-0 items-center gap-3 border-b border-content-border px-6 py-4">
         <Button plain onClick={onBack} className="shrink-0">
           <ArrowLeft aria-hidden="true" data-slot="icon" />
           Back

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -266,6 +266,115 @@
   --theme-sidebar-background: #21252b;
 }
 
+:root:is([data-theme='github'], [data-theme='dracula'], [data-theme='night-owl'], [data-theme='tokyo-night']) {
+  --theme-content-border: color-mix(in oklab, var(--theme-content-foreground) 12%, transparent);
+  --theme-content-hover-border: color-mix(in oklab, var(--theme-content-foreground) 25%, transparent);
+  --theme-content-interaction: color-mix(in oklab, var(--theme-content-foreground) 7%, transparent);
+  --theme-content-interaction-strong: color-mix(in oklab, var(--theme-content-foreground) 12%, transparent);
+  --theme-content-subtle-background: color-mix(in oklab, var(--theme-content-foreground) 6%, transparent);
+  --theme-session-message-code-background: color-mix(in oklab, var(--theme-content-foreground) 4%, transparent);
+  --theme-session-message-code-border: color-mix(in oklab, var(--theme-content-foreground) 8%, transparent);
+  --theme-control-disabled-background: color-mix(in oklab, var(--theme-content-foreground) 5%, transparent);
+  --theme-dropdown-background: color-mix(in oklab, var(--theme-content-background) 92%, transparent);
+  --theme-success-background: color-mix(in oklab, var(--theme-success-foreground) 14%, transparent);
+  --theme-activity-blocked: var(--theme-warning-foreground);
+  --theme-warning-border: var(--theme-warning-foreground);
+  --theme-activity-completed: var(--theme-success-foreground);
+  --theme-activity-failed: var(--theme-danger-foreground);
+  --theme-activity-running: var(--theme-accent);
+  --theme-changelog-list-marker: var(--theme-accent);
+}
+
+:root[data-theme='github'][data-color-scheme='light'] {
+  color-scheme: light;
+  --theme-accent: #0969da;
+  --theme-accent-foreground: #ffffff;
+  --theme-content-background: #ffffff;
+  --theme-content-foreground: #1f2328;
+  --theme-content-muted-foreground: #59636e;
+  --theme-control-background: #ffffff;
+  --theme-danger-background: #cf222e;
+  --theme-danger-border: #a40e26;
+  --theme-danger-foreground: #cf222e;
+  --theme-danger-on-background: #ffffff;
+  --theme-link-foreground: #0969da;
+  --theme-overlay-background: color-mix(in oklab, #1f2328 28%, transparent);
+  --theme-success-foreground: #1a7f37;
+  --theme-warning-foreground: #9a6700;
+}
+
+:root[data-theme='github'][data-color-scheme='dark'] {
+  color-scheme: dark;
+  --theme-accent: #2f81f7;
+  --theme-accent-foreground: #ffffff;
+  --theme-content-background: #0d1117;
+  --theme-content-foreground: #f0f6fc;
+  --theme-content-muted-foreground: #8b949e;
+  --theme-control-background: #161b22;
+  --theme-danger-background: #da3633;
+  --theme-danger-border: #f85149;
+  --theme-danger-foreground: #ff7b72;
+  --theme-danger-on-background: #ffffff;
+  --theme-link-foreground: #58a6ff;
+  --theme-overlay-background: color-mix(in oklab, #010409 60%, transparent);
+  --theme-success-foreground: #3fb950;
+  --theme-warning-foreground: #d29922;
+}
+
+:root[data-theme='dracula'][data-color-scheme='dark'] {
+  color-scheme: dark;
+  --theme-accent: #bd93f9;
+  --theme-accent-foreground: #282a36;
+  --theme-content-background: #282a36;
+  --theme-content-foreground: #f8f8f2;
+  --theme-content-muted-foreground: #bfbfc3;
+  --theme-control-background: #343746;
+  --theme-danger-background: #ff5555;
+  --theme-danger-border: #ff6e6e;
+  --theme-danger-foreground: #ff6e6e;
+  --theme-danger-on-background: #282a36;
+  --theme-link-foreground: #8be9fd;
+  --theme-overlay-background: color-mix(in oklab, #191a21 62%, transparent);
+  --theme-success-foreground: #50fa7b;
+  --theme-warning-foreground: #f1fa8c;
+}
+
+:root[data-theme='night-owl'][data-color-scheme='dark'] {
+  color-scheme: dark;
+  --theme-accent: #82aaff;
+  --theme-accent-foreground: #011627;
+  --theme-content-background: #011627;
+  --theme-content-foreground: #d6deeb;
+  --theme-content-muted-foreground: #9fb3c8;
+  --theme-control-background: #0b2942;
+  --theme-danger-background: #ef5350;
+  --theme-danger-border: #ff6b6b;
+  --theme-danger-foreground: #ff6b6b;
+  --theme-danger-on-background: #011627;
+  --theme-link-foreground: #82aaff;
+  --theme-overlay-background: color-mix(in oklab, #000b14 65%, transparent);
+  --theme-success-foreground: #addb67;
+  --theme-warning-foreground: #ecc48d;
+}
+
+:root[data-theme='tokyo-night'][data-color-scheme='dark'] {
+  color-scheme: dark;
+  --theme-accent: #7aa2f7;
+  --theme-accent-foreground: #1a1b26;
+  --theme-content-background: #1a1b26;
+  --theme-content-foreground: #c0caf5;
+  --theme-content-muted-foreground: #a9b1d6;
+  --theme-control-background: #24283b;
+  --theme-danger-background: #f7768e;
+  --theme-danger-border: #ff899d;
+  --theme-danger-foreground: #ff899d;
+  --theme-danger-on-background: #1a1b26;
+  --theme-link-foreground: #7aa2f7;
+  --theme-overlay-background: color-mix(in oklab, #101014 65%, transparent);
+  --theme-success-foreground: #9ece6a;
+  --theme-warning-foreground: #e0af68;
+}
+
 [data-streamdown='code-block'] {
   border-color: var(--theme-session-message-code-border);
   background: var(--theme-session-message-code-background);

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -300,10 +300,6 @@ body,
 }
 
 @container session-pane (min-width: 520px) {
-  .composer-tray {
-    padding-inline: 1.5rem;
-  }
-
   .composer-editable {
     max-height: 13.75rem;
   }

--- a/src/renderer/theme.tsx
+++ b/src/renderer/theme.tsx
@@ -9,11 +9,12 @@ import {
   type ReactNode,
 } from 'react'
 import { createSettingsSnapshot, defaultSettings, type SettingsSnapshot } from '@/src/settings'
-import { activeTheme, type AppearancePreference } from '@/src/theme'
+import { type AppearancePreference, type ThemeId } from '@/src/theme'
 
 type ThemeContextValue = SettingsSnapshot &
   Readonly<{
     setAppearance(preference: AppearancePreference): Promise<void>
+    setTheme(theme: ThemeId): Promise<void>
   }>
 
 type ThemeProviderProperties = Readonly<{
@@ -62,12 +63,17 @@ export function ThemeProvider({ children }: ThemeProviderProperties) {
       return
     }
 
-    document.documentElement.dataset.theme = activeTheme.id
+    document.documentElement.dataset.theme = snapshot.theme
     document.documentElement.dataset.colorScheme = snapshot.resolvedColorScheme
   }, [snapshot])
 
-  const setAppearance = useCallback(async (preference: AppearancePreference) => {
-    const nextSnapshot = await window.piWorkspace.settings.update({ appearance: preference })
+  const setAppearance = useCallback(async (appearance: AppearancePreference) => {
+    const nextSnapshot = await window.piWorkspace.settings.update({ appearance })
+    setSnapshot(nextSnapshot)
+  }, [])
+
+  const setTheme = useCallback(async (theme: ThemeId) => {
+    const nextSnapshot = await window.piWorkspace.settings.update({ theme })
     setSnapshot(nextSnapshot)
   }, [])
 
@@ -77,9 +83,10 @@ export function ThemeProvider({ children }: ThemeProviderProperties) {
         ? {
             ...snapshot,
             setAppearance,
+            setTheme,
           }
         : undefined,
-    [setAppearance, snapshot]
+    [setAppearance, setTheme, snapshot]
   )
 
   if (!value) {

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -395,6 +395,8 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
           onRenameWorkspace={renameWorkspace}
           onSelectWorkspace={selectWorkspace}
           onUpdateMembership={updateWorkspaceMembership}
+          applicationVersion={bundledReleaseNotes[0]?.version ?? 'Unknown'}
+          onOpenChangelog={openChangelog}
           selectedWorkspaceId={selectedWorkspaceId}
           workspaces={workspacesSnapshot.workspaces}
         >
@@ -440,6 +442,8 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             error={workstreamsLoadError}
             onRetry={() => setWorkstreamsLoadAttempt((attempt) => attempt + 1)}
           />
+        ) : mainContent.destination === 'changelog' ? (
+          <ChangelogScreen releaseNotes={bundledReleaseNotes} onBack={returnToStartup} />
         ) : visibleSessions.length > 0 ? (
           <SessionArea
             sessions={visibleSessions}
@@ -465,8 +469,6 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             sessionSkills={window.piWorkspace.sessionSkills}
             onToggleSessionPin={toggleSessionPin}
           />
-        ) : mainContent.destination === 'changelog' ? (
-          <ChangelogScreen releaseNotes={bundledReleaseNotes} onBack={returnToStartup} />
         ) : selectedWorkstream?.goal ? (
           <WorkstreamSelectionScreen workstream={selectedWorkstream} />
         ) : (

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -2,22 +2,29 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { createSettingsSnapshot, parseSettings, parseSettingsUpdate } from './settings'
 
-test('parses a saved appearance preference', () => {
+test('parses saved theme and appearance preferences', () => {
+  assert.deepEqual(parseSettings({ appearance: 'dark', theme: 'one' }), {
+    appearance: 'dark',
+    theme: 'one',
+  })
+})
+
+test('defaults the theme for saved appearance preferences from before themes', () => {
   assert.deepEqual(parseSettings({ appearance: 'dark' }), {
     appearance: 'dark',
+    theme: 'pi-workspace',
   })
 })
 
 test('rejects malformed saved settings instead of treating them as valid preferences', () => {
-  assert.equal(parseSettings({ appearance: 'sepia' }), undefined)
-  assert.equal(parseSettings({ appearance: 'dark', extra: true }), undefined)
+  assert.equal(parseSettings({ appearance: 'sepia', theme: 'one' }), undefined)
+  assert.equal(parseSettings({ appearance: 'dark', theme: 'one', extra: true }), undefined)
   assert.equal(parseSettings(null), undefined)
 })
 
-test('accepts an appearance-only settings update', () => {
-  assert.deepEqual(parseSettingsUpdate({ appearance: 'light' }), {
-    appearance: 'light',
-  })
+test('accepts independent appearance and theme updates', () => {
+  assert.deepEqual(parseSettingsUpdate({ appearance: 'light' }), { appearance: 'light' })
+  assert.deepEqual(parseSettingsUpdate({ theme: 'one' }), { theme: 'one' })
 })
 
 test('rejects unsupported settings updates', () => {
@@ -26,8 +33,17 @@ test('rejects unsupported settings updates', () => {
 })
 
 test('resolves the current color scheme without changing the saved appearance preference', () => {
-  assert.deepEqual(createSettingsSnapshot({ appearance: 'system' }, true), {
+  assert.deepEqual(createSettingsSnapshot({ appearance: 'system', theme: 'pi-workspace' }, true), {
     appearance: 'system',
+    theme: 'pi-workspace',
+    resolvedColorScheme: 'dark',
+  })
+})
+
+test('resolves a dark-only theme to dark without changing the saved appearance preference', () => {
+  assert.deepEqual(createSettingsSnapshot({ appearance: 'light', theme: 'dracula' }, false), {
+    appearance: 'light',
+    theme: 'dracula',
     resolvedColorScheme: 'dark',
   })
 })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,7 +1,15 @@
-import { isAppearancePreference, type AppearancePreference, type ColorScheme } from '@/src/theme'
+import {
+  isAppearancePreference,
+  isThemeId,
+  resolveThemeColorScheme,
+  type AppearancePreference,
+  type ColorScheme,
+  type ThemeId,
+} from '@/src/theme'
 
 export type Settings = Readonly<{
   appearance: AppearancePreference
+  theme: ThemeId
 }>
 
 export type SettingsSnapshot = Settings &
@@ -20,6 +28,7 @@ export interface SettingsBridge {
 
 export const defaultSettings: Settings = {
   appearance: 'system',
+  theme: 'pi-workspace',
 }
 
 export function parseSettings(value: unknown): Settings | undefined {
@@ -29,11 +38,19 @@ export function parseSettings(value: unknown): Settings | undefined {
 
   const settings = value as Record<string, unknown>
 
-  if (Object.keys(settings).length !== 1 || !isAppearancePreference(settings.appearance)) {
+  const hasTheme = Object.hasOwn(settings, 'theme')
+
+  if (
+    Object.keys(settings).length !== (hasTheme ? 2 : 1) ||
+    !isAppearancePreference(settings.appearance) ||
+    (hasTheme && !isThemeId(settings.theme))
+  ) {
     return undefined
   }
 
-  return { appearance: settings.appearance }
+  const theme = isThemeId(settings.theme) ? settings.theme : defaultSettings.theme
+
+  return { appearance: settings.appearance, theme }
 }
 
 export function parseSettingsUpdate(value: unknown): SettingsUpdate | undefined {
@@ -43,13 +60,12 @@ export function parseSettingsUpdate(value: unknown): SettingsUpdate | undefined 
 
   const update = value as Record<string, unknown>
 
-  if (Object.keys(update).length !== 1 || !isAppearancePreference(update.appearance)) {
-    return undefined
-  }
+  if (Object.keys(update).length !== 1) return undefined
 
-  return {
-    appearance: update.appearance,
-  }
+  if (isAppearancePreference(update.appearance)) return { appearance: update.appearance }
+  if (isThemeId(update.theme)) return { theme: update.theme }
+
+  return undefined
 }
 
 export function createSettingsSnapshot(
@@ -59,7 +75,7 @@ export function createSettingsSnapshot(
 ): SettingsSnapshot {
   return {
     ...settings,
-    resolvedColorScheme: usesDarkColors ? 'dark' : 'light',
+    resolvedColorScheme: resolveThemeColorScheme(settings.theme, usesDarkColors),
     ...(warning ? { warning } : {}),
   }
 }

--- a/src/theme.test.ts
+++ b/src/theme.test.ts
@@ -2,21 +2,43 @@ import assert from 'node:assert/strict'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import test from 'node:test'
-import { activeTheme, oneTheme, piWorkspaceTheme, themes } from './theme'
+import {
+  draculaTheme,
+  getTheme,
+  getThemeWindowBackgroundColor,
+  githubTheme,
+  nightOwlTheme,
+  oneTheme,
+  piWorkspaceTheme,
+  resolveThemeColorScheme,
+  themes,
+  tokyoNightTheme,
+} from './theme'
 
-test('uses Pi Workspace as the active theme', () => {
-  assert.equal(activeTheme, piWorkspaceTheme)
+test('looks up each selectable theme by its identifier', () => {
+  assert.equal(getTheme('pi-workspace'), piWorkspaceTheme)
+  assert.equal(getTheme('one'), oneTheme)
+  assert.equal(getTheme('github'), githubTheme)
+  assert.equal(getTheme('dracula'), draculaTheme)
+  assert.equal(getTheme('night-owl'), nightOwlTheme)
+  assert.equal(getTheme('tokyo-night'), tokyoNightTheme)
 })
 
 test('provides unique theme identifiers', () => {
   assert.equal(new Set(themes.map((theme) => theme.id)).size, themes.length)
 })
 
-test('provides a window background for every theme color scheme', () => {
+test('provides a window background for every supported theme color scheme', () => {
   for (const theme of themes) {
-    assert.match(theme.windowBackgroundColor.light, /^#[\da-f]{6}$/i)
-    assert.match(theme.windowBackgroundColor.dark, /^#[\da-f]{6}$/i)
+    for (const colorScheme of theme.colorSchemes) {
+      assert.match(getThemeWindowBackgroundColor(theme.id, colorScheme), /^#[\da-f]{6}$/i)
+    }
   }
+})
+
+test('resolves dark-only themes to dark mode without changing the saved appearance preference', () => {
+  assert.equal(resolveThemeColorScheme('dracula', false), 'dark')
+  assert.equal(resolveThemeColorScheme('dracula', true), 'dark')
 })
 
 test('pairs One Light and One Dark under one theme', () => {
@@ -28,6 +50,15 @@ test('pairs One Light and One Dark under one theme', () => {
 test('keeps Pi Workspace window backgrounds neutral', () => {
   assert.equal(piWorkspaceTheme.windowBackgroundColor.light, '#ffffff')
   assert.equal(piWorkspaceTheme.windowBackgroundColor.dark, '#18181b')
+})
+
+test('new themes provide a caution color for context usage', () => {
+  const stylesheet = readFileSync(join(process.cwd(), 'src', 'renderer', 'style.css'), 'utf8')
+
+  assert.match(
+    stylesheet,
+    /:root:is\(\[data-theme='github'\], \[data-theme='dracula'\], \[data-theme='night-owl'\], \[data-theme='tokyo-night'\]\) \{[\s\S]*--theme-warning-border:/
+  )
 })
 
 test('renderer components use semantic theme colors', () => {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,15 +3,20 @@ export const appearancePreferences = ['system', 'light', 'dark'] as const
 export type AppearancePreference = (typeof appearancePreferences)[number]
 export type ColorScheme = Exclude<AppearancePreference, 'system'>
 
+export const themeIds = ['pi-workspace', 'one', 'github', 'dracula', 'night-owl', 'tokyo-night'] as const
+export type ThemeId = (typeof themeIds)[number]
+
 export type Theme = Readonly<{
-  id: string
+  id: ThemeId
   name: string
-  windowBackgroundColor: Readonly<Record<ColorScheme, string>>
+  colorSchemes: readonly ColorScheme[]
+  windowBackgroundColor: Readonly<Partial<Record<ColorScheme, string>>>
 }>
 
 export const piWorkspaceTheme = {
   id: 'pi-workspace',
   name: 'Pi Workspace',
+  colorSchemes: ['light', 'dark'],
   windowBackgroundColor: {
     light: '#ffffff',
     dark: '#18181b',
@@ -21,16 +26,81 @@ export const piWorkspaceTheme = {
 export const oneTheme = {
   id: 'one',
   name: 'One',
+  colorSchemes: ['light', 'dark'],
   windowBackgroundColor: {
     light: '#fafafa',
     dark: '#282c34',
   },
 } as const satisfies Theme
 
-export const themes = [piWorkspaceTheme, oneTheme] as const satisfies readonly Theme[]
+export const githubTheme = {
+  id: 'github',
+  name: 'GitHub',
+  colorSchemes: ['light', 'dark'],
+  windowBackgroundColor: {
+    light: '#ffffff',
+    dark: '#0d1117',
+  },
+} as const satisfies Theme
 
-// Change this value while theme selection remains a manual development option.
-export const activeTheme: Theme = piWorkspaceTheme
+export const draculaTheme = {
+  id: 'dracula',
+  name: 'Dracula',
+  colorSchemes: ['dark'],
+  windowBackgroundColor: {
+    dark: '#282a36',
+  },
+} as const satisfies Theme
+
+export const nightOwlTheme = {
+  id: 'night-owl',
+  name: 'Night Owl',
+  colorSchemes: ['dark'],
+  windowBackgroundColor: {
+    dark: '#011627',
+  },
+} as const satisfies Theme
+
+export const tokyoNightTheme = {
+  id: 'tokyo-night',
+  name: 'Tokyo Night',
+  colorSchemes: ['dark'],
+  windowBackgroundColor: {
+    dark: '#1a1b26',
+  },
+} as const satisfies Theme
+
+export const themes = [
+  piWorkspaceTheme,
+  oneTheme,
+  githubTheme,
+  draculaTheme,
+  nightOwlTheme,
+  tokyoNightTheme,
+] as const satisfies readonly Theme[]
+
+export function isThemeId(value: unknown): value is ThemeId {
+  return themeIds.some((themeId) => themeId === value)
+}
+
+export function getTheme(themeId: ThemeId): Theme {
+  return themes.find((theme) => theme.id === themeId)!
+}
+
+export function resolveThemeColorScheme(themeId: ThemeId, usesDarkColors: boolean): ColorScheme {
+  const requestedColorScheme: ColorScheme = usesDarkColors ? 'dark' : 'light'
+  const theme = getTheme(themeId)
+
+  return theme.colorSchemes.includes(requestedColorScheme) ? requestedColorScheme : theme.colorSchemes[0]!
+}
+
+export function getThemeWindowBackgroundColor(themeId: ThemeId, colorScheme: ColorScheme): string {
+  const backgroundColor = getTheme(themeId).windowBackgroundColor[colorScheme]
+
+  if (!backgroundColor) throw new Error(`Theme ${themeId} does not support ${colorScheme} mode.`)
+
+  return backgroundColor
+}
 
 export function isAppearancePreference(value: unknown): value is AppearancePreference {
   return appearancePreferences.some((preference) => preference === value)


### PR DESCRIPTION
## Summary

- add persisted application appearance settings and selectable themes
- move Repository management into Workspace settings and add a sidebar release-notes/settings footer
- fix Markdown code-block copying by permitting sanitized clipboard writes
- align the Changelog header and simplify the Composer tray

## Related issue

None.

## Validation

- `bun run check`
- `bun run security:scan`
- `bun test src/theme.test.ts`

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] No new dependencies, copied or generated material, or assets were added.
- [x] Changes to `components/ui-kit/` remain within the licensed Pi Workspace application.