### PR TITLE
chore(release): prepare v0.5.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-workspace",
-  "version": "0.4.0-beta.1",
+  "version": "0.5.0-beta.1",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.14",

--- a/scripts/release-note-markdown.test.ts
+++ b/scripts/release-note-markdown.test.ts
@@ -10,6 +10,6 @@ test('formats the latest bundled Release Note for a GitHub Release', () => {
   assert.match(markdown, /^## New$/m)
   assert.match(
     markdown,
-    /^- Implement Sessions now create a separate Repository worktree only when Pi prepares that Repository for changes\./m
+    /^- Choose from six visual themes and color modes in Settings, with your preferences saved across launches\./m
   )
 })

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -20,6 +20,19 @@ export function isSemanticVersion(version: string): boolean {
 
 export const bundledReleaseNotes: readonly ReleaseNote[] = [
   {
+    version: '0.5.0-beta.1',
+    releaseDate: '2026-07-24',
+    summary: 'This beta adds appearance customization and brings Workspace and application controls together.',
+    changes: {
+      new: ['Choose from six visual themes and color modes in Settings, with your preferences saved across launches.'],
+      improved: [
+        'Manage Workspace Repositories from Workspace settings and open application Settings or Release notes from the sidebar footer.',
+        'Changelog and Composer controls now use a cleaner, more focused layout.',
+      ],
+      fixed: ['Copying Markdown code blocks now works without a browser permission failure.'],
+    },
+  },
+  {
     version: '0.4.0-beta.1',
     releaseDate: '2026-07-23',
     summary: 'This beta makes it easier to prepare changes in different Repositories at the same time.',


### PR DESCRIPTION
## Summary

- bump the application version to `0.5.0-beta.1`
- add the latest Release Note covering appearance settings, Workspace controls, layout improvements, and clipboard copying
- update the latest Release Note markdown test

## Validation

- `bun run release:validate`
- `bun test`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`