### PR TITLE
feat: add durable queued follow-ups

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,6 +68,9 @@ The newest bundled Release Note, which must match the current application versio
 **Agent Run**:
 The user-facing work cycle that begins when an idle Session accepts a user submission and ends when Pi settles.
 
+**Queued Follow-up**:
+A durable user message held for a working Session after its current Agent Run. Live Queued Follow-ups begin automatically when Pi settles. Queued Follow-ups restored after an application restart remain visible, removable, and paused until the user resumes them.
+
 **Agent Activity**:
 One user-understandable outcome within an Agent Run.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The default `startup` scenario opens at the printed local URL. Other determinist
 - `?scenario=completed-run`
 - `?scenario=multi-session`
 - `?scenario=quick-sessions` — two realistic frontend and API Quick Sessions pinned side by side
+- `?scenario=queued-messages` — an active Session with a transcript-visible steer and a full three-item follow-up queue
 - `?scenario=workstream`
 
 Unknown scenario names use `startup`. Use a 1200 by 800 browser viewport as the baseline screenshot composition.

--- a/src/composer-ipc.test.ts
+++ b/src/composer-ipc.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { sessionId } from '@/src/domain/session'
-import { maximumSessionMessageLength, parseSessionMessageSubmission, parseSessionRunStopRequest } from './composer-ipc'
+import {
+  maximumSessionMessageLength,
+  parseQueuedFollowUpRemovalRequest,
+  parseSessionMessageSubmission,
+  parseSessionRunStopRequest,
+} from './composer-ipc'
 
 test('accepts a narrow serializable Agent Run stop request', () => {
   assert.deepEqual(parseSessionRunStopRequest({ sessionId: 'session-a' }), { sessionId: sessionId('session-a') })
@@ -9,6 +14,17 @@ test('accepts a narrow serializable Agent Run stop request', () => {
 
 test('rejects an invalid Agent Run stop request', () => {
   assert.equal(parseSessionRunStopRequest({ sessionId: '' }), undefined)
+})
+
+test('accepts a narrow queued follow-up removal request', () => {
+  assert.deepEqual(parseQueuedFollowUpRemovalRequest({ sessionId: 'session-a', followUpId: 'follow-up-1' }), {
+    sessionId: sessionId('session-a'),
+    followUpId: 'follow-up-1',
+  })
+})
+
+test('rejects an invalid queued follow-up removal request', () => {
+  assert.equal(parseQueuedFollowUpRemovalRequest({ sessionId: 'session-a', followUpId: '' }), undefined)
 })
 
 test('accepts a narrow serializable Session message submission', () => {

--- a/src/composer-ipc.ts
+++ b/src/composer-ipc.ts
@@ -7,6 +7,8 @@ export const maximumSessionMessageLength = 200_000
 export const composerIpcChannels = {
   submit: 'composer:submit',
   stop: 'composer:stop',
+  removeQueuedFollowUp: 'composer:remove-queued-follow-up',
+  resumeQueuedFollowUps: 'composer:resume-queued-follow-ups',
 } as const
 
 export function parseSessionRunStopRequest(
@@ -17,6 +19,18 @@ export function parseSessionRunStopRequest(
   const id = (value as Record<string, unknown>).sessionId
 
   return isSessionId(id) ? { sessionId: id } : undefined
+}
+
+export function parseQueuedFollowUpRemovalRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionMessageSubmission['sessionId']; followUpId: string }> | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const request = value as Record<string, unknown>
+
+  return isSessionId(request.sessionId) && typeof request.followUpId === 'string' && request.followUpId.length > 0
+    ? { sessionId: request.sessionId, followUpId: request.followUpId }
+    : undefined
 }
 
 export function parseSessionMessageSubmission(value: unknown): SessionMessageSubmission | undefined {

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -53,4 +53,6 @@ export type SessionMessageSubmissionResult =
 export interface ComposerBridge {
   submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult>
   stop(sessionId: SessionId): Promise<SessionRunStopResult>
+  removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>
+  resumeQueuedFollowUps(sessionId: SessionId): Promise<boolean>
 }

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -62,6 +62,8 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
   let settingsSnapshot: SettingsSnapshot = createSettingsSnapshot(defaultSettings, colorSchemeMediaQuery.matches)
   let createdSessionNumber = 0
   let workstreamsSnapshot: WorkstreamsSnapshot = scenario.workstreams
+  const transcriptsBySessionId: Record<string, SessionTranscriptSnapshot> = { ...scenario.transcriptsBySessionId }
+  const transcriptListeners = new Set<Parameters<PiWorkspaceBridge['transcript']['subscribe']>[0]>()
   const settingsListeners = new Set<Parameters<PiWorkspaceBridge['settings']['subscribe']>[0]>()
 
   colorSchemeMediaQuery.addEventListener('change', (event) => {
@@ -77,7 +79,7 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
   })
 
   const transcriptSnapshot = (requestedSessionId: string): SessionTranscriptSnapshot =>
-    scenario.transcriptsBySessionId[requestedSessionId] ?? {
+    transcriptsBySessionId[requestedSessionId] ?? {
       sessionId: sessionId(requestedSessionId),
       revision: 0,
       isWorking: false,
@@ -131,6 +133,28 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       async stop() {
         return { status: 'not-running' }
       },
+      async removeQueuedFollowUp(sessionId, followUpId) {
+        const transcript = transcriptSnapshot(sessionId)
+        const queuedFollowUps = transcript.queuedFollowUps ?? []
+
+        if (!queuedFollowUps.some((followUp) => followUp.id === followUpId)) return false
+
+        const snapshot = {
+          ...transcript,
+          revision: transcript.revision + 1,
+          queuedFollowUps: queuedFollowUps.filter((followUp) => followUp.id !== followUpId),
+        }
+        transcriptsBySessionId[sessionId] = snapshot
+
+        for (const listener of transcriptListeners) {
+          listener({ sessionId, revision: snapshot.revision, snapshot })
+        }
+
+        return true
+      },
+      async resumeQueuedFollowUps() {
+        return false
+      },
     },
     sessionSkills: {
       async getAvailable() {
@@ -170,7 +194,7 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
         return transcriptSnapshot(sessionId)
       },
       async getWorkingStateSnapshots() {
-        return Object.values(scenario.transcriptsBySessionId).map(({ sessionId, revision, isWorking }) => ({
+        return Object.values(transcriptsBySessionId).map(({ sessionId, revision, isWorking }) => ({
           sessionId,
           revision,
           isWorking,
@@ -180,8 +204,9 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
         return scenario.activityDetailsBySessionId[sessionId]?.[activityId]
       },
       async openExternalLink() {},
-      subscribe() {
-        return () => {}
+      subscribe(listener) {
+        transcriptListeners.add(listener)
+        return () => transcriptListeners.delete(listener)
       },
     },
     workstreams: {

--- a/src/demo/demo-scenarios.test.ts
+++ b/src/demo/demo-scenarios.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getDemoScenario, getDemoScenarioPresentation } from './demo-scenarios'
+
+test('provides an active Session with transcript-visible steering and queued follow-ups', () => {
+  const scenario = getDemoScenario('queued-messages')
+  const transcript = scenario.transcriptsBySessionId['queued-messages']
+  const presentation = getDemoScenarioPresentation('queued-messages')
+
+  assert.equal(transcript?.isWorking, true)
+  assert.equal(presentation?.activeSessionId, 'queued-messages')
+  assert.deepEqual(
+    transcript?.entries
+      .filter((entry) => entry.type === 'message' && entry.message.role === 'user')
+      .map((entry) => (entry.type === 'message' ? entry.message.id : '')),
+    ['message-delivery-request', 'message-delivery-steer']
+  )
+  assert.deepEqual(
+    transcript?.queuedFollowUps?.map(({ id }) => id),
+    ['message-delivery-follow-up', 'message-delivery-validation', 'message-delivery-accessibility']
+  )
+})

--- a/src/demo/demo-scenarios.ts
+++ b/src/demo/demo-scenarios.ts
@@ -842,6 +842,111 @@ const multiSessionScenario = createEmptyScenario([
   ['harbor-offline', 'Design offline recovery'],
 ])
 
+const queuedMessagesSessionId = sessionId('queued-messages')
+const queuedMessagesStartedAt = Date.UTC(2026, 6, 17, 13, 40)
+const queuedMessagesScenario: DemoScenario = {
+  ...createEmptyScenario([['queued-messages', 'Refine Session message delivery']]),
+  transcriptsBySessionId: {
+    [queuedMessagesSessionId]: {
+      sessionId: queuedMessagesSessionId,
+      revision: 5,
+      isWorking: true,
+      runs: [
+        {
+          id: 'message-delivery-run',
+          initiatingMessageId: 'message-delivery-request',
+          status: 'running',
+          activityIds: ['inspect-message-delivery'],
+          startedAt: queuedMessagesStartedAt,
+        },
+      ],
+      entries: [
+        {
+          type: 'message',
+          message: {
+            id: 'message-delivery-request',
+            role: 'user',
+            text: 'Improve how queued messages appear while Pi is working. Keep the Composer ready for the next message, and make the transcript the clear record of what was sent.',
+            state: 'complete',
+            revision: 0,
+          },
+        },
+        {
+          type: 'activity',
+          activity: {
+            type: 'activity',
+            id: 'inspect-message-delivery',
+            runId: 'message-delivery-run',
+            kind: 'exploration',
+            title: 'Mapped Session message delivery',
+            summary: 'Traced the Composer acknowledgement and the canonical transcript update path.',
+            status: 'completed',
+            operationCount: 2,
+            fileCount: 2,
+            secondaryLine: '2 files inspected',
+            artifacts: [
+              { type: 'inspected-file', path: 'src/renderer/components/composer.tsx' },
+              { type: 'inspected-file', path: 'src/renderer/components/session-messages.tsx' },
+            ],
+            startedAt: queuedMessagesStartedAt + 4_000,
+            completedAt: queuedMessagesStartedAt + 31_000,
+          },
+        },
+        {
+          type: 'message',
+          message: {
+            id: 'message-delivery-response',
+            role: 'assistant',
+            text: 'I found the delivery handoff. I’m keeping the transcript as the visible record while I finish the current response.',
+            state: 'streaming',
+            revision: 0,
+          },
+        },
+        {
+          type: 'message',
+          message: {
+            id: 'message-delivery-steer',
+            role: 'user',
+            text: 'Steer the current work toward the transcript instead of leaving a persistent acknowledgement in the Composer.',
+            delivery: 'steer',
+            state: 'complete',
+            revision: 0,
+          },
+        },
+      ],
+      queuedFollowUps: [
+        {
+          id: 'message-delivery-follow-up',
+          text: 'After this response, also confirm that a new Session focuses its Composer after the creation dialog closes.',
+          createdAt: queuedMessagesStartedAt + 38_000,
+        },
+        {
+          id: 'message-delivery-validation',
+          text: '/skill:code-review Then run the focused Composer and transcript tests before we review the change.',
+          skills: [
+            {
+              offset: 0,
+              skill: {
+                name: 'code-review',
+                description: 'Review code changes for correctness and maintainability.',
+                availability: 'available',
+              },
+            },
+          ],
+          createdAt: queuedMessagesStartedAt + 42_000,
+        },
+        {
+          id: 'message-delivery-accessibility',
+          text: 'Check the queue controls with keyboard navigation and a screen reader.',
+          createdAt: queuedMessagesStartedAt + 46_000,
+        },
+      ],
+    },
+  },
+  activityDetailsBySessionId: {},
+  workstreamKnowledgesByWorkstreamId: {},
+}
+
 const frontendQuickSessionId = sessionId('atlas-web-checkout')
 const apiQuickSessionId = sessionId('atlas-api-checkout')
 const quickSessionsStartedAt = Date.UTC(2026, 6, 16, 11, 5)
@@ -1287,12 +1392,18 @@ const quickSessionsPresentation: DemoScenarioPresentation = {
   pinnedSessionIds: [frontendQuickSessionId, apiQuickSessionId],
 }
 
+const queuedMessagesPresentation: DemoScenarioPresentation = {
+  activeSessionId: queuedMessagesSessionId,
+  pinnedSessionIds: [],
+}
+
 const scenarios: Readonly<Record<string, DemoScenario>> = {
   startup: startupScenario,
   workstream: workstreamScenario,
   'completed-run': completedRunScenario,
   'multi-session': multiSessionScenario,
   'quick-sessions': quickSessionsScenario,
+  'queued-messages': queuedMessagesScenario,
 }
 
 export function getDemoScenario(name: string | undefined): DemoScenario {
@@ -1302,6 +1413,7 @@ export function getDemoScenario(name: string | undefined): DemoScenario {
 export function getDemoScenarioPresentation(name: string | undefined): DemoScenarioPresentation | undefined {
   if (name === 'workstream') return workstreamPresentation
   if (name === 'quick-sessions') return quickSessionsPresentation
+  if (name === 'queued-messages') return queuedMessagesPresentation
 
   return undefined
 }

--- a/src/main/activity-records.test.ts
+++ b/src/main/activity-records.test.ts
@@ -71,6 +71,56 @@ test('rejects malformed activity removal records', () => {
   assert.equal(isActivityLayerRecord({ version: 1, type: 'activity-removed', activityId: '' }), false)
 })
 
+test('rejects malformed queued follow-up records', () => {
+  assert.equal(
+    isActivityLayerRecord({ version: 1, type: 'queued-follow-up', followUp: { id: '', text: '', createdAt: -1 } }),
+    false
+  )
+  assert.equal(
+    isActivityLayerRecord({
+      version: 1,
+      type: 'queued-follow-up',
+      followUp: { id: 'follow-up-1', text: '/skill:tdd Continue.', skills: [{ offset: -1 }], createdAt: 1 },
+    }),
+    false
+  )
+  assert.equal(isActivityLayerRecord({ version: 1, type: 'queued-follow-up-removed', followUpId: '' }), false)
+})
+
+test('accepts queued follow-up records', () => {
+  assert.equal(
+    isActivityLayerRecord({
+      version: 1,
+      type: 'queued-follow-up',
+      followUp: {
+        id: 'follow-up-1',
+        text: '/skill:tdd Continue after this response.',
+        skills: [
+          {
+            offset: 0,
+            skill: { name: 'tdd', description: 'Develop test first.', availability: 'available' },
+          },
+        ],
+        createdAt: 1,
+      },
+    }),
+    true
+  )
+  assert.equal(isActivityLayerRecord({ version: 1, type: 'queued-follow-up-removed', followUpId: 'follow-up-1' }), true)
+})
+
+test('accepts a steering message record', () => {
+  assert.equal(
+    isActivityLayerRecord({
+      version: 1,
+      type: 'steering-message',
+      text: 'Prioritize transcript delivery.',
+      acceptedAt: 1,
+    }),
+    true
+  )
+})
+
 test('rejects malformed diagnostic records', () => {
   assert.equal(
     isActivityLayerRecord({

--- a/src/main/activity-records.ts
+++ b/src/main/activity-records.ts
@@ -1,3 +1,4 @@
+import type { QueuedFollowUp, QueuedFollowUpRecord } from '@/src/queued-follow-up'
 import {
   agentActivityKinds,
   type ActivityArtifact,
@@ -26,6 +27,8 @@ export type ActivityLayerRecord =
       execution: Omit<ToolExecution, 'input'>
     }>
   | Readonly<{ version: 1; type: 'activity-removed'; activityId: string }>
+  | Readonly<{ version: 1 } & QueuedFollowUpRecord>
+  | Readonly<{ version: 1; type: 'steering-message'; text: string; acceptedAt: number }>
   | Readonly<{
       version: 1
       type: 'diagnostic'
@@ -42,6 +45,9 @@ export function isActivityLayerRecord(value: unknown): value is ActivityLayerRec
   if (value.type === 'activity') return isAgentActivity(value.activity)
   if (value.type === 'operation') return isToolExecution(value.execution)
   if (value.type === 'activity-removed') return isNonEmptyString(value.activityId)
+  if (value.type === 'queued-follow-up') return isQueuedFollowUp(value.followUp)
+  if (value.type === 'queued-follow-up-removed') return isNonEmptyString(value.followUpId)
+  if (value.type === 'steering-message') return typeof value.text === 'string' && isTimestamp(value.acceptedAt)
   if (value.type === 'diagnostic') {
     return (
       isNonEmptyString(value.runId) &&
@@ -57,6 +63,28 @@ export function isActivityLayerRecord(value: unknown): value is ActivityLayerRec
   }
 
   return false
+}
+
+function isQueuedFollowUp(value: unknown): value is QueuedFollowUp {
+  if (!isRecord(value)) return false
+
+  return (
+    isNonEmptyString(value.id) &&
+    typeof value.text === 'string' &&
+    (value.skills === undefined || (Array.isArray(value.skills) && value.skills.every(isSessionSkillMention))) &&
+    isTimestamp(value.createdAt)
+  )
+}
+
+function isSessionSkillMention(value: unknown): boolean {
+  if (!isRecord(value) || !isCount(value.offset) || !isRecord(value.skill) || !isNonEmptyString(value.skill.name)) {
+    return false
+  }
+
+  return (
+    (value.skill.availability === 'available' && typeof value.skill.description === 'string') ||
+    value.skill.availability === 'unavailable'
+  )
 }
 
 function isAgentRun(value: unknown): value is AgentRun {

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -7,7 +7,12 @@ import type {
   WorkstreamKnowledgeCommand,
   WorkstreamKnowledgeMutationResult,
 } from '@/src/domain/workstream-knowledge-transitions'
-import { composerIpcChannels, parseSessionMessageSubmission, parseSessionRunStopRequest } from '@/src/composer-ipc'
+import {
+  composerIpcChannels,
+  parseQueuedFollowUpRemovalRequest,
+  parseSessionMessageSubmission,
+  parseSessionRunStopRequest,
+} from '@/src/composer-ipc'
 import { sessionId } from '@/src/domain/session'
 import { parseSessionSkillsRequest, sessionSkillsIpcChannels } from '@/src/session-skills-ipc'
 import type {
@@ -572,6 +577,18 @@ export function initializeComposer(authority: ApplicationAuthority): void {
     const request = parseSessionRunStopRequest(value)
 
     return request ? registry.stop(request.sessionId) : Promise.resolve({ status: 'not-running' })
+  })
+
+  handleTrustedIpc(composerIpcChannels.removeQueuedFollowUp, (_event, value: unknown): Promise<boolean> => {
+    const request = parseQueuedFollowUpRemovalRequest(value)
+
+    return request ? registry.removeQueuedFollowUp(request.sessionId, request.followUpId) : Promise.resolve(false)
+  })
+
+  handleTrustedIpc(composerIpcChannels.resumeQueuedFollowUps, (_event, value: unknown): Promise<boolean> => {
+    const request = parseSessionRunStopRequest(value)
+
+    return request ? registry.resumeQueuedFollowUps(request.sessionId) : Promise.resolve(false)
   })
 
   handleTrustedIpc(sessionSkillsIpcChannels.getAvailable, (_event, value: unknown) => {

--- a/src/main/pi-session-runtime-transcript.ts
+++ b/src/main/pi-session-runtime-transcript.ts
@@ -39,11 +39,15 @@ export type SessionRuntimeActivityControlTransition = Readonly<{
   accepted?: boolean
 }>
 
-export function persistActivityRecord(timeline: SessionRuntimeTimeline, record: ActivityLayerRecord): void {
+export function persistActivityRecord(timeline: SessionRuntimeTimeline, record: ActivityLayerRecord): boolean {
+  if (!timeline.persist) return false
+
   try {
-    timeline.persist?.(record)
+    timeline.persist(record)
+    return true
   } catch (error) {
     console.error('Unable to persist an activity-record transition.', error)
+    return false
   }
 }
 
@@ -75,12 +79,38 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
 
   timeline.runs = [...runs.values()].sort((left, right) => left.startedAt - right.startedAt)
 
+  const steeringMessageIds = new Set<string>()
+  const unmatchedConversations = [...history.conversations]
+
+  for (const record of history.activityRecords) {
+    if (record.type !== 'steering-message') continue
+
+    let index = -1
+    let nearestTimestampDifference = Number.POSITIVE_INFINITY
+
+    unmatchedConversations.forEach((conversation, candidateIndex) => {
+      const timestampDifference = Math.abs(conversation.timestamp - record.acceptedAt)
+      const matches = conversation.role === 'user' && conversation.text === record.text && timestampDifference <= 5_000
+
+      if (matches && timestampDifference < nearestTimestampDifference) {
+        index = candidateIndex
+        nearestTimestampDifference = timestampDifference
+      }
+    })
+
+    if (index < 0) continue
+
+    const [conversation] = unmatchedConversations.splice(index, 1)
+    if (conversation) steeringMessageIds.add(conversation.id)
+  }
+
   for (const conversation of history.conversations) {
     timeline.messages.set(conversation.id, {
       id: conversation.id,
       role: conversation.role,
       text: conversation.text,
       skills: conversation.skills,
+      delivery: steeringMessageIds.has(conversation.id) ? 'steer' : undefined,
       state: 'complete',
       revision: 0,
     })

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -187,6 +187,7 @@ export function createPiSessionRuntimeRegistry({
   const activationGate = createSessionRuntimeActivationGate()
   const activeAgentRunReservations = new Set<SessionId>()
   const queuedFollowUpQueue = createQueuedFollowUpQueue()
+  const submissionQueuesBySessionId = new Map<SessionId, Promise<void>>()
   const sessionReconciliationBySessionId = new Map<SessionId, () => Promise<boolean>>()
   const noProgressTimeoutsBySessionId = new Map<SessionId, ReturnType<typeof setTimeout>>()
   const noProgressTimeoutDurationsBySessionId = new Map<SessionId, number>()
@@ -247,7 +248,7 @@ export function createPiSessionRuntimeRegistry({
 
     const result = await submit({ sessionId, text: followUp.text, delivery: 'follow-up' })
 
-    if (result.status === 'accepted') {
+    if (result.status === 'accepted' && result.delivery !== 'follow-up') {
       if (!removeQueuedFollowUp(sessionId, followUp.id)) {
         queuedFollowUpQueue.pause(sessionId)
         publishTimeline(sessionId, 'Queued follow-ups paused because the delivered follow-up could not be removed.')
@@ -1236,7 +1237,7 @@ export function createPiSessionRuntimeRegistry({
     return { status: 'stopped' }
   }
 
-  async function submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult> {
+  async function submitImmediately(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult> {
     let runtime: PiSessionRuntime | undefined
     let leaseAcquired = false
     let runCapacityReserved = false
@@ -1322,6 +1323,27 @@ export function createPiSessionRuntimeRegistry({
     }
 
     return result
+  }
+
+  async function submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult> {
+    const previous = submissionQueuesBySessionId.get(submission.sessionId) ?? Promise.resolve()
+    let release!: () => void
+    const current = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const queued = previous.then(() => current)
+
+    submissionQueuesBySessionId.set(submission.sessionId, queued)
+
+    try {
+      await previous
+      return await submitImmediately(submission)
+    } finally {
+      release()
+      if (submissionQueuesBySessionId.get(submission.sessionId) === queued) {
+        submissionQueuesBySessionId.delete(submission.sessionId)
+      }
+    }
   }
 
   return {
@@ -1429,6 +1451,7 @@ export function createPiSessionRuntimeRegistry({
       configuration.dispose()
       activationGate.dispose()
       activeAgentRunReservations.clear()
+      submissionQueuesBySessionId.clear()
       queuedFollowUpQueue.clear()
     },
   }

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -43,6 +43,7 @@ import type {
   SessionConfigurationMutation,
   SessionConfigurationSnapshot,
 } from '@/src/session-configuration'
+import { createQueuedFollowUpQueue } from './queued-follow-up-queue'
 import { createSessionRuntimeActivationGate } from './pi-session-runtime-activation'
 import { createSessionRuntimeLifecycle, type SessionRuntimeEntry } from './pi-session-runtime-lifecycle'
 import {
@@ -139,6 +140,8 @@ export interface PiSessionRuntimeRegistry {
   ): void
   submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult>
   stop(sessionId: SessionId): Promise<SessionRunStopResult>
+  removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>
+  resumeQueuedFollowUps(sessionId: SessionId): Promise<boolean>
   renameSession(sessionId: SessionId, title: string): Promise<void>
   getWorkingStateSnapshots(): readonly SessionWorkingStateSnapshot[]
   loadActivityDetails(sessionId: SessionId, activityId: string): Promise<AgentActivityDetails | undefined>
@@ -165,7 +168,7 @@ const declaredActivityKinds = new Set<AgentActivityKind>(agentActivityKinds)
 /** Bounds simultaneous provider-backed Agent Runs across the application. */
 export const maximumConcurrentAgentRuns = 10
 /** Preserves normal follow-up use while bounding queued future provider work per Session. */
-export const maximumPendingSessionFollowUps = 100
+export const maximumPendingSessionFollowUps = 3
 
 export function createPiSessionRuntimeRegistry({
   findSession,
@@ -183,7 +186,7 @@ export function createPiSessionRuntimeRegistry({
   const transcriptListeners = new Set<(mutation: SessionTranscriptMutation) => void>()
   const activationGate = createSessionRuntimeActivationGate()
   const activeAgentRunReservations = new Set<SessionId>()
-  const pendingFollowUpsBySessionId = new Map<SessionId, number>()
+  const queuedFollowUpQueue = createQueuedFollowUpQueue()
   const sessionReconciliationBySessionId = new Map<SessionId, () => Promise<boolean>>()
   const noProgressTimeoutsBySessionId = new Map<SessionId, ReturnType<typeof setTimeout>>()
   const noProgressTimeoutDurationsBySessionId = new Map<SessionId, number>()
@@ -207,6 +210,54 @@ export function createPiSessionRuntimeRegistry({
     }
 
     return timeline
+  }
+
+  function hydrateQueuedFollowUps(sessionId: SessionId, history: PiSessionRuntimeHistory | undefined): void {
+    const records = (history?.activityRecords ?? []).flatMap((record) =>
+      record.type === 'queued-follow-up' || record.type === 'queued-follow-up-removed' ? [record] : []
+    )
+
+    queuedFollowUpQueue.hydrate(sessionId, records)
+  }
+
+  function removeQueuedFollowUp(sessionId: SessionId, followUpId: string): boolean {
+    const followUp = queuedFollowUpQueue.queuedFollowUps(sessionId).find((candidate) => candidate.id === followUpId)
+
+    if (!followUp) return false
+
+    const persisted = persistActivityRecord(getTimeline(sessionId), {
+      version: 1,
+      type: 'queued-follow-up-removed',
+      followUpId,
+    })
+
+    if (!persisted) return false
+
+    queuedFollowUpQueue.remove(sessionId, followUpId)
+    publishTimeline(sessionId)
+    return true
+  }
+
+  async function dispatchNextQueuedFollowUp(sessionId: SessionId): Promise<void> {
+    if (activeRun(getTimeline(sessionId))) return
+
+    const followUp = queuedFollowUpQueue.next(sessionId)
+
+    if (!followUp) return
+
+    const result = await submit({ sessionId, text: followUp.text, delivery: 'follow-up' })
+
+    if (result.status === 'accepted') {
+      if (!removeQueuedFollowUp(sessionId, followUp.id)) {
+        queuedFollowUpQueue.pause(sessionId)
+        publishTimeline(sessionId, 'Queued follow-ups paused because the delivered follow-up could not be removed.')
+      }
+
+      return
+    }
+
+    queuedFollowUpQueue.pause(sessionId)
+    publishTimeline(sessionId, 'Queued follow-ups paused because the next follow-up could not start.')
   }
 
   function publishTimeline(sessionId: SessionId, announcement?: string): void {
@@ -257,6 +308,8 @@ export function createPiSessionRuntimeRegistry({
       contextUsage: timeline.contextUsage,
       runs: timeline.runs,
       entries,
+      queuedFollowUps: queuedFollowUpQueue.queuedFollowUps(sessionId),
+      queuedFollowUpsPaused: queuedFollowUpQueue.isPaused(sessionId),
       runFailureReason:
         latestRun?.status === 'failed' || latestRun?.status === 'cancelled' ? latestRun.status : undefined,
     }
@@ -874,6 +927,8 @@ export function createPiSessionRuntimeRegistry({
         publishTimeline(sessionId, announcements.join('. ') || undefined)
       }
 
+      void dispatchNextQueuedFollowUp(sessionId)
+
       const reconcileAfterRun = sessionReconciliationBySessionId.get(sessionId)
 
       if (reconcileAfterRun) {
@@ -911,7 +966,9 @@ export function createPiSessionRuntimeRegistry({
     // The attaching runtime is authoritative for the Model's context window;
     // context_usage events keep it current from here.
     timeline.contextUsage = runtime.getContextUsage?.()
-    hydrateTimeline(timeline, runtime.loadHistory?.())
+    const history = runtime.loadHistory?.()
+    hydrateTimeline(timeline, history)
+    hydrateQueuedFollowUps(sessionId, history)
 
     const unsubscribes = [runtime.subscribe((event) => handleRuntimeEvent(sessionId, event))]
     return { runtime, runtimeKey, unsubscribes }
@@ -933,7 +990,8 @@ export function createPiSessionRuntimeRegistry({
     sessionId: SessionId,
     messageId: string,
     text: string,
-    skills?: readonly SessionSkillMention[]
+    skills?: readonly SessionSkillMention[],
+    delivery?: 'steer'
   ): void {
     const timeline = getTimeline(sessionId)
     const message: SessionTranscriptMessage = {
@@ -941,11 +999,63 @@ export function createPiSessionRuntimeRegistry({
       role: 'user',
       text,
       skills,
+      delivery,
       state: 'complete',
       revision: timeline.revision + 1,
     }
 
     timeline.messages.set(message.id, message)
+  }
+
+  function queueFollowUp(
+    submission: SessionMessageSubmission,
+    runtime: PiSessionRuntime
+  ): SessionMessageSubmissionResult {
+    const projected = projectSessionSkillSelections(submission.text)
+    const availableSkills = runtime.getSkills?.() ?? []
+    const skillsAvailable = projected.selections.every((selection) =>
+      availableSkills.some((skill) => skill.name === selection.name)
+    )
+
+    if (!skillsAvailable) return { status: 'rejected', reason: 'skill-unavailable' }
+
+    try {
+      if (replaceSessionSkillTokens(submission.text, (name) => runtime.getSkillPrompt?.(name)) === undefined) {
+        return { status: 'rejected', reason: 'skill-unavailable' }
+      }
+    } catch {
+      return { status: 'rejected', reason: 'unexpected' }
+    }
+
+    const queue = queuedFollowUpQueue.queuedFollowUps(submission.sessionId)
+
+    if (queue.length >= maximumPendingSessionFollowUps) {
+      return { status: 'rejected', reason: 'follow-up-capacity' }
+    }
+
+    const skills = projected.selections.flatMap((selection): SessionSkillMention[] => {
+      const available = availableSkills.find((skill) => skill.name === selection.name)
+
+      return available ? [{ offset: selection.offset, skill: { ...available, availability: 'available' } }] : []
+    })
+    const followUp = {
+      id: createId(),
+      text: submission.text,
+      skills: skills.length > 0 ? skills : undefined,
+      createdAt: now(),
+    }
+    const persisted = persistActivityRecord(getTimeline(submission.sessionId), {
+      version: 1,
+      type: 'queued-follow-up',
+      followUp,
+    })
+
+    if (!persisted) return { status: 'rejected', reason: 'unexpected' }
+
+    queuedFollowUpQueue.enqueue(submission.sessionId, followUp)
+    publishTimeline(submission.sessionId)
+
+    return { status: 'accepted', delivery: 'follow-up' }
   }
 
   async function deliverSubmission(
@@ -972,26 +1082,6 @@ export function createPiSessionRuntimeRegistry({
       return { status: 'rejected', reason: 'unexpected' }
     }
     if (promptText === undefined) return { status: 'rejected', reason: 'skill-unavailable' }
-    const tracksFollowUp = runtime.isStreaming && submission.delivery === 'follow-up'
-
-    if (tracksFollowUp) {
-      const pendingCount = pendingFollowUpsBySessionId.get(submission.sessionId) ?? 0
-      if (pendingCount >= maximumPendingSessionFollowUps) {
-        return { status: 'rejected', reason: 'follow-up-capacity' }
-      }
-
-      pendingFollowUpsBySessionId.set(submission.sessionId, pendingCount + 1)
-    }
-
-    const releaseFollowUp = () => {
-      if (!tracksFollowUp) return
-
-      const pendingCount = pendingFollowUpsBySessionId.get(submission.sessionId) ?? 1
-      if (pendingCount <= 1) pendingFollowUpsBySessionId.delete(submission.sessionId)
-      else pendingFollowUpsBySessionId.set(submission.sessionId, pendingCount - 1)
-    }
-
-    let promptStarted = false
     const result = await activationGate.run<SessionMessageSubmissionResult>(submission.sessionId, async () => {
       try {
         if (!(await authorize())) return { status: 'rejected', reason: 'session-unavailable' }
@@ -1028,6 +1118,7 @@ export function createPiSessionRuntimeRegistry({
               role: 'user',
               text: projected.text,
               skills: skillMentions,
+              delivery: acceptedDelivery === 'steer' ? 'steer' : undefined,
               timestamp,
             }
 
@@ -1046,7 +1137,23 @@ export function createPiSessionRuntimeRegistry({
               persistActivityRecord(timeline, { version: 1, type: 'run', run })
             }
 
-            acceptRun(submission.sessionId, messageId, projected.text, skillMentions)
+            acceptRun(
+              submission.sessionId,
+              messageId,
+              projected.text,
+              skillMentions,
+              acceptedDelivery === 'steer' ? 'steer' : undefined
+            )
+
+            if (acceptedDelivery === 'steer') {
+              persistActivityRecord(timeline, {
+                version: 1,
+                type: 'steering-message',
+                text: projected.text,
+                acceptedAt: timestamp,
+              })
+            }
+
             publishTimeline(submission.sessionId)
           }
 
@@ -1058,7 +1165,6 @@ export function createPiSessionRuntimeRegistry({
         }
 
         try {
-          promptStarted = true
           void runtime
             .prompt(promptText, {
               streamingBehavior,
@@ -1081,15 +1187,11 @@ export function createPiSessionRuntimeRegistry({
                 })
               }
             })
-            .finally(releaseFollowUp)
         } catch {
-          releaseFollowUp()
           finishPreflight(false)
         }
       })
     })
-
-    if (!promptStarted) releaseFollowUp()
 
     return result
   }
@@ -1144,6 +1246,10 @@ export function createPiSessionRuntimeRegistry({
 
       const existingEntry = lifecycle.getEntry(submission.sessionId)
       const existing = existingEntry ? await existingEntry : undefined
+      if (existing?.runtime.isStreaming && submission.delivery === 'follow-up') {
+        return queueFollowUp(submission, existing.runtime)
+      }
+
       if (existing?.runtime.isStreaming) {
         return deliverSubmission(submission, existing.runtime, async () => {
           if (!(await canSubmit(submission.sessionId))) return false
@@ -1192,6 +1298,12 @@ export function createPiSessionRuntimeRegistry({
       return { status: 'rejected', reason: leaseAcquired ? 'runtime-unavailable' : 'unexpected' }
     }
 
+    if (runtime.isStreaming && submission.delivery === 'follow-up') {
+      activeAgentRunReservations.delete(submission.sessionId)
+      await releaseRunLease(submission.sessionId)
+      return queueFollowUp(submission, runtime)
+    }
+
     const runReconciliation = reconcileAfterRun ? () => reconcileAfterRun(submission.sessionId) : undefined
 
     if (runReconciliation) {
@@ -1222,6 +1334,18 @@ export function createPiSessionRuntimeRegistry({
     },
     submit,
     stop,
+    async removeQueuedFollowUp(sessionId, followUpId) {
+      await getRuntime(sessionId)
+      return removeQueuedFollowUp(sessionId, followUpId)
+    },
+    async resumeQueuedFollowUps(sessionId) {
+      await getRuntime(sessionId)
+
+      if (activeRun(getTimeline(sessionId)) || !queuedFollowUpQueue.resume(sessionId)) return false
+
+      await dispatchNextQueuedFollowUp(sessionId)
+      return true
+    },
     async renameSession(sessionId, title) {
       const runtime = await getRuntime(sessionId)
 
@@ -1305,7 +1429,7 @@ export function createPiSessionRuntimeRegistry({
       configuration.dispose()
       activationGate.dispose()
       activeAgentRunReservations.clear()
-      pendingFollowUpsBySessionId.clear()
+      queuedFollowUpQueue.clear()
     },
   }
 }

--- a/src/main/queued-follow-up-queue.ts
+++ b/src/main/queued-follow-up-queue.ts
@@ -1,0 +1,77 @@
+import type { SessionId } from '@/src/domain/session'
+import type { QueuedFollowUp, QueuedFollowUpRecord } from '@/src/queued-follow-up'
+
+export interface QueuedFollowUpQueue {
+  hydrate(sessionId: SessionId, records: readonly QueuedFollowUpRecord[]): void
+  enqueue(sessionId: SessionId, followUp: QueuedFollowUp): void
+  remove(sessionId: SessionId, followUpId: string): QueuedFollowUp | undefined
+  resume(sessionId: SessionId): boolean
+  pause(sessionId: SessionId): void
+  isPaused(sessionId: SessionId): boolean
+  next(sessionId: SessionId): QueuedFollowUp | undefined
+  queuedFollowUps(sessionId: SessionId): readonly QueuedFollowUp[]
+  clear(): void
+}
+
+export function createQueuedFollowUpQueue(): QueuedFollowUpQueue {
+  const queuedFollowUpsBySessionId = new Map<SessionId, QueuedFollowUp[]>()
+  const hydratedSessionIds = new Set<SessionId>()
+  const resumedSessionIds = new Set<SessionId>()
+
+  return {
+    hydrate(sessionId, records) {
+      if (hydratedSessionIds.has(sessionId)) return
+
+      hydratedSessionIds.add(sessionId)
+      const queuedFollowUps = new Map<string, QueuedFollowUp>()
+
+      for (const record of records) {
+        if (record.type === 'queued-follow-up') queuedFollowUps.set(record.followUp.id, record.followUp)
+        if (record.type === 'queued-follow-up-removed') queuedFollowUps.delete(record.followUpId)
+      }
+
+      queuedFollowUpsBySessionId.set(sessionId, [...queuedFollowUps.values()])
+    },
+    enqueue(sessionId, followUp) {
+      const queue = queuedFollowUpsBySessionId.get(sessionId) ?? []
+
+      queuedFollowUpsBySessionId.set(sessionId, [...queue, followUp])
+      if (queue.length === 0) resumedSessionIds.add(sessionId)
+    },
+    remove(sessionId, followUpId) {
+      const queue = queuedFollowUpsBySessionId.get(sessionId) ?? []
+      const followUp = queue.find((candidate) => candidate.id === followUpId)
+
+      if (!followUp) return undefined
+
+      queuedFollowUpsBySessionId.set(
+        sessionId,
+        queue.filter((candidate) => candidate.id !== followUpId)
+      )
+      return followUp
+    },
+    resume(sessionId) {
+      if ((queuedFollowUpsBySessionId.get(sessionId)?.length ?? 0) === 0) return false
+
+      resumedSessionIds.add(sessionId)
+      return true
+    },
+    pause(sessionId) {
+      resumedSessionIds.delete(sessionId)
+    },
+    isPaused(sessionId) {
+      return (queuedFollowUpsBySessionId.get(sessionId)?.length ?? 0) > 0 && !resumedSessionIds.has(sessionId)
+    },
+    next(sessionId) {
+      return resumedSessionIds.has(sessionId) ? queuedFollowUpsBySessionId.get(sessionId)?.[0] : undefined
+    },
+    queuedFollowUps(sessionId) {
+      return queuedFollowUpsBySessionId.get(sessionId) ?? []
+    },
+    clear() {
+      queuedFollowUpsBySessionId.clear()
+      hydratedSessionIds.clear()
+      resumedSessionIds.clear()
+    },
+  }
+}

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -169,6 +169,44 @@ test('automatically sends a live queued follow-up when the active work settles',
   assert.deepEqual((await registry.getTranscript(id)).queuedFollowUps, [])
 })
 
+test('serializes a user submission behind automatic queued follow-up dispatch', async () => {
+  let streaming = true
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const prompts: string[] = []
+  const runtime: PiSessionRuntime = {
+    get isStreaming() {
+      return streaming
+    },
+    async prompt(text, options) {
+      prompts.push(text)
+      streaming = true
+      options.preflightResult(true)
+    },
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    appendActivityRecord() {},
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('serialized-follow-up-dispatch-session')
+
+  await registry.submit({ sessionId: id, text: 'Queued first', delivery: 'follow-up' })
+  streaming = false
+  emit({ type: 'agent_settled' })
+
+  const userSubmission = registry.submit({ sessionId: id, text: 'User second', delivery: 'steer' })
+  await userSubmission
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+  assert.deepEqual(prompts, ['Queued first', 'User second'])
+  assert.deepEqual((await registry.getTranscript(id)).queuedFollowUps, [])
+})
+
 test('pauses after dispatch when the delivered queue removal cannot persist', async () => {
   let streaming = true
   let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -46,6 +46,453 @@ test('keeps duplicate messages ordered and updates one streaming identity', asyn
   assert.equal(lastEntry?.type === 'message' ? lastEntry.message.state : undefined, 'complete')
 })
 
+test('persists queued follow-ups until the user resumes the queue', async () => {
+  let streaming = true
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const records: import('@/src/main/activity-records').ActivityLayerRecord[] = []
+  const prompts: string[] = []
+  const runtime: PiSessionRuntime = {
+    get isStreaming() {
+      return streaming
+    },
+    async prompt(text, options) {
+      prompts.push(text)
+      options.preflightResult(true)
+    },
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    loadHistory() {
+      return { conversations: [], activityRecords: records, finalState: 'completed' }
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const id = sessionId('queued-follow-up-session')
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  const queued = await registry.submit({ sessionId: id, text: 'Send this next', delivery: 'follow-up' })
+  const queuedAfter = await registry.submit({ sessionId: id, text: 'Send this after that', delivery: 'follow-up' })
+
+  assert.deepEqual(queued, { status: 'accepted', delivery: 'follow-up' })
+  assert.deepEqual(queuedAfter, { status: 'accepted', delivery: 'follow-up' })
+  assert.deepEqual(
+    (await registry.getTranscript(id)).queuedFollowUps?.map(({ text }) => text),
+    ['Send this next', 'Send this after that']
+  )
+  assert.deepEqual(prompts, [])
+  assert.equal((await registry.getTranscript(id)).queuedFollowUpsPaused, false)
+
+  streaming = false
+  const restartedRegistry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  assert.deepEqual(
+    (await restartedRegistry.getTranscript(id)).queuedFollowUps?.map(({ text }) => text),
+    ['Send this next', 'Send this after that']
+  )
+  assert.equal((await restartedRegistry.getTranscript(id)).queuedFollowUpsPaused, true)
+  assert.equal(await restartedRegistry.resumeQueuedFollowUps(id), true)
+  assert.deepEqual(prompts, ['Send this next'])
+
+  emit({ type: 'agent_settled' })
+  await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+
+  assert.deepEqual(prompts, ['Send this next', 'Send this after that'])
+  assert.deepEqual((await restartedRegistry.getTranscript(id)).queuedFollowUps, [])
+})
+
+test('rejects a queued follow-up when Session history persistence fails', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: true,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    appendActivityRecord() {
+      throw new Error('disk full')
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('unpersisted-follow-up-session')
+
+  assert.deepEqual(await registry.submit({ sessionId: id, text: 'Do not lose this', delivery: 'follow-up' }), {
+    status: 'rejected',
+    reason: 'unexpected',
+  })
+  assert.deepEqual((await registry.getTranscript(id)).queuedFollowUps, [])
+})
+
+test('automatically sends a live queued follow-up when the active work settles', async () => {
+  let streaming = true
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const prompts: string[] = []
+  const runtime: PiSessionRuntime = {
+    get isStreaming() {
+      return streaming
+    },
+    async prompt(text, options) {
+      prompts.push(text)
+      options.preflightResult(true)
+    },
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    appendActivityRecord() {},
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('live-follow-up-queue-session')
+
+  await registry.submit({ sessionId: id, text: 'Send this next', delivery: 'follow-up' })
+  streaming = false
+  emit({ type: 'agent_settled' })
+  await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+
+  assert.deepEqual(prompts, ['Send this next'])
+  assert.deepEqual((await registry.getTranscript(id)).queuedFollowUps, [])
+})
+
+test('pauses after dispatch when the delivered queue removal cannot persist', async () => {
+  let streaming = true
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const prompts: string[] = []
+  const runtime: PiSessionRuntime = {
+    get isStreaming() {
+      return streaming
+    },
+    async prompt(text, options) {
+      prompts.push(text)
+      options.preflightResult(true)
+    },
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    appendActivityRecord(record) {
+      if (record.type === 'queued-follow-up-removed') throw new Error('disk full')
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('unpersisted-dispatched-follow-up-session')
+
+  await registry.submit({ sessionId: id, text: 'Send this once', delivery: 'follow-up' })
+  streaming = false
+  emit({ type: 'agent_settled' })
+  await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+
+  assert.deepEqual(prompts, ['Send this once'])
+  assert.equal((await registry.getTranscript(id)).queuedFollowUpsPaused, true)
+
+  emit({ type: 'agent_settled' })
+  await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+
+  assert.deepEqual(prompts, ['Send this once'])
+})
+
+test('publishes a paused queue when automatic dispatch is rejected', async () => {
+  let streaming = true
+  let availableSkills = [{ name: 'tdd', description: 'Develop test first.' }]
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const mutations: import('@/src/session-transcript').SessionTranscriptMutation[] = []
+  const runtime: PiSessionRuntime = {
+    get isStreaming() {
+      return streaming
+    },
+    async prompt() {},
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    getSkills() {
+      return availableSkills
+    },
+    getSkillPrompt() {
+      return 'Develop test first.'
+    },
+    appendActivityRecord() {},
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('rejected-follow-up-dispatch-session')
+  registry.subscribeTranscript((mutation) => mutations.push(mutation))
+
+  await registry.submit({ sessionId: id, text: '/skill:tdd Write the test.', delivery: 'follow-up' })
+  mutations.length = 0
+  availableSkills = []
+  streaming = false
+  emit({ type: 'agent_settled' })
+  await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+
+  assert.equal(mutations.at(-1)?.snapshot.queuedFollowUpsPaused, true)
+})
+
+test('persists Skill references with a queued follow-up', async () => {
+  const records: import('@/src/main/activity-records').ActivityLayerRecord[] = []
+  const runtime: PiSessionRuntime = {
+    isStreaming: true,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    getSkills() {
+      return [{ name: 'tdd', description: 'Develop test first.' }]
+    },
+    getSkillPrompt() {
+      return 'Develop test first.'
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    createId: () => 'skilled-follow-up',
+  })
+  const id = sessionId('skilled-follow-up-queue-session')
+
+  await registry.submit({ sessionId: id, text: '/skill:tdd Write the test.', delivery: 'follow-up' })
+
+  assert.deepEqual((await registry.getTranscript(id)).queuedFollowUps?.[0]?.skills, [
+    {
+      offset: 0,
+      skill: { name: 'tdd', description: 'Develop test first.', availability: 'available' },
+    },
+  ])
+  assert.equal(
+    records.some((record) => record.type === 'queued-follow-up'),
+    true
+  )
+})
+
+test('rejects follow-ups after three are queued', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: true,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    appendActivityRecord() {},
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('full-follow-up-queue-session')
+
+  for (const text of ['First', 'Second', 'Third']) {
+    assert.deepEqual(await registry.submit({ sessionId: id, text, delivery: 'follow-up' }), {
+      status: 'accepted',
+      delivery: 'follow-up',
+    })
+  }
+
+  assert.deepEqual(await registry.submit({ sessionId: id, text: 'Fourth', delivery: 'follow-up' }), {
+    status: 'rejected',
+    reason: 'follow-up-capacity',
+  })
+  assert.deepEqual(
+    (await registry.getTranscript(id)).queuedFollowUps?.map(({ text }) => text),
+    ['First', 'Second', 'Third']
+  )
+})
+
+test('removes a queued follow-up before it resumes', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: true,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    appendActivityRecord() {},
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    createId: () => 'queued-follow-up-id',
+  })
+  const id = sessionId('removable-follow-up-session')
+
+  await registry.submit({ sessionId: id, text: 'Remove this', delivery: 'follow-up' })
+
+  assert.equal(await registry.removeQueuedFollowUp(id, 'queued-follow-up-id'), true)
+  assert.deepEqual((await registry.getTranscript(id)).queuedFollowUps, [])
+})
+
+test('keeps a queued follow-up when removal persistence fails', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: true,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    appendActivityRecord(record) {
+      if (record.type === 'queued-follow-up-removed') throw new Error('disk full')
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    createId: () => 'queued-follow-up-id',
+  })
+  const id = sessionId('unremovable-follow-up-session')
+
+  await registry.submit({ sessionId: id, text: 'Keep this', delivery: 'follow-up' })
+
+  assert.equal(await registry.removeQueuedFollowUp(id, 'queued-follow-up-id'), false)
+  assert.deepEqual(
+    (await registry.getTranscript(id)).queuedFollowUps?.map(({ text }) => text),
+    ['Keep this']
+  )
+})
+
+test('records a message sent to a working Session as steering', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: true,
+    async prompt(_text, options) {
+      options.preflightResult(true)
+    },
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('steering-session')
+
+  await registry.submit({ sessionId: id, text: 'Prioritize the transcript', delivery: 'steer' })
+
+  const message = (await registry.getTranscript(id)).entries[0]
+  assert.equal(message?.type, 'message')
+  assert.equal(message?.type === 'message' ? message.message.delivery : undefined, 'steer')
+})
+
+test('preserves steering delivery when the Session transcript is reopened', async () => {
+  let streaming = true
+  const records: import('@/src/main/activity-records').ActivityLayerRecord[] = []
+  const conversations: import('@/src/session-timeline').ConversationEntry[] = []
+  const runtime: PiSessionRuntime = {
+    get isStreaming() {
+      return streaming
+    },
+    async prompt(text, options) {
+      conversations.push({ type: 'conversation', id: 'pi-user-message', role: 'user', text, timestamp: 1_000 })
+      options.preflightResult(true)
+    },
+    subscribe() {
+      return () => {}
+    },
+    loadHistory() {
+      return { conversations, activityRecords: records, finalState: 'completed' }
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const id = sessionId('persisted-steering-session')
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    now: () => 1_000,
+  })
+
+  await registry.submit({ sessionId: id, text: 'Prioritize transcript delivery.', delivery: 'steer' })
+
+  streaming = false
+  const restartedRegistry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    now: () => 1_000,
+  })
+  const message = (await restartedRegistry.getTranscript(id)).entries[0]
+
+  assert.equal(message?.type, 'message')
+  assert.equal(message?.type === 'message' ? message.message.delivery : undefined, 'steer')
+})
+
+test('restores steering delivery to the nearest duplicate message', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    loadHistory() {
+      return {
+        conversations: [
+          {
+            type: 'conversation' as const,
+            id: 'ordinary-message',
+            role: 'user' as const,
+            text: 'Use the transcript.',
+            timestamp: 1_000,
+          },
+          {
+            type: 'conversation' as const,
+            id: 'steering-message',
+            role: 'user' as const,
+            text: 'Use the transcript.',
+            timestamp: 2_000,
+          },
+        ],
+        activityRecords: [
+          {
+            version: 1 as const,
+            type: 'steering-message' as const,
+            text: 'Use the transcript.',
+            acceptedAt: 2_000,
+          },
+        ],
+        finalState: 'completed' as const,
+      }
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  const messages = (await registry.getTranscript(sessionId('duplicate-steering-session'))).entries.flatMap((entry) =>
+    entry.type === 'message' ? [entry.message] : []
+  )
+
+  assert.equal(messages[0]?.delivery, undefined)
+  assert.equal(messages[1]?.delivery, 'steer')
+})
+
 test('invokes multiple available Skills where they were mentioned', async () => {
   let promptedText = ''
   const runtime: PiSessionRuntime = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -154,6 +154,12 @@ const composerBridge: ComposerBridge = {
   stop(sessionId) {
     return ipcRenderer.invoke(composerIpcChannels.stop, { sessionId }) as Promise<SessionRunStopResult>
   },
+  removeQueuedFollowUp(sessionId, followUpId) {
+    return ipcRenderer.invoke(composerIpcChannels.removeQueuedFollowUp, { sessionId, followUpId }) as Promise<boolean>
+  },
+  resumeQueuedFollowUps(sessionId) {
+    return ipcRenderer.invoke(composerIpcChannels.resumeQueuedFollowUps, { sessionId }) as Promise<boolean>
+  },
 }
 
 const sessionSkillsBridge: SessionSkillsBridge = {

--- a/src/queued-follow-up.ts
+++ b/src/queued-follow-up.ts
@@ -1,0 +1,12 @@
+import type { SessionSkillMention } from '@/src/session-skills'
+
+export type QueuedFollowUp = Readonly<{
+  id: string
+  text: string
+  skills?: readonly SessionSkillMention[]
+  createdAt: number
+}>
+
+export type QueuedFollowUpRecord =
+  | Readonly<{ type: 'queued-follow-up'; followUp: QueuedFollowUp }>
+  | Readonly<{ type: 'queued-follow-up-removed'; followUpId: string }>

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -601,6 +601,32 @@ test('focuses the Composer when a new focus request arrives', async () => {
   await waitFor(() => assert.equal(browser.document.activeElement, view.getByRole('textbox')))
 })
 
+test('restores Composer focus after the creation dialog restores its trigger', async () => {
+  const view = renderInBrowser(
+    <>
+      <button type="button">Create Session</button>
+      <Composer
+        session={session}
+        draft=""
+        focusRequest={1}
+        isWorking={false}
+        onActivate={() => {}}
+        onDraftChange={() => {}}
+        submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+      />
+    </>
+  )
+  const trigger = view.getByRole('button', { name: 'Create Session' })
+
+  window.setTimeout(() => trigger.focus(), 100)
+
+  await new Promise<void>((resolve) => window.setTimeout(() => resolve(), 110))
+  assert.equal(browser.document.activeElement, trigger)
+
+  await new Promise<void>((resolve) => window.setTimeout(() => resolve(), 30))
+  assert.equal(browser.document.activeElement, view.getByRole('textbox'))
+})
+
 test('prevents Agent Run acceptance while a Model change is pending', async () => {
   let resolveModelChange: () => void = () => {}
   const configuration = sessionConfigurationSnapshot()

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -92,11 +92,11 @@ export function Composer({
 
     editorHandle.current?.focus()
 
-    // Focus again after creation dialogs have finished closing and restoring
-    // focus to their trigger.
-    const frame = window.requestAnimationFrame(() => editorHandle.current?.focus())
+    // The creation dialog restores focus to its trigger after its 100 ms close
+    // transition. Restore focus once more after that transition has completed.
+    const timeout = window.setTimeout(() => editorHandle.current?.focus(), 125)
 
-    return () => window.cancelAnimationFrame(frame)
+    return () => window.clearTimeout(timeout)
   }, [focusRequest])
 
   useEffect(() => {

--- a/src/renderer/components/queued-follow-up-tray.test.tsx
+++ b/src/renderer/components/queued-follow-up-tray.test.tsx
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { sessionId } from '@/src/domain/session'
+import { browser } from '@/src/renderer/test-dom'
+import { QueuedFollowUpTray } from './queued-follow-up-tray'
+
+afterEach(() => cleanup())
+
+const id = sessionId('session-a')
+
+function renderInBrowser(element: React.ReactNode) {
+  return render(element, { container: browser.document.body as unknown as HTMLElement })
+}
+
+test('expands queued follow-ups on hover and removes the selected item', async () => {
+  const removedFollowUps: string[] = []
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderInBrowser(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking={false}
+      queuedFollowUps={[
+        { id: 'follow-up-1', text: 'Send this next.', createdAt: 1 },
+        { id: 'follow-up-2', text: 'Send this after that.', createdAt: 2 },
+      ]}
+      removeQueuedFollowUp={async (_sessionId, followUpId) => {
+        removedFollowUps.push(followUpId)
+        return true
+      }}
+    />
+  )
+
+  assert.equal(view.queryAllByRole('button', { name: 'Remove queued follow-up' }).length, 0)
+
+  await user.hover(view.getByText('Next follow-up'))
+
+  assert.equal(view.getAllByRole('button', { name: 'Remove queued follow-up' }).length, 2)
+
+  await act(async () => {
+    fireEvent.click(view.getAllByRole('button', { name: 'Remove queued follow-up' })[0]!)
+    await new Promise<void>((resolve) => window.setTimeout(() => resolve(), 30))
+  })
+
+  assert.deepEqual(removedFollowUps, ['follow-up-1'])
+})
+
+test('expands a working queue from the keyboard', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderInBrowser(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking
+      queuedFollowUps={[
+        { id: 'follow-up-1', text: 'Send this next.', createdAt: 1 },
+        { id: 'follow-up-2', text: 'Send this after that.', createdAt: 2 },
+      ]}
+      removeQueuedFollowUp={async () => true}
+    />
+  )
+
+  assert.equal(view.queryAllByRole('button', { name: 'Remove queued follow-up' }).length, 0)
+
+  await user.tab()
+
+  assert.equal(
+    view.getByRole('button', { name: /Next follow-up Send this next/ }).getAttribute('aria-expanded'),
+    'true'
+  )
+  assert.equal(view.getAllByRole('button', { name: 'Remove queued follow-up' }).length, 2)
+})
+
+test('renders queued Skill tokens as Skill references', () => {
+  const view = renderInBrowser(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking
+      queuedFollowUps={[
+        {
+          id: 'follow-up-1',
+          text: '/skill:tdd Write the focused test.',
+          skills: [
+            {
+              offset: 0,
+              skill: { name: 'tdd', description: 'Develop test first.', availability: 'available' },
+            },
+          ],
+          createdAt: 1,
+        },
+      ]}
+    />
+  )
+
+  assert.ok(view.container.querySelector('[data-skill-reference="tdd"]'))
+  assert.equal(view.queryByText('/skill:tdd'), null)
+  assert.match(view.container.textContent ?? '', /Write the focused test\./)
+})
+
+test('reveals only the next three queued follow-ups', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderInBrowser(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking={false}
+      queuedFollowUps={Array.from({ length: 5 }, (_, index) => ({
+        id: `follow-up-${index}`,
+        text: `Queued message ${index + 1}`,
+        createdAt: index,
+      }))}
+    />
+  )
+
+  await user.hover(view.getByText('Next follow-up'))
+
+  assert.equal(view.container.querySelectorAll('li').length, 3)
+  assert.ok(view.getByText('Next follow-up'))
+  assert.ok(view.getByText('Queued message 1'))
+  assert.equal(view.queryByText('Queued message 4'), null)
+})
+
+test('shows Resume only for a paused idle queue', () => {
+  const view = renderInBrowser(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking={false}
+      queuedFollowUps={[{ id: 'follow-up-1', text: 'Send this next.', createdAt: 1 }]}
+      resumeQueuedFollowUps={async () => true}
+    />
+  )
+
+  assert.equal(view.queryByRole('button', { name: 'Resume' }), null)
+
+  view.rerender(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking
+      queuedFollowUps={[{ id: 'follow-up-1', text: 'Send this next.', createdAt: 1 }]}
+      queuedFollowUpsPaused
+      resumeQueuedFollowUps={async () => true}
+    />
+  )
+
+  assert.equal(view.queryByRole('button', { name: 'Resume' }), null)
+})
+
+test('resumes queued follow-ups when the Session is idle', async () => {
+  const resumedSessions: string[] = []
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderInBrowser(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking={false}
+      queuedFollowUps={[{ id: 'follow-up-1', text: 'Send this next.', createdAt: 1 }]}
+      queuedFollowUpsPaused
+      resumeQueuedFollowUps={async (sessionId) => {
+        resumedSessions.push(sessionId)
+        return true
+      }}
+    />
+  )
+
+  await user.click(view.getByRole('button', { name: 'Resume' }))
+  await new Promise<void>((resolve) => window.setTimeout(() => resolve(), 30))
+
+  assert.deepEqual(resumedSessions, [id])
+})

--- a/src/renderer/components/queued-follow-up-tray.tsx
+++ b/src/renderer/components/queued-follow-up-tray.tsx
@@ -1,0 +1,158 @@
+import { ListRestart, X } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import type { ComposerBridge } from '@/src/composer'
+import type { SessionId } from '@/src/domain/session'
+import type { QueuedFollowUp } from '@/src/queued-follow-up'
+import { SkillMentionText } from '@/src/renderer/components/skill-mention-text'
+import { projectSessionSkillSelections } from '@/src/session-skills'
+
+const maximumVisibleFollowUps = 3
+const collapsedFollowUpOffset = 8
+const expandedFollowUpOffset = 72
+const followUpCardHeight = 64
+
+type QueuedFollowUpTrayProperties = Readonly<{
+  sessionId: SessionId
+  isWorking: boolean
+  queuedFollowUps: readonly QueuedFollowUp[]
+  queuedFollowUpsPaused?: boolean
+  removeQueuedFollowUp?: NonNullable<ComposerBridge['removeQueuedFollowUp']>
+  resumeQueuedFollowUps?: NonNullable<ComposerBridge['resumeQueuedFollowUps']>
+}>
+
+function QueuedFollowUpContent({ followUp, next }: Readonly<{ followUp: QueuedFollowUp; next: boolean }>) {
+  const projected = projectSessionSkillSelections(followUp.text)
+  const skills =
+    followUp.skills ??
+    projected.selections.map(({ name, offset }) => ({
+      offset,
+      skill: { name, availability: 'unavailable' as const },
+    }))
+
+  return (
+    <>
+      <span className="block text-xs/4 font-medium text-content-muted-foreground">
+        {next ? 'Next follow-up' : 'Follow-up'}
+      </span>
+      <span className="mt-0.5 line-clamp-2 block whitespace-pre-wrap break-words">
+        <SkillMentionText text={projected.text} skills={skills} />
+      </span>
+    </>
+  )
+}
+
+export function QueuedFollowUpTray({
+  sessionId,
+  isWorking,
+  queuedFollowUps,
+  queuedFollowUpsPaused = false,
+  removeQueuedFollowUp: removeQueuedFollowUpMessage,
+  resumeQueuedFollowUps: resumeQueuedFollowUpMessages,
+}: QueuedFollowUpTrayProperties) {
+  const [expanded, setExpanded] = useState(false)
+  const [actionPending, setActionPending] = useState(false)
+  const visibleFollowUps = queuedFollowUps.slice(0, maximumVisibleFollowUps)
+
+  const removeQueuedFollowUp = useCallback(
+    async (followUpId: string) => {
+      if (!removeQueuedFollowUpMessage || actionPending) return
+
+      setActionPending(true)
+
+      try {
+        await removeQueuedFollowUpMessage(sessionId, followUpId)
+      } finally {
+        setActionPending(false)
+      }
+    },
+    [actionPending, removeQueuedFollowUpMessage, sessionId]
+  )
+
+  const resumeQueuedFollowUps = useCallback(async () => {
+    if (!resumeQueuedFollowUpMessages || actionPending) return
+
+    setActionPending(true)
+
+    try {
+      await resumeQueuedFollowUpMessages(sessionId)
+    } finally {
+      setActionPending(false)
+    }
+  }, [actionPending, resumeQueuedFollowUpMessages, sessionId])
+
+  if (queuedFollowUps.length === 0) return null
+
+  return (
+    <div
+      className="relative z-20 h-19 shrink-0 px-3 pb-3"
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setExpanded(false)
+      }}
+      onFocusCapture={() => setExpanded(true)}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') setExpanded(false)
+      }}
+      onMouseEnter={() => setExpanded(true)}
+      onMouseLeave={() => setExpanded(false)}
+    >
+      <ol
+        className="absolute right-3 bottom-3 left-3"
+        style={{
+          height: `${followUpCardHeight + (expanded ? (visibleFollowUps.length - 1) * expandedFollowUpOffset : 0)}px`,
+        }}
+      >
+        {visibleFollowUps.map((followUp, index) => (
+          <li
+            key={followUp.id}
+            className={`absolute inset-x-0 bottom-0 flex min-h-13 items-center gap-2 rounded-xl border border-content-border bg-content-background px-3 py-2 text-sm/5 text-content-foreground shadow-sm transition-transform duration-150 ease-out will-change-transform motion-reduce:transition-none ${
+              !expanded && index > 0 ? 'pointer-events-none' : ''
+            }`}
+            style={{
+              transform: `translateY(-${index * (expanded ? expandedFollowUpOffset : collapsedFollowUpOffset)}px)`,
+              zIndex: visibleFollowUps.length - index,
+            }}
+          >
+            {index === 0 ? (
+              <button
+                type="button"
+                aria-expanded={expanded}
+                className="min-w-0 flex-1 rounded-sm text-left focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
+                onClick={() => setExpanded((current) => !current)}
+              >
+                <QueuedFollowUpContent followUp={followUp} next />
+              </button>
+            ) : (
+              <div className="min-w-0 flex-1">
+                <QueuedFollowUpContent followUp={followUp} next={false} />
+              </div>
+            )}
+            <div className="flex shrink-0 items-center gap-1">
+              {index === 0 && queuedFollowUpsPaused && !isWorking && (
+                <button
+                  type="button"
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs/4 font-medium text-content-foreground hover:bg-session-interaction focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={!resumeQueuedFollowUpMessages || actionPending}
+                  onClick={() => void resumeQueuedFollowUps()}
+                >
+                  <ListRestart aria-hidden="true" className="size-3.5" />
+                  Resume
+                </button>
+              )}
+              {expanded && (
+                <button
+                  type="button"
+                  aria-label="Remove queued follow-up"
+                  className="rounded-sm p-1 text-content-muted-foreground hover:bg-session-interaction hover:text-content-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={!removeQueuedFollowUpMessage || actionPending}
+                  onClick={() => void removeQueuedFollowUp(followUp.id)}
+                >
+                  <X aria-hidden="true" className="size-4" />
+                </button>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/src/renderer/components/session-area.tsx
+++ b/src/renderer/components/session-area.tsx
@@ -30,6 +30,8 @@ type SessionAreaProperties = {
   onDraftChange: (sessionId: SessionId, draft: string) => void
   submitMessage: ComposerBridge['submit']
   stopRun?: ComposerBridge['stop']
+  removeQueuedFollowUp?: NonNullable<ComposerBridge['removeQueuedFollowUp']>
+  resumeQueuedFollowUps?: NonNullable<ComposerBridge['resumeQueuedFollowUps']>
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
   onToggleSessionPin: (sessionId: SessionId) => void
@@ -53,6 +55,8 @@ export function SessionArea({
   onDraftChange,
   submitMessage,
   stopRun,
+  removeQueuedFollowUp,
+  resumeQueuedFollowUps,
   sessionConfiguration,
   sessionSkills,
   onToggleSessionPin,
@@ -106,6 +110,8 @@ export function SessionArea({
             onDraftChange={(draft) => onDraftChange(session.id, draft)}
             submitMessage={submitMessage}
             stopRun={stopRun}
+            removeQueuedFollowUp={removeQueuedFollowUp}
+            resumeQueuedFollowUps={resumeQueuedFollowUps}
             sessionConfiguration={sessionConfiguration}
             sessionSkills={sessionSkills}
             onTogglePin={() => onToggleSessionPin(session.id)}

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -5,6 +5,7 @@ import type { OwnedSession, WorkstreamLifecycle } from '@/src/domain/workstream'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
 import { Composer } from '@/src/renderer/components/composer'
+import { QueuedFollowUpTray } from '@/src/renderer/components/queued-follow-up-tray'
 import { SessionMessages } from '@/src/renderer/components/session-messages'
 import { SessionPinButton } from '@/src/renderer/components/session-pin-button'
 import { SessionTitleEditor } from '@/src/renderer/components/session-title-editor'
@@ -27,6 +28,8 @@ type SessionContainerProperties = {
   onDraftChange: (draft: string) => void
   submitMessage: ComposerBridge['submit']
   stopRun?: ComposerBridge['stop']
+  removeQueuedFollowUp?: NonNullable<ComposerBridge['removeQueuedFollowUp']>
+  resumeQueuedFollowUps?: NonNullable<ComposerBridge['resumeQueuedFollowUps']>
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
   onTogglePin: () => void
@@ -48,6 +51,8 @@ export function SessionContainer({
   onDraftChange,
   submitMessage,
   stopRun,
+  removeQueuedFollowUp,
+  resumeQueuedFollowUps,
   sessionConfiguration,
   sessionSkills,
   onTogglePin,
@@ -132,6 +137,16 @@ export function SessionContainer({
         timelineError={transcriptState.error}
         onReloadTimeline={transcriptState.reload}
       />
+      {!composerUnavailable && transcriptState.snapshot?.queuedFollowUps && (
+        <QueuedFollowUpTray
+          sessionId={session.id}
+          isWorking={isWorking}
+          queuedFollowUps={transcriptState.snapshot.queuedFollowUps}
+          queuedFollowUpsPaused={transcriptState.snapshot.queuedFollowUpsPaused ?? false}
+          removeQueuedFollowUp={removeQueuedFollowUp}
+          resumeQueuedFollowUps={resumeQueuedFollowUps}
+        />
+      )}
       {composerUnavailable ? (
         <div className="composer-tray shrink-0 border-t border-content-border p-3">
           <div className="flex min-h-13 items-center justify-center gap-2 rounded-xl border border-dashed border-composer-border bg-composer-background px-4 text-center text-sm/5 text-composer-muted-foreground">

--- a/src/renderer/components/session-messages.test.tsx
+++ b/src/renderer/components/session-messages.test.tsx
@@ -97,6 +97,32 @@ test('keeps the name of an unavailable Skill in the transcript', () => {
   )
 })
 
+test('labels a steering message separately from an ordinary user message', () => {
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking
+      transcript={transcript([
+        {
+          type: 'message',
+          message: {
+            id: 'steer-1',
+            role: 'user',
+            text: 'Prioritize transcript delivery.',
+            delivery: 'steer',
+            state: 'complete',
+            revision: 1,
+          },
+        },
+      ])}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  assert.ok(view.getByText('Steering', { exact: true }))
+  assert.ok(view.getByText('Prioritize transcript delivery.', { exact: true }))
+})
+
 test('keeps a streaming assistant message in one identity when it completes', () => {
   const view = render(
     <SessionMessages

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -3,7 +3,7 @@ import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRe
 import { Button } from '@/components/ui-kit/button'
 import type { SessionId } from '@/src/domain/session'
 import { AgentActivityCard } from '@/src/renderer/components/agent-activity-card'
-import { SkillReference } from '@/src/renderer/components/skill-reference'
+import { SkillMentionText } from '@/src/renderer/components/skill-mention-text'
 import type { AgentActivity } from '@/src/session-timeline'
 import type { SessionTranscriptMessage, SessionTranscriptSnapshot } from '@/src/session-transcript'
 
@@ -99,7 +99,12 @@ export function SessionMessages({
           {!isLoading &&
             transcript.map((entry) =>
               entry.type === 'message' ? (
-                <SessionMessageRow key={entry.key} message={entry.message} onOpenExternalLink={requestExternalLink} />
+                <SessionMessageRow
+                  key={entry.key}
+                  message={entry.message}
+                  isWorking={isWorking}
+                  onOpenExternalLink={requestExternalLink}
+                />
               ) : (
                 <AgentActivityCard
                   key={entry.key}
@@ -323,32 +328,31 @@ function useTranscriptScroll({
   }
 }
 
-function UserMessageContent({ message }: Readonly<{ message: SessionTranscriptMessage }>) {
-  const content: React.ReactNode[] = []
-  let textOffset = 0
-
-  for (const [index, mention] of (message.skills ?? []).entries()) {
-    content.push(message.text.slice(textOffset, mention.offset))
-    content.push(<SkillReference key={`${mention.offset}:${mention.skill.name}:${index}`} skill={mention.skill} />)
-    textOffset = mention.offset
-  }
-
-  content.push(message.text.slice(textOffset))
-  return content
-}
-
 function SessionMessageRow({
   message,
+  isWorking,
   onOpenExternalLink,
 }: Readonly<{
   message: SessionTranscriptMessage
+  isWorking: boolean
   onOpenExternalLink: (url: string) => void
 }>) {
   if (message.role === 'user') {
+    const steering = message.delivery === 'steer'
+
     return (
-      <article className="ml-auto w-fit max-w-[80%] rounded-xl border border-session-message-person-border bg-session-message-person-background px-3 py-2 text-sm/6 text-session-message-person-foreground">
+      <article
+        className={`ml-auto w-fit max-w-[80%] rounded-xl border px-3 py-2 text-sm/6 ${
+          steering
+            ? `border-content-border bg-content-subtle-background text-content-foreground opacity-80${
+                isWorking ? ' motion-safe:animate-pulse' : ''
+              }`
+            : 'border-session-message-person-border bg-session-message-person-background text-session-message-person-foreground'
+        }`}
+      >
+        {steering && <p className="mb-1 text-xs/4 font-medium text-content-muted-foreground">Steering</p>}
         <p className="whitespace-pre-wrap break-words">
-          <UserMessageContent message={message} />
+          <SkillMentionText text={message.text} skills={message.skills ?? []} />
         </p>
       </article>
     )

--- a/src/renderer/components/skill-mention-text.tsx
+++ b/src/renderer/components/skill-mention-text.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+import type { SessionSkillMention } from '@/src/session-skills'
+import { SkillReference } from './skill-reference'
+
+type SkillMentionTextProperties = Readonly<{
+  text: string
+  skills: readonly SessionSkillMention[]
+}>
+
+export function SkillMentionText({ text, skills }: SkillMentionTextProperties) {
+  const content: ReactNode[] = []
+  let textOffset = 0
+
+  for (const [index, mention] of skills.entries()) {
+    content.push(text.slice(textOffset, mention.offset))
+    content.push(<SkillReference key={`${mention.offset}:${mention.skill.name}:${index}`} skill={mention.skill} />)
+    textOffset = mention.offset
+  }
+
+  content.push(text.slice(textOffset))
+  return content
+}

--- a/src/renderer/composer-submission.test.ts
+++ b/src/renderer/composer-submission.test.ts
@@ -13,6 +13,33 @@ test('accepted submission clears the exact submitted draft at preflight acceptan
   )
 })
 
+test('accepted queued delivery clears the draft without a persistent Composer notice', () => {
+  assert.deepEqual(
+    getComposerSubmissionState({
+      type: 'resolve',
+      submittedDraft: 'After the current work',
+      result: { status: 'accepted', delivery: 'follow-up' },
+    }),
+    { draft: '', awaiting: false, error: '', status: '' }
+  )
+})
+
+test('full follow-up queue restores the draft and explains the three-item limit', () => {
+  assert.deepEqual(
+    getComposerSubmissionState({
+      type: 'resolve',
+      submittedDraft: 'Fourth follow-up',
+      result: { status: 'rejected', reason: 'follow-up-capacity' },
+    }),
+    {
+      draft: 'Fourth follow-up',
+      awaiting: false,
+      error: 'This Session already has three queued follow-ups. Wait for Pi to process one, then try again.',
+      status: '',
+    }
+  )
+})
+
 test('rejected submission restores the exact submitted draft with an error', () => {
   assert.deepEqual(
     getComposerSubmissionState({

--- a/src/renderer/composer-submission.ts
+++ b/src/renderer/composer-submission.ts
@@ -32,7 +32,7 @@ export function getComposerSubmissionState(event: ComposerSubmissionEvent): Comp
       'run-in-progress': 'This Session is already starting work. Wait a moment and try again.',
       'agent-run-capacity': 'Ten Agent Runs are already active. Wait for one to finish, then try again.',
       'follow-up-capacity':
-        'This Session already has 100 pending follow-ups. Wait for Pi to process one, then try again.',
+        'This Session already has three queued follow-ups. Wait for Pi to process one, then try again.',
       'runtime-unavailable': 'Pi couldn’t open this Session. Check its Repository and history, then try again.',
       'skill-unavailable': 'That Skill is no longer available for this Session. Remove it and choose another.',
       'preflight-rejected': 'Pi couldn’t start this run. Check the selected Model and provider, then try again.',
@@ -47,12 +47,6 @@ export function getComposerSubmissionState(event: ComposerSubmissionEvent): Comp
     }
   }
 
-  const status =
-    event.result.delivery === 'steer'
-      ? 'Message queued to steer the Session'
-      : event.result.delivery === 'follow-up'
-        ? 'Message queued for after the current work'
-        : ''
-
-  return { draft: '', awaiting: false, error: '', status }
+  // The accepted message is already visible in the canonical transcript.
+  return { draft: '', awaiting: false, error: '', status: '' }
 }

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -243,6 +243,9 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
 
   const submitMessage = (submission: SessionMessageSubmission) => window.piWorkspace.composer.submit(submission)
   const stopRun = (sessionId: SessionId) => window.piWorkspace.composer.stop(sessionId)
+  const removeQueuedFollowUp = (sessionId: SessionId, followUpId: string) =>
+    window.piWorkspace.composer.removeQueuedFollowUp(sessionId, followUpId)
+  const resumeQueuedFollowUps = (sessionId: SessionId) => window.piWorkspace.composer.resumeQueuedFollowUps(sessionId)
 
   const startTitleEditing = (sessionId: SessionId, origin: 'header' | 'sidebar') => {
     const session = sessions.find((candidate) => candidate.id === sessionId)
@@ -465,6 +468,8 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             onDraftChange={updateDraft}
             submitMessage={submitMessage}
             stopRun={stopRun}
+            removeQueuedFollowUp={removeQueuedFollowUp}
+            resumeQueuedFollowUps={resumeQueuedFollowUps}
             sessionConfiguration={window.piWorkspace.sessionConfiguration}
             sessionSkills={window.piWorkspace.sessionSkills}
             onToggleSessionPin={toggleSessionPin}

--- a/src/session-timeline.ts
+++ b/src/session-timeline.ts
@@ -22,6 +22,7 @@ export type ConversationEntry = Readonly<{
   role: 'user' | 'assistant'
   text: string
   skills?: readonly SessionSkillMention[]
+  delivery?: 'steer'
   timestamp: number
 }>
 

--- a/src/session-transcript.ts
+++ b/src/session-transcript.ts
@@ -1,4 +1,5 @@
 import type { SessionId } from '@/src/domain/session'
+import type { QueuedFollowUp } from '@/src/queued-follow-up'
 import type { SessionSkillMention } from '@/src/session-skills'
 
 const allowedExternalUrlProtocols = new Set(['http:', 'https:', 'mailto:'])
@@ -20,6 +21,7 @@ export type SessionTranscriptMessage = Readonly<{
   role: 'user' | 'assistant'
   text: string
   skills?: readonly SessionSkillMention[]
+  delivery?: 'steer'
   state: 'complete' | 'streaming'
   revision: number
 }>
@@ -41,6 +43,8 @@ export type SessionTranscriptSnapshot = Readonly<{
   contextUsage?: SessionContextUsage
   runs: readonly AgentRun[]
   entries: readonly SessionTranscriptEntry[]
+  queuedFollowUps?: readonly QueuedFollowUp[]
+  queuedFollowUpsPaused?: boolean
   runFailureReason?: 'failed' | 'cancelled'
 }>
 


### PR DESCRIPTION
## Summary

Add a durable three-item follow-up queue for working Sessions. Queued follow-ups persist in Session history, drain in FIFO order, remain removable, pause after an application restart, and render as an expandable stack above the Composer with inline Skill references.

Steering messages now appear distinctly in the transcript and retain that presentation after Session history is reopened. The isolated demo includes a full queue and transcript-visible steering example.

## Related issue

None.

## Validation

- [x] `bun run check` — passed: format, lint, typecheck, 510 tests, and production build.
- [x] `bun run security:scan` — passed: no secrets or dependency issues found.
- [x] Focused runtime and renderer coverage verifies queue durability and capacity, restart/resume behavior, FIFO dispatch, persistence failures, removal, Skill rendering, steering hydration, and keyboard interaction.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing and domain documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications: none.
- [x] I have read and will follow the Code of Conduct.
