### PR TITLE
fix: repair macOS and Windows release packaging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "minimatch@9.0.9": "patches/minimatch@9.0.9.patch",
+  },
   "overrides": {
     "brace-expansion": "5.0.8",
     "fast-uri": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -160,5 +160,8 @@
     "brace-expansion": "5.0.8",
     "fast-uri": "3.1.4",
     "tar": "7.5.21"
+  },
+  "patchedDependencies": {
+    "minimatch@9.0.9": "patches/minimatch@9.0.9.patch"
   }
 }

--- a/patches/minimatch@9.0.9.patch
+++ b/patches/minimatch@9.0.9.patch
@@ -1,0 +1,35 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index c12dc5e6476874f9dbba429a19e445a4a688e1df..45e194452d9ba33ec5a38b70f0a0cb7366edf3fc 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -1,10 +1,7 @@
+ "use strict";
+-var __importDefault = (this && this.__importDefault) || function (mod) {
+-    return (mod && mod.__esModule) ? mod : { "default": mod };
+-};
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.unescape = exports.escape = exports.AST = exports.Minimatch = exports.match = exports.makeRe = exports.braceExpand = exports.defaults = exports.filter = exports.GLOBSTAR = exports.sep = exports.minimatch = void 0;
+-const brace_expansion_1 = __importDefault(require("brace-expansion"));
++const brace_expansion_1 = require("brace-expansion");
+ const assert_valid_pattern_js_1 = require("./assert-valid-pattern.js");
+ const ast_js_1 = require("./ast.js");
+ const escape_js_1 = require("./escape.js");
+@@ -157,7 +154,7 @@ const braceExpand = (pattern, options = {}) => {
+         // shortcut. no need to expand.
+         return [pattern];
+     }
+-    return (0, brace_expansion_1.default)(pattern);
++    return (0, brace_expansion_1.expand)(pattern);
+ };
+ exports.braceExpand = braceExpand;
+ exports.minimatch.braceExpand = exports.braceExpand;
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 737c8095415235e69e4717b505d0ee4ea3c0b6fa..d5cb9cf4a859e00769290f90ecf3964d7ab3214d 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -1,4 +1,4 @@
+-import expand from 'brace-expansion';
++import { expand } from 'brace-expansion';
+ import { assertValidPattern } from './assert-valid-pattern.js';
+ import { AST } from './ast.js';
+ import { escape } from './escape.js';

--- a/scripts/check-renderer-bundle.mjs
+++ b/scripts/check-renderer-bundle.mjs
@@ -1,5 +1,6 @@
 import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
+import { identifyRendererBundleFiles } from './renderer-bundle-files.mjs'
 
 const rendererDirectory = 'dist/renderer'
 const initialJavaScriptBudget = 1100 * 1024
@@ -19,9 +20,7 @@ async function filesIn(directory) {
 }
 
 const files = await filesIn(rendererDirectory)
-const assets = files.filter((path) => path.includes('/assets/'))
-const javascriptAssets = assets.filter((path) => path.endsWith('.js'))
-const entry = javascriptAssets.find((path) => /\/index-[^/]+\.js$/.test(path))
+const { assets, entry } = identifyRendererBundleFiles(files)
 
 if (!entry) throw new Error('Renderer bundle entry was not found.')
 

--- a/scripts/renderer-bundle-files.mjs
+++ b/scripts/renderer-bundle-files.mjs
@@ -1,0 +1,7 @@
+export function identifyRendererBundleFiles(files) {
+  const assets = files.filter((path) => /[\\/]assets[\\/]/.test(path))
+  const javascriptAssets = assets.filter((path) => path.endsWith('.js'))
+  const entry = javascriptAssets.find((path) => /[\\/]index-[^\\/]+\.js$/.test(path))
+
+  return { assets, entry }
+}

--- a/scripts/renderer-bundle-files.test.mjs
+++ b/scripts/renderer-bundle-files.test.mjs
@@ -1,0 +1,8 @@
+import { expect, test } from 'bun:test'
+import { identifyRendererBundleFiles } from './renderer-bundle-files.mjs'
+
+test('identifies the renderer entry from Windows paths', () => {
+  const entry = 'dist\\renderer\\assets\\index-abc123.js'
+
+  expect(identifyRendererBundleFiles([entry]).entry).toBe(entry)
+})


### PR DESCRIPTION
## Summary

- recognize both POSIX and Windows separators when locating the renderer entry bundle
- add regression coverage for Windows renderer paths
- patch `minimatch@9.0.9` to use the named `brace-expansion@5.0.8` export required by the security override

## Cause

The [0.6.0-beta.1 release run](https://github.com/pi-workspace/pi-workspace/actions/runs/30157926699) exposed two independent failures:

- Windows bundle validation only matched `/` separators, so it could not find the generated `index-*.js` file.
- macOS universal packaging loaded `brace-expansion@5.0.8` through `minimatch@9.0.9`, whose default import is incompatible with the secured dependency's named export.

## Validation

- `bun install --frozen-lockfile`
- `bun run check` — 513 passed
- `bun run security:scan` — no issues found
- `bun run package:linux`
- verified the patched `minimatch` ESM and CommonJS entry points against brace expansion
