### PR TITLE
fix: harden release verification

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -176,9 +176,24 @@ jobs:
         env:
           DEBIAN_VERSION: ${{ matrix.debian }}
         run: |
+          image="debian:$DEBIAN_VERSION"
+
+          for attempt in 1 2 3; do
+            if docker pull "$image"; then
+              break
+            fi
+
+            if [[ "$attempt" = 3 ]]; then
+              echo "Unable to pull $image after $attempt attempts." >&2
+              exit 1
+            fi
+
+            sleep "$((attempt * 5))"
+          done
+
           docker run --rm \
             --volume "$PWD/release:/release:ro" \
-            "debian:$DEBIAN_VERSION" \
+            "$image" \
             bash -euxo pipefail -c '
               apt-get update
               cd /release
@@ -256,7 +271,7 @@ jobs:
       - name: Verify packaged application files
         shell: pwsh
         run: |
-          $packageContents = & bun x asar list release/win-unpacked/resources/app.asar
+          $packageContents = @(& bun x asar list release/win-unpacked/resources/app.asar) -replace '\\', '/'
           $expectedPaths = @(
             '/assets/pi-workspace-mark.png'
             '/dist/main/index.js'


### PR DESCRIPTION
## Summary

- normalize Windows ASAR paths before checking packaged application contents
- retry Debian verification image pulls up to three times before failing

## Cause

The [latest release run](https://github.com/pi-workspace/pi-workspace/actions/runs/30159302212) exposed two independent verification failures:

- the Windows installer was built successfully, but ASAR returned `\\`-separated paths and package verification compared them with `/`-separated expected paths
- Debian 13 verification did not reach the package because Docker Hub timed out while pulling `debian:13`

## Validation

- `bun run check` — 513 passed
- `bun run security:scan` — no unignored issues
- `bun x prettier --check .github/workflows/release-beta.yml`
- `git diff --check`
- confirmed that normalizing the Windows path `\\assets\\pi-workspace-mark.png` produces the expected `/assets/pi-workspace-mark.png`
