### PR TITLE
fix: verify Windows installer exit codes

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -382,9 +382,13 @@ jobs:
             throw 'Windows installer checksum does not match.'
           }
 
-          & $installer[0].FullName /S
-          if ($LASTEXITCODE -ne 0) {
-            throw "Windows installer exited with $LASTEXITCODE."
+          $installerProcess = Start-Process `
+            -FilePath $installer[0].FullName `
+            -ArgumentList '/S' `
+            -Wait `
+            -PassThru
+          if ($installerProcess.ExitCode -ne 0) {
+            throw "Windows installer exited with $($installerProcess.ExitCode)."
           }
 
           $application = Get-ChildItem "$env:LOCALAPPDATA\Programs" -File -Filter 'Pi Workspace.exe' -Recurse |
@@ -407,8 +411,12 @@ jobs:
             throw 'Windows installer did not install an uninstaller.'
           }
 
-          & $uninstaller.FullName /S
-          if ($LASTEXITCODE -ne 0 -or (Test-Path $application.FullName)) {
+          $uninstallerProcess = Start-Process `
+            -FilePath $uninstaller.FullName `
+            -ArgumentList '/S' `
+            -Wait `
+            -PassThru
+          if ($uninstallerProcess.ExitCode -ne 0 -or (Test-Path $application.FullName)) {
             throw 'Windows uninstaller did not remove Pi Workspace.'
           }
 


### PR DESCRIPTION
## Summary
- run the Windows installer with `Start-Process -Wait -PassThru`
- verify the installer's explicit process exit code instead of relying on an unset `$LASTEXITCODE`
- use the same reliable exit-code handling for silent uninstallation

## Context
[Beta release run 30161521687](https://github.com/pi-workspace/pi-workspace/actions/runs/30161521687) successfully built the Windows installer and verified its packaged files. The installer verification then reported `Windows installer exited with .` because invoking the GUI executable directly did not populate `$LASTEXITCODE`, and PowerShell treated `$null -ne 0` as true.

## Validation
- `bun run check` (513 tests passed)
- `bun run security:scan` (no unignored issues)
- `bun x prettier --check .github/workflows/release-beta.yml`
- `git diff --check`
