### PR TITLE
feat: add manual Session context compaction

### DIFF
--- a/src/composer-ipc.ts
+++ b/src/composer-ipc.ts
@@ -5,11 +5,18 @@ import { isSessionId } from '@/src/domain/session'
 export const maximumSessionMessageLength = 200_000
 
 export const composerIpcChannels = {
+  compact: 'composer:compact',
   submit: 'composer:submit',
   stop: 'composer:stop',
   removeQueuedFollowUp: 'composer:remove-queued-follow-up',
   resumeQueuedFollowUps: 'composer:resume-queued-follow-ups',
 } as const
+
+export function parseSessionCompactRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionMessageSubmission['sessionId'] }> | undefined {
+  return parseSessionRunStopRequest(value)
+}
 
 export function parseSessionRunStopRequest(
   value: unknown

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -24,6 +24,9 @@ export function isSessionSkillName(value: unknown): value is string {
 
 export type AcceptedSessionMessageDelivery = 'prompt' | SessionMessageDelivery
 
+export type SessionContextCompactionResult =
+  Readonly<{ status: 'compacted' }> | Readonly<{ status: 'rejected'; message: string }>
+
 export type SessionRunStopResult = Readonly<{ status: 'stopped' | 'not-running' }>
 
 export const sessionMessageRejectionReasons = [
@@ -51,6 +54,7 @@ export type SessionMessageSubmissionResult =
     }>
 
 export interface ComposerBridge {
+  compact(sessionId: SessionId): Promise<SessionContextCompactionResult>
   submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult>
   stop(sessionId: SessionId): Promise<SessionRunStopResult>
   removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -127,6 +127,9 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       },
     },
     composer: {
+      async compact() {
+        return { status: 'compacted' as const }
+      },
       async submit() {
         return { status: 'rejected', reason: 'unexpected' }
       },

--- a/src/main/application-state/application-state-store.ts
+++ b/src/main/application-state/application-state-store.ts
@@ -258,10 +258,12 @@ export async function initializeApplicationStateStore(storageDirectory: string, 
 
     try {
       database.exec('BEGIN IMMEDIATE;')
-      const leases = database.prepare("SELECT lease_id FROM session_run_leases WHERE purpose = 'agent-run'").all()
+      const leases = database
+        .prepare("SELECT lease_id FROM session_run_leases WHERE purpose IN ('agent-run', 'context-compaction')")
+        .all()
 
       if (leases.length > 0) {
-        database.prepare("DELETE FROM session_run_leases WHERE purpose = 'agent-run'").run()
+        database.prepare("DELETE FROM session_run_leases WHERE purpose IN ('agent-run', 'context-compaction')").run()
         incrementRevision(database)
       }
 
@@ -272,7 +274,7 @@ export async function initializeApplicationStateStore(storageDirectory: string, 
       } catch {
         // Startup reconciliation failed before a transaction was active.
       }
-      startup = { status: 'recovery-only', diagnostic: 'Interrupted Agent Run recovery failed.' }
+      startup = { status: 'recovery-only', diagnostic: 'Interrupted Session activity recovery failed.' }
     } finally {
       database.close()
     }

--- a/src/main/application-state/index.ts
+++ b/src/main/application-state/index.ts
@@ -88,6 +88,8 @@ export type ApplicationAuthority = Readonly<{
   subscribeWorkstreamKnowledge(listener: (state: WorkstreamKnowledge) => void): () => void
   acquireSessionRunLease(sessionId: SessionId): Promise<boolean>
   settleSessionRunLease(sessionId: SessionId): Promise<boolean>
+  acquireSessionCompactionLease(sessionId: SessionId): Promise<boolean>
+  settleSessionCompactionLease(sessionId: SessionId): Promise<boolean>
   getCurrentWorkstreamRepositorySet(workstreamId: string): Promise<readonly string[]>
 }>
 
@@ -125,7 +127,8 @@ export async function initializeApplicationAuthority(
   } = workspaceRepositoryStore
   const { reconcilePendingSessionFiles, refreshOwnedSessionAvailability, reconcileCommittedSession } =
     sessionFileReconciliation
-  const { acquireSessionRunLease, settleSessionRunLease } = runLeaseStore
+  const { acquireSessionRunLease, settleSessionRunLease, acquireSessionCompactionLease, settleSessionCompactionLease } =
+    runLeaseStore
   const {
     getWorkstreamKnowledge,
     applyUserWorkstreamKnowledgeCommand,
@@ -186,6 +189,8 @@ export async function initializeApplicationAuthority(
     subscribeWorkstreamKnowledge,
     acquireSessionRunLease,
     settleSessionRunLease,
+    acquireSessionCompactionLease,
+    settleSessionCompactionLease,
     getCurrentWorkstreamRepositorySet,
   }
 }

--- a/src/main/application-state/run-lease-store.ts
+++ b/src/main/application-state/run-lease-store.ts
@@ -7,7 +7,10 @@ type RunLeaseStoreOptions = Readonly<{
 }>
 
 export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
-  async function acquireSessionRunLease(sessionId: SessionId): Promise<boolean> {
+  async function acquireSessionLease(
+    sessionId: SessionId,
+    purpose: 'agent-run' | 'context-compaction'
+  ): Promise<boolean> {
     const database = openDatabase()
 
     try {
@@ -25,15 +28,12 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
         database.exec('ROLLBACK;')
         return false
       }
-      if (
-        database
-          .prepare("SELECT lease_id FROM session_run_leases WHERE session_id = ? AND purpose = 'agent-run'")
-          .get(sessionId)
-      ) {
+      if (database.prepare('SELECT lease_id FROM session_run_leases WHERE session_id = ?').get(sessionId)) {
         database.exec('ROLLBACK;')
         return false
       }
       if (
+        purpose === 'agent-run' &&
         database
           .prepare(
             `SELECT 1
@@ -56,9 +56,9 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
       database
         .prepare(
           `INSERT INTO session_run_leases (workstream_id, lease_id, session_id, purpose, acquired_at)
-           VALUES (?, ?, ?, 'agent-run', ?)`
+           VALUES (?, ?, ?, ?, ?)`
         )
-        .run(session.workstream_id, randomUUID(), sessionId, Date.now())
+        .run(session.workstream_id, randomUUID(), sessionId, purpose, Date.now())
       database.exec('COMMIT;')
       return true
     } catch (error) {
@@ -73,12 +73,15 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
     }
   }
 
-  async function settleSessionRunLease(sessionId: SessionId): Promise<boolean> {
+  async function settleSessionLease(
+    sessionId: SessionId,
+    purpose: 'agent-run' | 'context-compaction'
+  ): Promise<boolean> {
     const database = openDatabase()
 
     try {
       database.exec('BEGIN IMMEDIATE;')
-      database.prepare("DELETE FROM session_run_leases WHERE session_id = ? AND purpose = 'agent-run'").run(sessionId)
+      database.prepare('DELETE FROM session_run_leases WHERE session_id = ? AND purpose = ?').run(sessionId, purpose)
       database.exec('COMMIT;')
       return true
     } catch (error) {
@@ -89,5 +92,10 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
     }
   }
 
-  return { acquireSessionRunLease, settleSessionRunLease }
+  return {
+    acquireSessionRunLease: (sessionId: SessionId) => acquireSessionLease(sessionId, 'agent-run'),
+    settleSessionRunLease: (sessionId: SessionId) => settleSessionLease(sessionId, 'agent-run'),
+    acquireSessionCompactionLease: (sessionId: SessionId) => acquireSessionLease(sessionId, 'context-compaction'),
+    settleSessionCompactionLease: (sessionId: SessionId) => settleSessionLease(sessionId, 'context-compaction'),
+  }
 }

--- a/src/main/application-state/workstreams.test.ts
+++ b/src/main/application-state/workstreams.test.ts
@@ -1659,6 +1659,18 @@ test('releases an interrupted ordinary Agent Run lease during startup', async ()
   assert.equal(await restarted.acquireSessionRunLease(created.sessionId), true)
 })
 
+test('releases an interrupted Session context compaction lease during startup', async () => {
+  const { authority, storageDirectory, workspace } = await createFixture()
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Resume after interrupted compaction' })
+
+  assert.equal(await authority.acquireSessionCompactionLease(created.sessionId), true)
+
+  const restarted = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
+
+  assert.equal(await restarted.acquireSessionCompactionLease(created.sessionId), true)
+  await restarted.settleSessionCompactionLease(created.sessionId)
+})
+
 test('withholds submission capability from archived Sessions', async () => {
   const { authority, workspace } = await createFixture()
   const created = await authority.createWorkstream(workspace.id, { goal: 'Stop while archived' })
@@ -1671,6 +1683,19 @@ test('withholds submission capability from archived Sessions', async () => {
   assert.equal(resolution?.canSubmit, false)
   assert.equal(resolution?.toolAccess, 'none')
   assert.equal(await authority.acquireSessionRunLease(created.sessionId), false)
+})
+
+test('rejects archival while Session context compaction is active', async () => {
+  const { authority, workspace } = await createFixture()
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Stay active while compacting' })
+  const workstream = created.snapshot.workstreams[0]!
+
+  assert.equal(await authority.acquireSessionCompactionLease(created.sessionId), true)
+  await assert.rejects(authority.setWorkstreamLifecycle(workstream.id, 'archived'), /only while every Session is idle/)
+  await authority.settleSessionCompactionLease(created.sessionId)
+
+  const archived = await authority.setWorkstreamLifecycle(workstream.id, 'archived')
+  assert.equal(archived.workstreams[0]?.lifecycle, 'archived')
 })
 
 test('rejects archival while a Workstream Agent Run is active', async () => {

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -10,6 +10,7 @@ import type {
 import {
   composerIpcChannels,
   parseQueuedFollowUpRemovalRequest,
+  parseSessionCompactRequest,
   parseSessionMessageSubmission,
   parseSessionRunStopRequest,
 } from '@/src/composer-ipc'
@@ -39,6 +40,7 @@ import {
   type PiSessionRuntimeEvent,
   type PiSessionRuntimeRegistry,
 } from '@/src/main/pi-session-runtimes'
+import { canCompactSessionHistory } from '@/src/main/pi-session-compaction'
 import { classifyPersistedAgentState } from '@/src/main/pi-session-history'
 import { createManagedSessionServices } from '@/src/main/managed-session-resources'
 import { createManagedSessionRuntimePolicyGuard } from '@/src/main/managed-session-runtime-policy'
@@ -279,6 +281,19 @@ export async function createPiSessionRuntime(
     })
   }
 
+  const getContextUsage = () => {
+    const usage = session.getContextUsage()
+    if (!usage) return undefined
+
+    return {
+      ...usage,
+      canCompact: canCompactSessionHistory(
+        session.sessionManager.getBranch(),
+        session.settingsManager.getCompactionSettings()
+      ),
+    }
+  }
+
   return {
     get isStreaming() {
       return session.isStreaming
@@ -289,8 +304,12 @@ export async function createPiSessionRuntime(
     rename(title) {
       session.sessionManager.appendSessionInfo(title)
     },
-    getContextUsage() {
-      return session.getContextUsage()
+    getContextUsage,
+    compact() {
+      return session.compact().then(() => undefined)
+    },
+    canCompact() {
+      return getContextUsage()?.canCompact === true
     },
     subscribe(listener) {
       runtimeListeners.add(listener)
@@ -338,7 +357,7 @@ export async function createPiSessionRuntime(
         if (normalized) listener(normalized)
 
         if (event.type === 'message_end' || event.type === 'compaction_end') {
-          listener({ type: 'context_usage', usage: session.getContextUsage() })
+          listener({ type: 'context_usage', usage: getContextUsage() })
         }
       })
 
@@ -378,6 +397,19 @@ export async function createPiSessionRuntime(
         ]
       })
 
+      const compactions = entries.flatMap((entry) =>
+        entry.type === 'compaction'
+          ? [
+              {
+                type: 'context-compaction' as const,
+                id: entry.id,
+                summary: entry.summary,
+                timestamp: Number.isFinite(Date.parse(entry.timestamp)) ? Date.parse(entry.timestamp) : Date.now(),
+              },
+            ]
+          : []
+      )
+
       const activityRecords = entries.flatMap((entry): ActivityLayerRecord[] => {
         return entry.type === 'custom' &&
           entry.customType === activityLayerCustomEntryType &&
@@ -391,7 +423,7 @@ export async function createPiSessionRuntime(
         .at(-1)
       const finalState = classifyPersistedAgentState(lastAssistant)
 
-      return { conversations, activityRecords, finalState }
+      return { conversations, compactions, activityRecords, finalState }
     },
     appendActivityRecord(record) {
       session.sessionManager.appendCustomEntry(activityLayerCustomEntryType, record)
@@ -449,7 +481,7 @@ export async function createPiSessionRuntime(
 
       await session.setModel(model)
       session.settingsManager.setDefaultModelAndProvider(model.provider, model.id)
-      runtimeListeners.forEach((listener) => listener({ type: 'context_usage', usage: session.getContextUsage() }))
+      runtimeListeners.forEach((listener) => listener({ type: 'context_usage', usage: getContextUsage() }))
     },
     async setConfigurationEffort(effort: SessionConfigurationEffort) {
       if (!session.supportsThinking() && effort === 'off') return
@@ -515,6 +547,14 @@ function normalizePiSessionEvent(
     return { type: 'model_turn_started', noProgressTimeoutMs: modelTurnNoProgressTimeoutMs }
   }
   if (
+    event.type === 'compaction_end' &&
+    typeof event.result === 'object' &&
+    event.result !== null &&
+    typeof (event.result as { summary?: unknown }).summary === 'string'
+  ) {
+    return { type: 'compaction_completed', summary: (event.result as { summary: string }).summary }
+  }
+  if (
     event.type === 'message_start' ||
     event.type === 'message_update' ||
     event.type === 'auto_retry_start' ||
@@ -544,6 +584,10 @@ export function initializeComposer(authority: ApplicationAuthority): void {
     releaseRunLease: async (id) => {
       await authority.settleSessionRunLease(id)
     },
+    acquireCompactionLease: (id) => authority.acquireSessionCompactionLease(id),
+    releaseCompactionLease: async (id) => {
+      await authority.settleSessionCompactionLease(id)
+    },
     reconcileAfterRun: (id) => authority.settleSessionRunLease(id),
     createSession: async ({ directoryPath, sessionPath, managedPolicy }) => {
       const { SessionManager } = await import('@earendil-works/pi-coding-agent')
@@ -564,6 +608,13 @@ export function initializeComposer(authority: ApplicationAuthority): void {
     },
   })
   composerRegistry = registry
+
+  handleTrustedIpc(composerIpcChannels.compact, (_event, value: unknown) => {
+    const request = parseSessionCompactRequest(value)
+    return request
+      ? registry.compact(request.sessionId)
+      : Promise.resolve({ status: 'rejected' as const, message: 'Invalid Session.' })
+  })
 
   handleTrustedIpc(composerIpcChannels.submit, (_event, value: unknown): Promise<SessionMessageSubmissionResult> => {
     const submission = parseSessionMessageSubmission(value)

--- a/src/main/pi-session-compaction.test.ts
+++ b/src/main/pi-session-compaction.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { SessionEntry } from '@earendil-works/pi-coding-agent'
+import { canCompactSessionHistory } from './pi-session-compaction'
+
+function messageEntry(id: string, role: 'user' | 'assistant', text: string, timestamp: number): SessionEntry {
+  return {
+    type: 'message',
+    id,
+    parentId: null,
+    timestamp: new Date(timestamp).toISOString(),
+    message:
+      role === 'user'
+        ? { role, content: [{ type: 'text', text }], timestamp }
+        : {
+            role,
+            content: [{ type: 'text', text }],
+            api: 'openai-responses',
+            provider: 'test',
+            model: 'test',
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: 'stop',
+            timestamp,
+          },
+  }
+}
+
+test('does not offer compaction when the Session has no older context to summarize', () => {
+  const entries = [
+    messageEntry('user-1', 'user', 'Inspect this Repository.', 1),
+    messageEntry('assistant-1', 'assistant', 'The inspection is complete.', 2),
+  ]
+
+  assert.equal(canCompactSessionHistory(entries, { keepRecentTokens: 20_000 }), false)
+})
+
+test('offers compaction when older Session context can be summarized', () => {
+  const entries = [
+    messageEntry('user-1', 'user', 'Inspect this Repository.', 1),
+    messageEntry('assistant-1', 'assistant', 'The inspection is complete.', 2),
+    messageEntry('user-2', 'user', 'Now implement the requested change in detail.', 3),
+    messageEntry('assistant-2', 'assistant', 'Implementation is in progress.', 4),
+  ]
+
+  assert.equal(canCompactSessionHistory(entries, { keepRecentTokens: 10 }), true)
+})

--- a/src/main/pi-session-compaction.ts
+++ b/src/main/pi-session-compaction.ts
@@ -1,0 +1,26 @@
+import { findCutPoint, sessionEntryToContextMessages, type SessionEntry } from '@earendil-works/pi-coding-agent'
+
+export function canCompactSessionHistory(
+  entries: readonly SessionEntry[],
+  settings: Readonly<{ keepRecentTokens: number }>
+): boolean {
+  if (entries.at(-1)?.type === 'compaction') return false
+
+  const previousCompactionIndex = entries.findLastIndex((entry) => entry.type === 'compaction')
+  let boundaryStart = 0
+
+  if (previousCompactionIndex >= 0) {
+    const previousCompaction = entries[previousCompactionIndex]
+
+    if (previousCompaction?.type === 'compaction') {
+      const firstKeptEntryIndex = entries.findIndex((entry) => entry.id === previousCompaction.firstKeptEntryId)
+      boundaryStart = firstKeptEntryIndex >= 0 ? firstKeptEntryIndex : previousCompactionIndex + 1
+    }
+  }
+
+  const cutPoint = findCutPoint([...entries], boundaryStart, entries.length, settings.keepRecentTokens)
+
+  return entries
+    .slice(boundaryStart, cutPoint.firstKeptEntryIndex)
+    .some((entry) => entry.type !== 'compaction' && sessionEntryToContextMessages(entry).length > 0)
+}

--- a/src/main/pi-session-runtime-transcript.ts
+++ b/src/main/pi-session-runtime-transcript.ts
@@ -7,6 +7,7 @@ export type SessionRuntimeTimeline = {
   revision: number
   runtimeDirectory?: string
   contextUsage?: SessionContextUsage
+  isCompacting: boolean
   runs: AgentRun[]
   entries: SessionTimelineEntry[]
   messages: Map<string, SessionTranscriptMessage>
@@ -144,10 +145,10 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
     timeline.operations.set(execution.toolCallId, { execution: { ...execution, input: undefined } })
   }
 
-  timeline.entries = [...conversations, ...activities.values()].sort(
+  timeline.entries = [...conversations, ...activities.values(), ...(history.compactions ?? [])].sort(
     (left, right) =>
-      (left.type === 'conversation' ? left.timestamp : left.startedAt) -
-      (right.type === 'conversation' ? right.timestamp : right.startedAt)
+      (left.type === 'conversation' || left.type === 'context-compaction' ? left.timestamp : left.startedAt) -
+      (right.type === 'conversation' || right.type === 'context-compaction' ? right.timestamp : right.startedAt)
   )
   timeline.revision = history.activityRecords.length
 

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -2,6 +2,7 @@ import type {
   AcceptedSessionMessageDelivery,
   SessionMessageSubmission,
   SessionMessageSubmissionResult,
+  SessionContextCompactionResult,
   SessionRunStopResult,
 } from '@/src/composer'
 import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
@@ -25,6 +26,7 @@ import {
   type AgentActivityDetails,
   type AgentActivityKind,
   type AgentRun,
+  type ContextCompaction,
   type ConversationEntry,
   type SessionWorkingStateSnapshot,
   type ToolExecution,
@@ -67,6 +69,8 @@ export interface PiSessionRuntime {
   rename?(title: string): void
   subscribe(listener: (event: PiSessionRuntimeEvent) => void): () => void
   abort?(): Promise<void>
+  compact?(): Promise<void>
+  canCompact?(): boolean
   loadHistory?(): PiSessionRuntimeHistory
   appendActivityRecord?(record: ActivityLayerRecord): void
   loadRawOperation?(toolCallId: string): Readonly<{ input: unknown; result?: unknown }> | undefined
@@ -83,11 +87,13 @@ export interface PiSessionRuntime {
 export type PiSessionRuntimeHistory = Readonly<{
   conversations: readonly ConversationEntry[]
   activityRecords: readonly ActivityLayerRecord[]
+  compactions?: readonly ContextCompaction[]
   finalState: 'completed' | 'failed' | 'cancelled' | 'indeterminate'
 }>
 
 export type PiSessionRuntimeEvent =
   | Readonly<{ type: 'context_usage'; usage?: SessionContextUsage }>
+  | Readonly<{ type: 'compaction_completed'; summary: string }>
   | Readonly<{ type: 'tool_execution_start'; toolCallId: string; toolName: string; input: unknown }>
   | Readonly<{
       type: 'activity_control_accepted'
@@ -127,6 +133,8 @@ type PiSessionRuntimeRegistryOptions = Readonly<{
   reconcileAfterRun?: (sessionId: SessionId) => Promise<boolean>
   acquireRunLease?: (sessionId: SessionId) => boolean | Promise<boolean>
   releaseRunLease?: (sessionId: SessionId) => void | Promise<void>
+  acquireCompactionLease?: (sessionId: SessionId) => boolean | Promise<boolean>
+  releaseCompactionLease?: (sessionId: SessionId) => void | Promise<void>
   noProgressTimeoutMs?: number
   stopTimeoutMs?: number
 }>
@@ -140,6 +148,7 @@ export interface PiSessionRuntimeRegistry {
   ): void
   submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult>
   stop(sessionId: SessionId): Promise<SessionRunStopResult>
+  compact(sessionId: SessionId): Promise<SessionContextCompactionResult>
   removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>
   resumeQueuedFollowUps(sessionId: SessionId): Promise<boolean>
   renameSession(sessionId: SessionId, title: string): Promise<void>
@@ -179,6 +188,8 @@ export function createPiSessionRuntimeRegistry({
   reconcileAfterRun,
   acquireRunLease = () => true,
   releaseRunLease = () => {},
+  acquireCompactionLease = () => true,
+  releaseCompactionLease = () => {},
   noProgressTimeoutMs = 30_000,
   stopTimeoutMs = 5_000,
 }: PiSessionRuntimeRegistryOptions): PiSessionRuntimeRegistry {
@@ -205,6 +216,7 @@ export function createPiSessionRuntimeRegistry({
         activities: new Map(),
         operations: new Map(),
         controlTransitions: new Map(),
+        isCompacting: false,
       }
 
       timelineBySessionId.set(sessionId, timeline)
@@ -288,6 +300,10 @@ export function createPiSessionRuntimeRegistry({
         entries.push({ type: 'activity', activity: entry })
         return
       }
+      if (entry.type === 'context-compaction') {
+        entries.push({ type: 'compaction', compaction: entry })
+        return
+      }
 
       const message = messagesById.get(entry.id)
       if (!message) return
@@ -306,6 +322,7 @@ export function createPiSessionRuntimeRegistry({
       sessionId,
       revision: timeline.revision,
       isWorking: timeline.runs.some((run) => run.status === 'running'),
+      isCompacting: timeline.isCompacting,
       contextUsage: timeline.contextUsage,
       runs: timeline.runs,
       entries,
@@ -580,6 +597,13 @@ export function createPiSessionRuntimeRegistry({
 
     if (event.type === 'context_usage') {
       timeline.contextUsage = event.usage
+      publishTimeline(sessionId)
+
+      return
+    }
+
+    if (event.type === 'compaction_completed') {
+      timeline.entries.push({ type: 'context-compaction', id: createId(), summary: event.summary, timestamp: now() })
       publishTimeline(sessionId)
 
       return
@@ -1197,6 +1221,95 @@ export function createPiSessionRuntimeRegistry({
     return result
   }
 
+  async function compactImmediately(sessionId: SessionId): Promise<SessionContextCompactionResult> {
+    const timeline = getTimeline(sessionId)
+    if (timeline.runs.some((run) => run.status === 'running'))
+      return { status: 'rejected', message: 'Wait for the Agent Run to finish before compacting.' }
+    if (timeline.isCompacting) return { status: 'rejected', message: 'Session context is already compacting.' }
+
+    let leaseAcquired: boolean
+    try {
+      leaseAcquired = await acquireCompactionLease(sessionId)
+    } catch {
+      return { status: 'rejected', message: 'Pi couldn’t reserve this Session for context compaction.' }
+    }
+
+    if (!leaseAcquired) {
+      return { status: 'rejected', message: 'This Session is unavailable or already busy.' }
+    }
+
+    try {
+      timeline.isCompacting = true
+      publishTimeline(sessionId, 'Compacting Session context…')
+
+      let runtime: SessionRuntimeEntry | undefined
+      try {
+        const entry = lifecycle.getEntry(sessionId)
+        runtime = entry
+          ? await entry
+          : await getRuntime(sessionId).then((value) =>
+              value ? ({ runtime: value } as SessionRuntimeEntry) : undefined
+            )
+      } catch {
+        timeline.isCompacting = false
+        publishTimeline(sessionId, 'Session context compaction failed.')
+        return { status: 'rejected', message: 'Pi couldn’t open this Session.' }
+      }
+
+      if (!runtime?.runtime.compact || runtime.runtime.canCompact?.() === false) {
+        timeline.isCompacting = false
+        publishTimeline(sessionId)
+        return {
+          status: 'rejected',
+          message: runtime?.runtime.compact
+            ? 'More Session context is needed before it can be compacted.'
+            : 'This Session does not support manual compaction.',
+        }
+      }
+
+      try {
+        await runtime.runtime.compact()
+        timeline.isCompacting = false
+        publishTimeline(sessionId, 'Session context compacted.')
+        return { status: 'compacted' }
+      } catch (error) {
+        timeline.isCompacting = false
+        publishTimeline(sessionId, 'Session context compaction failed.')
+        return {
+          status: 'rejected',
+          message: error instanceof Error ? error.message : 'Context could not be compacted.',
+        }
+      }
+    } finally {
+      try {
+        await releaseCompactionLease(sessionId)
+      } catch (error) {
+        console.error('Unable to release a Session context compaction lease.', error)
+      }
+    }
+  }
+
+  async function compact(sessionId: SessionId): Promise<SessionContextCompactionResult> {
+    const previous = submissionQueuesBySessionId.get(sessionId) ?? Promise.resolve()
+    let release!: () => void
+    const current = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const queued = previous.then(() => current)
+
+    submissionQueuesBySessionId.set(sessionId, queued)
+
+    try {
+      await previous
+      return await activationGate.run(sessionId, () => compactImmediately(sessionId))
+    } finally {
+      release()
+      if (submissionQueuesBySessionId.get(sessionId) === queued) {
+        submissionQueuesBySessionId.delete(sessionId)
+      }
+    }
+  }
+
   async function stop(sessionId: SessionId): Promise<SessionRunStopResult> {
     const timeline = timelineBySessionId.get(sessionId)
 
@@ -1356,6 +1469,7 @@ export function createPiSessionRuntimeRegistry({
     },
     submit,
     stop,
+    compact,
     async removeQueuedFollowUp(sessionId, followUpId) {
       await getRuntime(sessionId)
       return removeQueuedFollowUp(sessionId, followUpId)

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -715,3 +715,176 @@ test('publishes a failed transcript run without a parallel failure stream', asyn
   assert.equal(snapshot.runFailureReason, 'failed')
   assert.equal(snapshot.isWorking, false)
 })
+
+test('queues an Agent Run until Session context compaction completes', async () => {
+  let finishCompaction: () => void = () => {}
+  const compacted = new Promise<void>((resolve) => {
+    finishCompaction = resolve
+  })
+  let prompted = false
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt(_text, options) {
+      prompted = true
+      options.preflightResult(true)
+    },
+    compact() {
+      return compacted
+    },
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('compacting-session')
+
+  const compaction = registry.compact(id)
+  await Promise.resolve()
+  await Promise.resolve()
+
+  assert.equal((await registry.getTranscript(id)).isCompacting, true)
+  const submission = registry.submit({ sessionId: id, text: 'start work', delivery: 'steer' })
+
+  assert.equal(prompted, false)
+
+  finishCompaction()
+  assert.deepEqual(await compaction, { status: 'compacted' })
+  assert.deepEqual(await submission, { status: 'accepted', delivery: 'prompt' })
+  assert.equal((await registry.getTranscript(id)).isCompacting, false)
+})
+
+test('holds a Session context compaction lease until compaction completes', async () => {
+  let finishCompaction: () => void = () => {}
+  const compacted = new Promise<void>((resolve) => {
+    finishCompaction = resolve
+  })
+  let leaseHeld = false
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    compact() {
+      return compacted
+    },
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    acquireCompactionLease: () => {
+      leaseHeld = true
+      return true
+    },
+    releaseCompactionLease: () => {
+      leaseHeld = false
+    },
+  })
+  const id = sessionId('compaction-lease-session')
+
+  const compaction = registry.compact(id)
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+  assert.equal(leaseHeld, true)
+
+  finishCompaction()
+
+  assert.deepEqual(await compaction, { status: 'compacted' })
+  assert.equal(leaseHeld, false)
+})
+
+test('queues a Model change until Session context compaction completes', async () => {
+  let finishCompaction: () => void = () => {}
+  const compacted = new Promise<void>((resolve) => {
+    finishCompaction = resolve
+  })
+  let model = { provider: 'provider', id: 'initial' }
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    compact() {
+      return compacted
+    },
+    async getConfiguration() {
+      return {
+        models: [],
+        model,
+        effort: 'off',
+        supportedEfforts: ['off'],
+      }
+    },
+    async setConfigurationModel(nextModel) {
+      model = nextModel
+    },
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('compaction-configuration-session')
+
+  const compaction = registry.compact(id)
+  await Promise.resolve()
+  await Promise.resolve()
+
+  const configuration = registry.setConfigurationModel(id, { provider: 'provider', id: 'selected' })
+  await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+  assert.deepEqual(model, { provider: 'provider', id: 'initial' })
+
+  finishCompaction()
+
+  assert.deepEqual(await compaction, { status: 'compacted' })
+  assert.equal((await configuration).status, 'applied')
+  assert.deepEqual(model, { provider: 'provider', id: 'selected' })
+})
+
+test('does not compact while a submission is acquiring its Session run lease', async () => {
+  let authorizeSubmission: () => void = () => {}
+  const submissionAuthorized = new Promise<void>((resolve) => {
+    authorizeSubmission = resolve
+  })
+  let prompted = false
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt(_text, options) {
+      prompted = true
+      options.preflightResult(true)
+    },
+    async compact() {},
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    canSubmit: async () => {
+      await submissionAuthorized
+      return true
+    },
+    createSession: async () => runtime,
+  })
+  const id = sessionId('submission-lease-session')
+
+  const submission = registry.submit({ sessionId: id, text: 'start work', delivery: 'steer' })
+  const compaction = registry.compact(id)
+
+  authorizeSubmission()
+
+  assert.deepEqual(await submission, { status: 'accepted', delivery: 'prompt' })
+  assert.equal(prompted, true)
+  assert.deepEqual(await compaction, {
+    status: 'rejected',
+    message: 'Wait for the Agent Run to finish before compacting.',
+  })
+})

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -148,6 +148,9 @@ const workstreamKnowledgeBridge: WorkstreamKnowledgeBridge = {
 }
 
 const composerBridge: ComposerBridge = {
+  compact(sessionId) {
+    return ipcRenderer.invoke(composerIpcChannels.compact, { sessionId })
+  },
   submit(submission) {
     return ipcRenderer.invoke(composerIpcChannels.submit, submission) as Promise<SessionMessageSubmissionResult>
   },

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -629,7 +629,7 @@ test('restores Composer focus after the creation dialog restores its trigger', a
   assert.equal(browser.document.activeElement, view.getByRole('textbox'))
 })
 
-test('prevents Agent Run acceptance while a Model change is pending', async () => {
+test('prevents Session actions while a Model change is pending', async () => {
   let resolveModelChange: () => void = () => {}
   const configuration = sessionConfigurationSnapshot()
   const bridge: SessionConfigurationBridge = {
@@ -657,6 +657,7 @@ test('prevents Agent Run acceptance while a Model change is pending', async () =
       session={session}
       draft="Send after configuration"
       isWorking={false}
+      contextUsage={{ tokens: 48_000, contextWindow: 200_000, percent: 24, canCompact: true }}
       onActivate={() => {}}
       onDraftChange={() => {}}
       submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
@@ -675,6 +676,7 @@ test('prevents Agent Run acceptance while a Model change is pending', async () =
     )
   )
   assert.equal((view.getByRole('button', { name: 'Send message' }) as HTMLButtonElement).disabled, true)
+  assert.equal((view.getByRole('button', { name: 'Compact context' }) as HTMLButtonElement).disabled, true)
 
   act(() => resolveModelChange())
 
@@ -706,6 +708,63 @@ test('shows the current context window usage in the Composer action cluster', ()
   assert.equal(contextWindow.getAttribute('aria-valuetext'), '48k used of 200k tokens; 152k left')
   assert.equal(contextWindow.getAttribute('title'), '48k used of 200k tokens; 152k left')
   assert.equal(contextWindow.getAttribute('data-level'), 'nominal')
+})
+
+test('hides context compaction until the Session has enough context', () => {
+  const view = renderInBrowser(
+    <Composer
+      session={session}
+      draft=""
+      isWorking={false}
+      contextUsage={{ tokens: 2_000, contextWindow: 200_000, percent: 1, canCompact: false }}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+    />
+  )
+
+  assert.equal(view.queryByRole('button', { name: 'Compact context' }), null)
+})
+
+test('disables the Composer while Session context is compacting', async () => {
+  const configuration = sessionConfigurationSnapshot()
+  const view = renderInBrowser(
+    <Composer
+      session={session}
+      draft="Keep this draft"
+      isWorking={false}
+      isCompacting
+      contextUsage={{ tokens: 48_000, contextWindow: 200_000, percent: 24 }}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+      sessionConfiguration={{
+        async getSnapshot() {
+          return configuration
+        },
+        async setModel() {
+          return { status: 'applied', snapshot: configuration }
+        },
+        async setEffort() {
+          return { status: 'applied', snapshot: configuration }
+        },
+        async dismissWarning() {
+          return configuration
+        },
+        subscribe() {
+          return () => {}
+        },
+      }}
+    />
+  )
+
+  assert.equal(
+    view.getByRole('textbox', { name: 'Message for First Session' }).getAttribute('contenteditable'),
+    'false'
+  )
+  assert.equal(view.getByRole('button', { name: 'Send message' }).hasAttribute('disabled'), true)
+  assert.equal(((await view.findByRole('combobox', { name: 'Model' })) as HTMLButtonElement).disabled, true)
+  assert.equal(view.queryByRole('button', { name: 'Compact context' }), null)
 })
 
 test('grows the context window fill in place so increments animate', () => {
@@ -801,7 +860,7 @@ test('escalates the context window usage level as the window fills', () => {
   }
 })
 
-test('explains when context usage is recalculating after compaction', () => {
+test('hides context usage while Pi recalculates it after compaction', () => {
   const view = renderInBrowser(
     <Composer
       session={session}
@@ -814,10 +873,7 @@ test('explains when context usage is recalculating after compaction', () => {
     />
   )
 
-  const updating = view.getByRole('status')
-
-  assert.equal(updating.querySelector('[data-slot="context-usage-fill"]'), null)
-  assert.equal(updating.getAttribute('title'), 'Context window usage is updating after compaction')
+  assert.equal(view.queryByRole('status'), null)
   assert.equal(view.queryByRole('progressbar', { name: 'Context window' }), null)
 })
 

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -1,5 +1,6 @@
-import { Send, Square } from 'lucide-react'
+import { Minimize2, Send, Square } from 'lucide-react'
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Button } from '@/components/ui-kit/button'
 import { Combobox, ComboboxDescription, ComboboxLabel, ComboboxOption } from '@/components/ui-kit/combobox'
 import { Listbox, ListboxOption } from '@/components/ui-kit/listbox'
 import type { ComposerBridge, SessionMessageDelivery } from '@/src/composer'
@@ -22,6 +23,7 @@ type ComposerProperties = Readonly<{
   draft: string
   focusRequest?: number
   isWorking: boolean
+  isCompacting?: boolean
   contextUsage?: SessionContextUsage
   onActivate: () => void
   onDraftChange: (draft: string) => void
@@ -36,6 +38,7 @@ export function Composer({
   draft,
   focusRequest,
   isWorking,
+  isCompacting = false,
   contextUsage,
   onActivate,
   onDraftChange,
@@ -55,7 +58,9 @@ export function Composer({
   const [pendingConfiguration, setPendingConfiguration] = useState<ReadonlySet<'model' | 'effort'>>(() => new Set())
   const [configurationError, setConfigurationError] = useState<string>()
   const [stopping, setStopping] = useState(false)
+  const [compacting, setCompacting] = useState(false)
   const [stopError, setStopError] = useState<string>()
+  const [compactError, setCompactError] = useState<string>()
   const [availableSkills, setAvailableSkills] = useState<readonly SessionSkill[]>([])
   const [skillsError, setSkillsError] = useState<string>()
   const configurationPending = pendingConfiguration.size > 0
@@ -152,14 +157,20 @@ export function Composer({
   const empty = draft.trim().length === 0
   const sendLabel = isWorking ? 'Steer session' : 'Send message'
   const { awaiting, error, status } = submissionState
-  const configurationDisabled = isWorking || awaiting
-  const agentRunDisabled = awaiting || configurationPending
+  const configurationDisabled = isWorking || awaiting || compacting || isCompacting
+  const agentRunDisabled = awaiting || configurationPending || compacting || isCompacting
   const modelConfigurationRequired = configuration !== undefined && configuration.models.length === 0
   const configurationMessage = modelConfigurationRequired
     ? 'No Model is available. Install Pi CLI, sign in to a provider, then restart Railyard.'
     : undefined
   const errorMessage =
-    error || stopError || configurationError || skillsError || configurationMessage || configuration?.persistenceWarning
+    error ||
+    stopError ||
+    compactError ||
+    configurationError ||
+    skillsError ||
+    configurationMessage ||
+    configuration?.persistenceWarning
   const statusMessage = errorMessage || status
 
   const changeConfiguration = useCallback(
@@ -207,6 +218,20 @@ export function Composer({
       ),
     [changeConfiguration, session.id]
   )
+
+  const compact = useCallback(async () => {
+    if (compacting || configurationPending || isCompacting || isWorking || !contextUsage?.canCompact) return
+    setCompacting(true)
+    setCompactError(undefined)
+    try {
+      const result = await window.piWorkspace.composer.compact(session.id)
+      if (result.status === 'rejected') setCompactError(result.message ?? 'Context could not be compacted.')
+    } catch {
+      setCompactError('Context could not be compacted.')
+    } finally {
+      setCompacting(false)
+    }
+  }, [compacting, configurationPending, contextUsage?.canCompact, isCompacting, isWorking, session.id])
 
   const stop = useCallback(async () => {
     if (!stopRun || stopping) return
@@ -260,6 +285,22 @@ export function Composer({
           )}
           <div className="ml-auto flex items-end gap-1">
             {contextUsage && <ContextWindowUsage usage={contextUsage} />}
+            {contextUsage?.canCompact && !isWorking && !isCompacting && (
+              <Button
+                plain
+                type="button"
+                aria-label="Compact context"
+                className="size-11 !items-center !justify-center !p-0 text-composer-muted-foreground data-hover:!bg-composer-interaction data-hover:!text-content-foreground"
+                disabled={compacting || configurationPending}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  void compact()
+                }}
+                title={compacting ? 'Compacting context…' : 'Compact context'}
+              >
+                <Minimize2 aria-hidden="true" className={compacting ? 'size-4 animate-pulse' : 'size-4'} />
+              </Button>
+            )}
             {isWorking && stopRun && (
               <button
                 type="button"
@@ -277,10 +318,11 @@ export function Composer({
                 </span>
               </button>
             )}
-            <button
+            <Button
+              plain
               type="button"
               aria-label={sendLabel}
-              className="flex size-11 items-end justify-center rounded-lg text-composer-action-foreground outline-none transition-opacity motion-reduce:transition-none enabled:cursor-pointer focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-composer-background disabled:cursor-not-allowed disabled:opacity-35"
+              className="size-11 !items-center !justify-center !p-0 !text-composer-action-foreground data-disabled:opacity-35"
               disabled={empty || agentRunDisabled || modelConfigurationRequired}
               onClick={(event) => {
                 event.stopPropagation()
@@ -293,7 +335,7 @@ export function Composer({
               <span className="flex size-9 items-center justify-center rounded-lg bg-composer-action-background">
                 <Send aria-hidden="true" className="size-4" strokeWidth={2.25} />
               </span>
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -336,26 +378,7 @@ function contextUsageLevel(percent: number): ContextUsageLevel {
 function ContextWindowUsage({ usage }: ContextWindowUsageProperties) {
   const contextWindow = formatTokenCount(usage.contextWindow)
 
-  if (usage.tokens === null || usage.percent === null) {
-    return (
-      <div className="flex h-11 items-end pb-3">
-        <span
-          className="context-usage"
-          data-level="nominal"
-          role="status"
-          title="Context window usage is updating after compaction"
-        >
-          <span aria-hidden="true" className="context-usage-track" />
-          <span aria-hidden="true" className="context-usage-value">
-            —
-          </span>
-          <span className="sr-only">
-            Context window usage is updating after compaction, and is unavailable until Pi finishes its next response.
-          </span>
-        </span>
-      </div>
-    )
-  }
+  if (usage.tokens === null || usage.percent === null) return null
 
   // The runtime reports an unrounded float. The bar is drawn from it directly so
   // sub-percent growth still moves;

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -132,6 +132,7 @@ export function SessionContainer({
       <SessionMessages
         sessionId={session.id}
         isWorking={isWorking}
+        isCompacting={transcriptState.snapshot?.isCompacting ?? false}
         transcript={transcriptState.snapshot}
         timelineAnnouncement={transcriptState.announcement}
         timelineError={transcriptState.error}
@@ -173,6 +174,7 @@ export function SessionContainer({
           draft={draft}
           focusRequest={composerFocusRequest}
           isWorking={isWorking}
+          isCompacting={transcriptState.snapshot?.isCompacting ?? false}
           contextUsage={transcriptState.snapshot?.contextUsage}
           onActivate={onActivate}
           onDraftChange={onDraftChange}

--- a/src/renderer/components/session-messages.test.tsx
+++ b/src/renderer/components/session-messages.test.tsx
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import { browser } from '@/src/renderer/test-dom'
 import { cleanup, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { sessionId } from '@/src/domain/session'
 import type { SessionTranscriptSnapshot } from '@/src/session-transcript'
 import { SessionMessages } from './session-messages'
@@ -13,6 +14,49 @@ const id = sessionId('session-a')
 function transcript(entries: SessionTranscriptSnapshot['entries']): SessionTranscriptSnapshot {
   return { sessionId: id, revision: 1, isWorking: false, runs: [], entries }
 }
+
+test('shows a visible status while Session context is compacting', () => {
+  const view = render(<SessionMessages sessionId={id} isWorking={false} isCompacting transcript={transcript([])} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+
+  assert.equal(view.getByRole('status').textContent, 'Pi is compacting this Session…')
+})
+
+test('renders a compaction summary as a collapsed Markdown disclosure', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking={false}
+      transcript={{
+        ...transcript([]),
+        entries: [
+          {
+            type: 'compaction',
+            compaction: {
+              type: 'context-compaction',
+              id: 'compaction-1',
+              summary: '## Goal\nPreserve the **current implementation plan**.',
+              timestamp: 1,
+            },
+          },
+        ],
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  const disclosure = view.getByText('Context compacted').closest('details')
+  assert.ok(disclosure)
+  assert.equal(disclosure.open, false)
+
+  await user.click(view.getByText('Context compacted'))
+
+  assert.equal(disclosure.open, true)
+  assert.ok(await view.findByRole('heading', { name: 'Goal' }))
+  assert.equal(view.getByText('current implementation plan').tagName, 'STRONG')
+})
 
 test('renders duplicate message text in canonical entry order', () => {
   const view = render(

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -1,15 +1,16 @@
-import { LoaderCircle } from 'lucide-react'
+import { FoldHorizontal, LoaderCircle } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui-kit/button'
 import type { SessionId } from '@/src/domain/session'
 import { AgentActivityCard } from '@/src/renderer/components/agent-activity-card'
 import { SkillMentionText } from '@/src/renderer/components/skill-mention-text'
-import type { AgentActivity } from '@/src/session-timeline'
+import type { AgentActivity, ContextCompaction } from '@/src/session-timeline'
 import type { SessionTranscriptMessage, SessionTranscriptSnapshot } from '@/src/session-transcript'
 
 type SessionMessagesProperties = Readonly<{
   sessionId: SessionId
   isWorking: boolean
+  isCompacting?: boolean
   transcript?: SessionTranscriptSnapshot
   timelineAnnouncement?: string
   timelineError?: string
@@ -19,6 +20,7 @@ type SessionMessagesProperties = Readonly<{
 type TranscriptEntry =
   | Readonly<{ type: 'message'; key: string; message: SessionTranscriptMessage }>
   | Readonly<{ type: 'activity'; key: string; activity: AgentActivity }>
+  | Readonly<{ type: 'compaction'; key: string; compaction: ContextCompaction }>
 
 const bottomThreshold = 24
 const MarkdownMessage = lazy(async () =>
@@ -28,6 +30,7 @@ const MarkdownMessage = lazy(async () =>
 export function SessionMessages({
   sessionId,
   isWorking,
+  isCompacting,
   transcript: canonicalTranscript,
   timelineAnnouncement,
   timelineError,
@@ -42,7 +45,9 @@ export function SessionMessages({
       canonicalTranscript?.entries.map((entry) =>
         entry.type === 'activity'
           ? { type: 'activity', key: `activity-${entry.activity.id}`, activity: entry.activity }
-          : { type: 'message', key: `message-${entry.message.id}`, message: entry.message }
+          : entry.type === 'compaction'
+            ? { type: 'compaction', key: `compaction-${entry.compaction.id}`, compaction: entry.compaction }
+            : { type: 'message', key: `message-${entry.message.id}`, message: entry.message }
       ) ?? [],
     [canonicalTranscript]
   )
@@ -66,7 +71,7 @@ export function SessionMessages({
     scrollContainerRef,
     messageListRef,
     isLoading,
-    contentVersion: `${revision}:${isWorking ? 'working' : 'idle'}:${runFailureReason ?? 'ready'}`,
+    contentVersion: `${revision}:${isWorking ? 'working' : 'idle'}:${isCompacting ? 'compacting' : 'ready'}:${runFailureReason ?? 'ready'}`,
   })
 
   const requestExternalLink = useCallback((url: string) => {
@@ -105,6 +110,12 @@ export function SessionMessages({
                   isWorking={isWorking}
                   onOpenExternalLink={requestExternalLink}
                 />
+              ) : entry.type === 'compaction' ? (
+                <SessionCompactionSummary
+                  key={entry.key}
+                  compaction={entry.compaction}
+                  onOpenExternalLink={requestExternalLink}
+                />
               ) : (
                 <AgentActivityCard
                   key={entry.key}
@@ -113,6 +124,7 @@ export function SessionMessages({
                 />
               )
             )}
+          {isCompacting && <SessionActivityIndicator label="Pi is compacting this Session…" />}
           {!isLoading && runFailureReason ? (
             <SessionRunFailure reason={runFailureReason} />
           ) : !isLoading && isWorking ? (
@@ -372,11 +384,32 @@ function SessionMessageRow({
   )
 }
 
-function SessionActivityIndicator() {
+function SessionCompactionSummary({
+  compaction,
+  onOpenExternalLink,
+}: Readonly<{ compaction: ContextCompaction; onOpenExternalLink: (url: string) => void }>) {
+  return (
+    <details className="group rounded-xl border border-content-border bg-content-subtle-background px-4 py-3 text-content-foreground">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-xs/5 font-medium text-session-message-status-foreground outline-none focus-visible:ring-2 focus-visible:ring-focus-ring">
+        <FoldHorizontal aria-hidden="true" className="size-3.5 shrink-0" />
+        <span>Context compacted</span>
+        <span className="ml-auto font-normal text-content-muted-foreground group-open:hidden">View summary</span>
+        <span className="ml-auto hidden font-normal text-content-muted-foreground group-open:inline">Hide summary</span>
+      </summary>
+      <div className="mt-3 border-t border-content-border pt-3 text-sm/6">
+        <Suspense fallback={<p className="text-content-muted-foreground">Loading summary…</p>}>
+          <MarkdownMessage source={compaction.summary} streaming={false} onOpenExternalLink={onOpenExternalLink} />
+        </Suspense>
+      </div>
+    </details>
+  )
+}
+
+function SessionActivityIndicator({ label = 'Pi is working' }: Readonly<{ label?: string }>) {
   return (
     <div className="flex items-center gap-2 text-xs/5 text-session-message-status-foreground" role="status">
       <LoaderCircle aria-hidden="true" className="size-3.5 animate-spin motion-reduce:animate-none" />
-      <span>Pi is working</span>
+      <span>{label}</span>
     </div>
   )
 }

--- a/src/session-timeline.ts
+++ b/src/session-timeline.ts
@@ -84,7 +84,14 @@ export type AgentActivity = Readonly<{
   completedAt?: number
 }>
 
-export type SessionTimelineEntry = ConversationEntry | AgentActivity
+export type ContextCompaction = Readonly<{
+  type: 'context-compaction'
+  id: string
+  summary: string
+  timestamp: number
+}>
+
+export type SessionTimelineEntry = ConversationEntry | AgentActivity | ContextCompaction
 
 export type AgentRun = Readonly<{
   id: string

--- a/src/session-transcript.ts
+++ b/src/session-transcript.ts
@@ -4,7 +4,13 @@ import type { SessionSkillMention } from '@/src/session-skills'
 
 const allowedExternalUrlProtocols = new Set(['http:', 'https:', 'mailto:'])
 export const maximumExternalUrlLength = 8_192
-import type { AgentActivity, AgentRun, AgentActivityDetails, SessionWorkingStateSnapshot } from '@/src/session-timeline'
+import type {
+  AgentActivity,
+  AgentRun,
+  AgentActivityDetails,
+  ContextCompaction,
+  SessionWorkingStateSnapshot,
+} from '@/src/session-timeline'
 
 export function isAllowedExternalUrl(value: unknown): value is string {
   if (typeof value !== 'string' || value.length > maximumExternalUrlLength) return false
@@ -29,17 +35,20 @@ export type SessionTranscriptMessage = Readonly<{
 export type SessionTranscriptEntry =
   | Readonly<{ type: 'message'; message: SessionTranscriptMessage }>
   | Readonly<{ type: 'activity'; activity: AgentActivity }>
+  | Readonly<{ type: 'compaction'; compaction: ContextCompaction }>
 
 export type SessionContextUsage = Readonly<{
   tokens: number | null
   contextWindow: number
   percent: number | null
+  canCompact?: boolean
 }>
 
 export type SessionTranscriptSnapshot = Readonly<{
   sessionId: SessionId
   revision: number
   isWorking: boolean
+  isCompacting?: boolean
   contextUsage?: SessionContextUsage
   runs: readonly AgentRun[]
   entries: readonly SessionTranscriptEntry[]


### PR DESCRIPTION
## Summary

- add a Composer action for manually compacting eligible Session context
- retain and render compaction summaries in the Session transcript
- serialize compaction with Agent Runs and configuration changes
- hold a durable compaction lease so active compaction blocks archival and recovers safely after restart
- derive compaction eligibility from Pi's actual history cut-point behavior

## Related issue

None.

## Validation

- `bun run check` — passed (525 tests)
- `bun run security:scan` — passed
- Focused compaction runtime, lifecycle, eligibility, and Composer tests are included.

- [x] `bun run check`
- [x] Focused tests or manual validation are described above.
- [x] `bun run security:scan` was run, or this change does not affect dependencies or security-sensitive behavior.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed.
- [x] I have read and will follow the Code of Conduct.

No new dependencies, copied material, generated assets, or license implications.
