### PR TITLE
chore: prepare Railyard 1.0.0-beta.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "railyard",
-  "version": "0.6.0-beta.1",
+  "version": "1.0.0-beta.1",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.14",

--- a/scripts/release-note-markdown.test.ts
+++ b/scripts/release-note-markdown.test.ts
@@ -7,9 +7,6 @@ test('formats the latest bundled Release Note for a GitHub Release', () => {
   const markdown = formatReleaseNoteAsMarkdown(bundledReleaseNotes[0]!)
 
   assert.match(markdown, new RegExp(`^${bundledReleaseNotes[0]!.summary}`, 'm'))
-  assert.match(markdown, /^## New$/m)
-  assert.match(
-    markdown,
-    /^- Install Pi Workspace on Windows 11 x64 and work with Repositories whose paths include drive letters and spaces\./m
-  )
+  assert.match(markdown, /^## Improved$/m)
+  assert.match(markdown, /^- Pi Workspace is now Railyard, with a renamed app and packages,/m)
 })

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -20,6 +20,18 @@ export function isSemanticVersion(version: string): boolean {
 
 export const bundledReleaseNotes: readonly ReleaseNote[] = [
   {
+    version: '1.0.0-beta.1',
+    releaseDate: '2026-07-25',
+    summary: 'This beta establishes the foundation for Railyard’s next stage of development.',
+    changes: {
+      new: [],
+      improved: [
+        'Pi Workspace is now Railyard, with a renamed app and packages, new native icons, Space Grotesk and IBM Plex Mono typography, and refreshed light and dark visuals; first launch copies existing Workspaces, Sessions, and appearance settings into the renamed app.',
+      ],
+      fixed: [],
+    },
+  },
+  {
     version: '0.6.0-beta.1',
     releaseDate: '2026-07-25',
     summary:


### PR DESCRIPTION
## Summary
- bump Railyard from `0.6.0-beta.1` to `1.0.0-beta.1`
- prepend the bundled Release Note for the Railyard rebrand and legacy application-data migration
- update the focused GitHub Release markdown test

The major version reflects the incompatible package, executable, and application identity changes, while the first-launch migration preserves existing application data.

## Release baseline
- tag: `v0.6.0-beta.1`
- commit: `fee0e05fdbfd70d6b1f510bb30962b1d56908b9c`
- release date: `2026-07-25`

## Validation
- `bun run release:validate`
- `bun test` (518 passing)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`