### PR TITLE
fix: render Linux app description correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
       ],
       "artifactName": "railyard-${version}-${arch}.${ext}",
       "category": "Development",
-      "description": "Railyard is a local desktop app for working with Pi across Git repositories and long-running goals.\n\nOrganize related repositories into Workspaces, use Quick Sessions for focused tasks, and carry shared context across long-running Workstreams. Plan with Brainstorm Sessions, then make and validate changes with Implement Sessions.\n\nApplication data is stored locally. Railyard uses Pi's existing model-provider configuration; it does not provide a separate account or provider login.",
+      "description": "Railyard is a local desktop app for working with Pi across Git repositories and long-running goals. Organize related repositories into Workspaces, use Quick Sessions for focused tasks, and carry shared context across long-running Workstreams. Plan with Brainstorm Sessions, then make and validate changes with Implement Sessions. Application data is stored locally. Railyard uses Pi's existing model-provider configuration; it does not provide a separate account or provider login.",
       "executableName": "railyard",
       "icon": "assets/icons",
       "maintainer": "Railyard contributors <7268075+OfficialOzzy@users.noreply.github.com>",


### PR DESCRIPTION
## Summary

Removes paragraph breaks from the Debian/Linux package description so GNOME Software does not render them as `��`.

## Related issue

None.

## Validation

- `python3 -m json.tool package.json`
- `git diff --check`
- `bun` checks could not run because Bun is not installed in the environment.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused validation.
- [x] No documentation, dependency, security, or licensing changes are needed.