### PR TITLE
feat: add Session action cards and isolate development data

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,22 +167,22 @@ Unknown scenario names use `startup`. Use a 1200 by 800 browser viewport as the 
 
 ### Development commands
 
-| Command                    | Description                                                      |
-| -------------------------- | ---------------------------------------------------------------- |
-| `bun run build`            | Build the production Electron application into `dist/`.          |
-| `bun run check`            | Run the complete local and CI quality gate.                      |
-| `bun run demo`             | Open the isolated product screenshot demo.                       |
-| `bun run dev`              | Run the development application.                                 |
-| `bun run start`            | Build and launch the production application.                     |
-| `bun run test`             | Run the test suite.                                              |
-| `bun run lint`             | Lint the source files.                                           |
-| `bun run format:check`     | Check formatting.                                                |
-| `bun run package:linux`    | Build a local Debian package for release troubleshooting.        |
-| `bun run package:mac`      | Build a local universal macOS DMG for release troubleshooting.   |
-| `bun run package:win`      | Build a local Windows x64 installer for release troubleshooting. |
-| `bun run release:validate` | Validate the beta version and latest bundled Release Note.       |
-| `bun run security:scan`    | Scan Git history and dependencies for known risks.               |
-| `bun run typecheck`        | Check TypeScript types.                                          |
+| Command                    | Description                                                            |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `bun run build`            | Build the production Electron application into `dist/`.                |
+| `bun run check`            | Run the complete local and CI quality gate.                            |
+| `bun run demo`             | Open the isolated product screenshot demo.                             |
+| `bun run dev`              | Run the development application with data isolated to its Git branch.  |
+| `bun run start`            | Build and launch the production application with normal Railyard data. |
+| `bun run test`             | Run the test suite.                                                    |
+| `bun run lint`             | Lint the source files.                                                 |
+| `bun run format:check`     | Check formatting.                                                      |
+| `bun run package:linux`    | Build a local Debian package for release troubleshooting.              |
+| `bun run package:mac`      | Build a local universal macOS DMG for release troubleshooting.         |
+| `bun run package:win`      | Build a local Windows x64 installer for release troubleshooting.       |
+| `bun run release:validate` | Validate the beta version and latest bundled Release Note.             |
+| `bun run security:scan`    | Scan Git history and dependencies for known risks.                     |
+| `bun run typecheck`        | Check TypeScript types.                                                |
 
 ## License
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,8 +1,23 @@
 import chokidar from 'chokidar'
 import { createRequire } from 'node:module'
+import { basename } from 'node:path'
 import { createServer } from 'vite'
 
 const rootDirectory = process.cwd()
+
+function resolveDevelopmentSpace() {
+  const result = Bun.spawnSync({
+    cmd: ['git', 'branch', '--show-current'],
+    cwd: rootDirectory,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  })
+  const branch = new TextDecoder().decode(result.stdout).trim()
+
+  return branch || basename(rootDirectory)
+}
+
+const developmentSpace = resolveDevelopmentSpace()
 const require = createRequire(import.meta.url)
 const electronExecutable = require('electron')
 
@@ -56,7 +71,7 @@ function startElectron() {
   const nextElectronProcess = Bun.spawn({
     cmd: [electronExecutable, '.'],
     cwd: rootDirectory,
-    env: { ...process.env, VITE_DEV_SERVER_URL: rendererUrl },
+    env: { ...process.env, RAILYARD_DEV_SPACE: developmentSpace, VITE_DEV_SERVER_URL: rendererUrl },
     stdout: 'inherit',
     stderr: 'inherit',
   })
@@ -139,5 +154,6 @@ if (!rendererUrl) {
   throw new Error('Vite did not provide a local development URL.')
 }
 
+console.log(`Starting Railyard development space: ${developmentSpace}`)
 console.log(`Renderer HMR available at ${rendererUrl}`)
 void rebuildAndRestartMain()

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,6 +1,6 @@
 import type { SessionId } from '@/src/domain/session'
 
-export const sessionMessageDeliveries = ['steer', 'follow-up'] as const
+export const sessionMessageDeliveries = ['steer', 'follow-up', 'action'] as const
 
 export type SessionMessageDelivery = (typeof sessionMessageDeliveries)[number]
 

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -203,6 +203,9 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       async loadActivityDetails(sessionId, activityId) {
         return scenario.activityDetailsBySessionId[sessionId]?.[activityId]
       },
+      async acceptActionCard() {
+        return false
+      },
       async openExternalLink() {},
       subscribe(listener) {
         transcriptListeners.add(listener)

--- a/src/main/activity-records.test.ts
+++ b/src/main/activity-records.test.ts
@@ -121,6 +121,18 @@ test('accepts a steering message record', () => {
   )
 })
 
+test('accepts an action-card status record', () => {
+  assert.equal(
+    isActivityLayerRecord({
+      version: 1,
+      type: 'action-card-status',
+      actionCardId: 'card-1',
+      status: 'accepted',
+    }),
+    true
+  )
+})
+
 test('rejects malformed diagnostic records', () => {
   assert.equal(
     isActivityLayerRecord({

--- a/src/main/activity-records.ts
+++ b/src/main/activity-records.ts
@@ -1,4 +1,5 @@
 import type { QueuedFollowUp, QueuedFollowUpRecord } from '@/src/queued-follow-up'
+import type { SessionActionCard, SessionActionCardStatus } from '@/src/session-action-cards'
 import {
   agentActivityKinds,
   type ActivityArtifact,
@@ -27,8 +28,16 @@ export type ActivityLayerRecord =
       execution: Omit<ToolExecution, 'input'>
     }>
   | Readonly<{ version: 1; type: 'activity-removed'; activityId: string }>
+  | Readonly<{ version: 1; type: 'action-card'; card: SessionActionCard }>
+  | Readonly<{
+      version: 1
+      type: 'action-card-status'
+      actionCardId: string
+      status: Exclude<SessionActionCardStatus, 'available'>
+    }>
   | Readonly<{ version: 1 } & QueuedFollowUpRecord>
   | Readonly<{ version: 1; type: 'steering-message'; text: string; acceptedAt: number }>
+  | Readonly<{ version: 1; type: 'action-message'; text: string; acceptedAt: number }>
   | Readonly<{
       version: 1
       type: 'diagnostic'
@@ -45,9 +54,15 @@ export function isActivityLayerRecord(value: unknown): value is ActivityLayerRec
   if (value.type === 'activity') return isAgentActivity(value.activity)
   if (value.type === 'operation') return isToolExecution(value.execution)
   if (value.type === 'activity-removed') return isNonEmptyString(value.activityId)
+  if (value.type === 'action-card') return isSessionActionCard(value.card)
+  if (value.type === 'action-card-status') {
+    return isNonEmptyString(value.actionCardId) && (value.status === 'accepted' || value.status === 'dismissed')
+  }
   if (value.type === 'queued-follow-up') return isQueuedFollowUp(value.followUp)
   if (value.type === 'queued-follow-up-removed') return isNonEmptyString(value.followUpId)
-  if (value.type === 'steering-message') return typeof value.text === 'string' && isTimestamp(value.acceptedAt)
+  if (value.type === 'steering-message' || value.type === 'action-message') {
+    return typeof value.text === 'string' && isTimestamp(value.acceptedAt)
+  }
   if (value.type === 'diagnostic') {
     return (
       isNonEmptyString(value.runId) &&
@@ -63,6 +78,20 @@ export function isActivityLayerRecord(value: unknown): value is ActivityLayerRec
   }
 
   return false
+}
+
+function isSessionActionCard(value: unknown): value is SessionActionCard {
+  if (!isRecord(value)) return false
+
+  return (
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.sessionId) &&
+    (value.kind === 'start-implement-session' || value.kind === 'prepare-pull-request') &&
+    isNonEmptyString(value.title) &&
+    isNonEmptyString(value.description) &&
+    value.status === 'available' &&
+    isTimestamp(value.createdAt)
+  )
 }
 
 function isQueuedFollowUp(value: unknown): value is QueuedFollowUp {

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -160,11 +160,11 @@ export async function createPiSessionRuntime(
   const suggestAction = defineTool({
     name: 'suggest_action',
     label: 'Suggest action',
-    description: 'Show the user an optional Pi Workspace action card for an allowlisted next step.',
+    description: 'Show the user an optional Railyard action card for an allowlisted next step.',
     promptGuidelines: [
       'Use only when the suggested action follows clearly from the completed work.',
       'Use start-implement-session only in a Brainstorm Session when planning is ready for implementation.',
-      'Use prepare-pull-request only after implementation is ready for the user to review and create a pull request.',
+      'When implementation is ready for user review and a pull request can be created, call suggest_action with prepare-pull-request before completing your response.',
     ],
     parameters: Type.Object({
       kind: Type.Union([Type.Literal('start-implement-session'), Type.Literal('prepare-pull-request')]),

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -14,6 +14,7 @@ import {
   parseSessionRunStopRequest,
 } from '@/src/composer-ipc'
 import { sessionId } from '@/src/domain/session'
+import { parseSessionActionCardToolInput } from '@/src/session-action-cards'
 import { parseSessionSkillsRequest, sessionSkillsIpcChannels } from '@/src/session-skills-ipc'
 import type {
   SessionConfigurationEffort,
@@ -50,6 +51,7 @@ import {
 import { broadcastToTrustedRenderers, handleTrustedIpc } from '@/src/main/trusted-ipc'
 import { isAllowedExternalUrl } from '@/src/session-transcript'
 import {
+  parseActionCardAcceptanceRequest,
   parseSessionTranscriptRequest,
   parseTranscriptActivityDetailsRequest,
   sessionTranscriptIpcChannels,
@@ -155,6 +157,37 @@ export async function createPiSessionRuntime(
     },
   })
 
+  const suggestAction = defineTool({
+    name: 'suggest_action',
+    label: 'Suggest action',
+    description: 'Show the user an optional Pi Workspace action card for an allowlisted next step.',
+    promptGuidelines: [
+      'Use only when the suggested action follows clearly from the completed work.',
+      'Use start-implement-session only in a Brainstorm Session when planning is ready for implementation.',
+      'Use prepare-pull-request only after implementation is ready for the user to review and create a pull request.',
+    ],
+    parameters: Type.Object({
+      kind: Type.Union([Type.Literal('start-implement-session'), Type.Literal('prepare-pull-request')]),
+      title: Type.String({ minLength: 1 }),
+      description: Type.String({ minLength: 1 }),
+    }),
+    async execute(_toolCallId, input) {
+      const action = parseSessionActionCardToolInput(input)
+      if (!action) throw new TypeError('An allowlisted action card with a title and description is required.')
+      if (
+        action.kind === 'start-implement-session' &&
+        (options.kind !== 'managed' || options.policy.mode !== 'brainstorm')
+      ) {
+        throw new TypeError('Only a Brainstorm Session can suggest starting an Implement Session.')
+      }
+
+      runtimeListeners.forEach((listener) =>
+        listener({ type: 'action_card_created', input: action, createdAt: Date.now() })
+      )
+      return { content: [{ type: 'text' as const, text: 'Action card shown to the user.' }], details: {} }
+    },
+  })
+
   const managedTools =
     options.kind === 'managed'
       ? [
@@ -237,7 +270,7 @@ export async function createPiSessionRuntime(
           }),
         ]
       : []
-  const customTools = [startActivity, completeActivity, ...managedTools]
+  const customTools = [startActivity, completeActivity, suggestAction, ...managedTools]
   const managedServices =
     options.kind === 'managed'
       ? await createManagedSessionServices(
@@ -609,6 +642,14 @@ export function initializeComposer(authority: ApplicationAuthority): void {
 
   handleTrustedIpc(sessionTranscriptIpcChannels.openExternalLink, async (_event, value: unknown) => {
     if (isAllowedExternalUrl(value)) await shell.openExternal(value)
+  })
+
+  handleTrustedIpc(sessionTranscriptIpcChannels.acceptActionCard, (_event, value: unknown) => {
+    const request = parseActionCardAcceptanceRequest(value)
+
+    return request
+      ? registry.acceptActionCard(sessionId(request.sessionId), request.actionCardId)
+      : Promise.resolve(false)
   })
 
   handleTrustedIpc(sessionTranscriptIpcChannels.loadActivityDetails, (_event, value: unknown) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ import { initializeWorkstreamKnowledge } from '@/src/main/workstream-knowledge-i
 import { configureTrustedRendererUrl, registerTrustedRendererWindow } from '@/src/main/trusted-ipc'
 import { getThemeWindowBackgroundColor } from '@/src/theme'
 import { migrateLegacyUserData, type UserDataMigrationResult } from '@/src/main/user-data-migration'
+import { resolveUserDataDirectory } from '@/src/main/user-data-directory'
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -37,11 +38,12 @@ protocol.registerSchemesAsPrivileged([
 ])
 
 const applicationDataDirectory = app.getPath('appData')
+const developmentSpace = process.env.RAILYARD_DEV_SPACE
 const legacyUserDataDirectories = [
   join(applicationDataDirectory, 'pi-workspace'),
   join(applicationDataDirectory, 'Pi Workspace'),
 ]
-const userDataDirectory = join(applicationDataDirectory, 'Railyard')
+const userDataDirectory = resolveUserDataDirectory(applicationDataDirectory, developmentSpace)
 
 async function findLegacyUserDataDirectory(): Promise<string> {
   for (const directory of legacyUserDataDirectories) {
@@ -55,17 +57,20 @@ async function findLegacyUserDataDirectory(): Promise<string> {
   return legacyUserDataDirectories[0]!
 }
 
-const legacyUserDataDirectory = await findLegacyUserDataDirectory()
 let legacyUserDataMigrationResult: UserDataMigrationResult = 'not-required'
 let legacyUserDataMigrationError: unknown
 
-try {
-  legacyUserDataMigrationResult = await migrateLegacyUserData({
-    legacyDirectory: legacyUserDataDirectory,
-    userDataDirectory,
-  })
-} catch (error) {
-  legacyUserDataMigrationError = error
+if (!developmentSpace) {
+  const legacyUserDataDirectory = await findLegacyUserDataDirectory()
+
+  try {
+    legacyUserDataMigrationResult = await migrateLegacyUserData({
+      legacyDirectory: legacyUserDataDirectory,
+      userDataDirectory,
+    })
+  } catch (error) {
+    legacyUserDataMigrationError = error
+  }
 }
 
 await mkdir(userDataDirectory, { mode: 0o700, recursive: true })

--- a/src/main/pi-session-runtime-transcript.ts
+++ b/src/main/pi-session-runtime-transcript.ts
@@ -1,6 +1,7 @@
 import type { ActivityLayerRecord } from '@/src/main/activity-records'
 import type { AgentActivity, AgentRun, SessionTimelineEntry, ToolExecution } from '@/src/session-timeline'
 import type { SessionContextUsage, SessionTranscriptMessage } from '@/src/session-transcript'
+import type { SessionActionCard } from '@/src/session-action-cards'
 import type { PiSessionRuntime, PiSessionRuntimeHistory } from './pi-session-runtimes'
 
 export type SessionRuntimeTimeline = {
@@ -9,6 +10,7 @@ export type SessionRuntimeTimeline = {
   contextUsage?: SessionContextUsage
   runs: AgentRun[]
   entries: SessionTimelineEntry[]
+  actionCards: SessionActionCard[]
   messages: Map<string, SessionTranscriptMessage>
   currentActivityId?: string
   activities: Map<string, SessionRuntimeActivity>
@@ -69,21 +71,31 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
   const runs = new Map<string, AgentRun>()
   const activities = new Map<string, AgentActivity>()
   const operations = new Map<string, Omit<ToolExecution, 'input'>>()
+  const actionCards = new Map<string, SessionActionCard>()
+  const actionCardStatuses = new Map<string, SessionActionCard['status']>()
 
   for (const record of history.activityRecords) {
     if (record.type === 'run') runs.set(record.run.id, record.run)
     if (record.type === 'activity') activities.set(record.activity.id, record.activity)
     if (record.type === 'operation') operations.set(record.execution.toolCallId, record.execution)
     if (record.type === 'activity-removed') activities.delete(record.activityId)
+    if (record.type === 'action-card') actionCards.set(record.card.id, record.card)
+    if (record.type === 'action-card-status') actionCardStatuses.set(record.actionCardId, record.status)
   }
 
   timeline.runs = [...runs.values()].sort((left, right) => left.startedAt - right.startedAt)
+  timeline.actionCards = [...actionCards.values()].map((card) => {
+    const status = actionCardStatuses.get(card.id)
 
+    return status ? { ...card, status } : card
+  })
+
+  const hiddenMessageIds = new Set<string>()
   const steeringMessageIds = new Set<string>()
   const unmatchedConversations = [...history.conversations]
 
   for (const record of history.activityRecords) {
-    if (record.type !== 'steering-message') continue
+    if (record.type !== 'steering-message' && record.type !== 'action-message') continue
 
     let index = -1
     let nearestTimestampDifference = Number.POSITIVE_INFINITY
@@ -101,10 +113,18 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
     if (index < 0) continue
 
     const [conversation] = unmatchedConversations.splice(index, 1)
-    if (conversation) steeringMessageIds.add(conversation.id)
+    if (!conversation) continue
+
+    if (record.type === 'action-message') {
+      hiddenMessageIds.add(conversation.id)
+    } else {
+      steeringMessageIds.add(conversation.id)
+    }
   }
 
   for (const conversation of history.conversations) {
+    if (hiddenMessageIds.has(conversation.id)) continue
+
     timeline.messages.set(conversation.id, {
       id: conversation.id,
       role: conversation.role,
@@ -116,12 +136,14 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
     })
   }
 
-  const conversations = history.conversations.map((conversation) => {
-    const ownerIndex = timeline.runs.findLastIndex((run) => run.startedAt <= conversation.timestamp + 1_000)
-    const owner = ownerIndex >= 0 ? timeline.runs[ownerIndex] : undefined
+  const conversations = history.conversations
+    .filter((conversation) => !hiddenMessageIds.has(conversation.id))
+    .map((conversation) => {
+      const ownerIndex = timeline.runs.findLastIndex((run) => run.startedAt <= conversation.timestamp + 1_000)
+      const owner = ownerIndex >= 0 ? timeline.runs[ownerIndex] : undefined
 
-    return owner ? { ...conversation, runId: owner.id } : conversation
-  })
+      return owner ? { ...conversation, runId: owner.id } : conversation
+    })
 
   timeline.runs = timeline.runs.map((run) => {
     const initiatingMessage = conversations.find(

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/src/composer'
 import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
 import type { SessionId } from '@/src/domain/session'
+import type { SessionActionCardToolInput } from '@/src/session-action-cards'
 import {
   projectSessionSkillSelections,
   replaceSessionSkillTokens,
@@ -94,6 +95,7 @@ export type PiSessionRuntimeEvent =
       toolCallId: string
       toolName: 'start_activity' | 'complete_activity'
     }>
+  | Readonly<{ type: 'action_card_created'; input: SessionActionCardToolInput; createdAt: number }>
   | Readonly<{
       type: 'tool_execution_end'
       toolCallId: string
@@ -142,6 +144,7 @@ export interface PiSessionRuntimeRegistry {
   stop(sessionId: SessionId): Promise<SessionRunStopResult>
   removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>
   resumeQueuedFollowUps(sessionId: SessionId): Promise<boolean>
+  acceptActionCard(sessionId: SessionId, actionCardId: string): Promise<boolean>
   renameSession(sessionId: SessionId, title: string): Promise<void>
   getWorkingStateSnapshots(): readonly SessionWorkingStateSnapshot[]
   loadActivityDetails(sessionId: SessionId, activityId: string): Promise<AgentActivityDetails | undefined>
@@ -201,6 +204,7 @@ export function createPiSessionRuntimeRegistry({
         revision: 0,
         runs: [],
         entries: [],
+        actionCards: [],
         messages: new Map(),
         activities: new Map(),
         operations: new Map(),
@@ -235,6 +239,31 @@ export function createPiSessionRuntimeRegistry({
     if (!persisted) return false
 
     queuedFollowUpQueue.remove(sessionId, followUpId)
+    publishTimeline(sessionId)
+    return true
+  }
+
+  function acceptActionCard(sessionId: SessionId, actionCardId: string): boolean {
+    const timeline = getTimeline(sessionId)
+    const cardIndex = timeline.actionCards.findIndex(
+      (card) => card.id === actionCardId && card.sessionId === sessionId && card.status === 'available'
+    )
+
+    if (cardIndex < 0) return false
+
+    const card = timeline.actionCards[cardIndex]
+    if (!card) return false
+
+    const persisted = persistActivityRecord(timeline, {
+      version: 1,
+      type: 'action-card-status',
+      actionCardId,
+      status: 'accepted',
+    })
+
+    if (!persisted) return false
+
+    timeline.actionCards[cardIndex] = { ...card, status: 'accepted' }
     publishTimeline(sessionId)
     return true
   }
@@ -309,6 +338,7 @@ export function createPiSessionRuntimeRegistry({
       contextUsage: timeline.contextUsage,
       runs: timeline.runs,
       entries,
+      actionCards: timeline.actionCards,
       queuedFollowUps: queuedFollowUpQueue.queuedFollowUps(sessionId),
       queuedFollowUpsPaused: queuedFollowUpQueue.isPaused(sessionId),
       runFailureReason:
@@ -674,6 +704,22 @@ export function createPiSessionRuntimeRegistry({
 
     if (event.type === 'activity_control_accepted') {
       acceptActivityControl(sessionId, timeline, event.toolCallId)
+      return
+    }
+
+    if (event.type === 'action_card_created') {
+      const card = {
+        id: createId(),
+        sessionId,
+        kind: event.input.kind,
+        title: event.input.title,
+        description: event.input.description,
+        status: 'available' as const,
+        createdAt: event.createdAt,
+      }
+      timeline.actionCards.push(card)
+      persistActivityRecord(timeline, { version: 1, type: 'action-card', card })
+      publishTimeline(sessionId, 'Action available.')
       return
     }
 
@@ -1091,7 +1137,8 @@ export function createPiSessionRuntimeRegistry({
       }
 
       const wasWorking = runtime.isStreaming
-      const acceptedDelivery: AcceptedSessionMessageDelivery = wasWorking ? submission.delivery : 'prompt'
+      const acceptedDelivery: AcceptedSessionMessageDelivery =
+        submission.delivery === 'action' ? 'action' : wasWorking ? submission.delivery : 'prompt'
       const streamingBehavior = wasWorking ? (submission.delivery === 'follow-up' ? 'followUp' : 'steer') : undefined
 
       return new Promise<SessionMessageSubmissionResult>((resolve) => {
@@ -1123,7 +1170,7 @@ export function createPiSessionRuntimeRegistry({
               timestamp,
             }
 
-            timeline.entries.push(message)
+            if (acceptedDelivery !== 'action') timeline.entries.push(message)
 
             if (!activeRun) {
               const run: AgentRun = {
@@ -1138,18 +1185,20 @@ export function createPiSessionRuntimeRegistry({
               persistActivityRecord(timeline, { version: 1, type: 'run', run })
             }
 
-            acceptRun(
-              submission.sessionId,
-              messageId,
-              projected.text,
-              skillMentions,
-              acceptedDelivery === 'steer' ? 'steer' : undefined
-            )
+            if (acceptedDelivery !== 'action') {
+              acceptRun(
+                submission.sessionId,
+                messageId,
+                projected.text,
+                skillMentions,
+                acceptedDelivery === 'steer' ? 'steer' : undefined
+              )
+            }
 
-            if (acceptedDelivery === 'steer') {
+            if (acceptedDelivery === 'steer' || acceptedDelivery === 'action') {
               persistActivityRecord(timeline, {
                 version: 1,
-                type: 'steering-message',
+                type: acceptedDelivery === 'action' ? 'action-message' : 'steering-message',
                 text: projected.text,
                 acceptedAt: timestamp,
               })
@@ -1367,6 +1416,10 @@ export function createPiSessionRuntimeRegistry({
 
       await dispatchNextQueuedFollowUp(sessionId)
       return true
+    },
+    async acceptActionCard(sessionId, actionCardId) {
+      await getRuntime(sessionId)
+      return acceptActionCard(sessionId, actionCardId)
     },
     async renameSession(sessionId, title) {
       const runtime = await getRuntime(sessionId)

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -46,6 +46,56 @@ test('keeps duplicate messages ordered and updates one streaming identity', asyn
   assert.equal(lastEntry?.type === 'message' ? lastEntry.message.state : undefined, 'complete')
 })
 
+test('persists an accepted action card across a runtime restart', async () => {
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const records: import('@/src/main/activity-records').ActivityLayerRecord[] = []
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    loadHistory() {
+      return { conversations: [], activityRecords: records, finalState: 'completed' }
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const id = sessionId('action-card-session')
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  await registry.getTranscript(id)
+  emit({
+    type: 'action_card_created',
+    input: {
+      kind: 'start-implement-session',
+      title: 'Start implementation',
+      description: 'Create an Implement Session for this plan.',
+    },
+    createdAt: 1,
+  })
+
+  const created = (await registry.getTranscript(id)).actionCards?.[0]
+  assert.equal(created?.status, 'available')
+  assert.ok(created)
+  assert.equal(await registry.acceptActionCard(id, created.id), true)
+  assert.equal(await registry.acceptActionCard(id, created.id), false)
+  assert.equal((await registry.getTranscript(id)).actionCards?.[0]?.status, 'accepted')
+
+  const restartedRegistry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  assert.equal((await restartedRegistry.getTranscript(id)).actionCards?.[0]?.status, 'accepted')
+})
+
 test('persists queued follow-ups until the user resumes the queue', async () => {
   let streaming = true
   let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}

--- a/src/main/user-data-directory.test.ts
+++ b/src/main/user-data-directory.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { basename, dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { resolveUserDataDirectory } from './user-data-directory'
+
+test('uses the normal Railyard user-data directory without a development space', () => {
+  assert.equal(resolveUserDataDirectory('/application-data'), join('/application-data', 'Railyard'))
+})
+
+test('uses a stable, portable directory for a development space', () => {
+  const directory = resolveUserDataDirectory('/application-data', 'feature/session cards')
+
+  assert.equal(dirname(directory), join('/application-data', 'Railyard Development'))
+  assert.match(basename(directory), /^feature-session-cards-[a-f0-9]{16}$/)
+})
+
+test('keeps development spaces separate', () => {
+  const firstDirectory = resolveUserDataDirectory('/application-data', 'action-cards')
+  const secondDirectory = resolveUserDataDirectory('/application-data', 'compact')
+
+  assert.notEqual(firstDirectory, secondDirectory)
+})

--- a/src/main/user-data-directory.ts
+++ b/src/main/user-data-directory.ts
@@ -1,0 +1,25 @@
+import { createHash } from 'node:crypto'
+import { join } from 'node:path'
+
+const productionUserDataDirectoryName = 'Railyard'
+const developmentUserDataDirectoryName = 'Railyard Development'
+
+function developmentSpaceDirectoryName(developmentSpace: string): string {
+  const readableName = developmentSpace
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+  const hash = createHash('sha256').update(developmentSpace).digest('hex').slice(0, 16)
+
+  return `${readableName || 'development'}-${hash}`
+}
+
+export function resolveUserDataDirectory(applicationDataDirectory: string, developmentSpace?: string): string {
+  if (!developmentSpace) return join(applicationDataDirectory, productionUserDataDirectoryName)
+
+  return join(
+    applicationDataDirectory,
+    developmentUserDataDirectoryName,
+    developmentSpaceDirectoryName(developmentSpace)
+  )
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -218,6 +218,12 @@ const sessionTranscriptBridge: SessionTranscriptBridge = {
       AgentActivityDetails | undefined
     >
   },
+  acceptActionCard(sessionId, actionCardId) {
+    return ipcRenderer.invoke(sessionTranscriptIpcChannels.acceptActionCard, {
+      sessionId,
+      actionCardId,
+    }) as Promise<boolean>
+  },
   openExternalLink(url) {
     return ipcRenderer.invoke(sessionTranscriptIpcChannels.openExternalLink, url) as Promise<void>
   },

--- a/src/renderer/components/session-area.tsx
+++ b/src/renderer/components/session-area.tsx
@@ -4,6 +4,7 @@ import type { SessionId } from '@/src/domain/session'
 import type { OwnedSession, WorkstreamLifecycle } from '@/src/domain/workstream'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
+import type { SessionTranscriptBridge } from '@/src/session-transcript'
 import { SessionContainer } from '@/src/renderer/components/session-container'
 
 type SessionAreaProperties = {
@@ -35,6 +36,8 @@ type SessionAreaProperties = {
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
   onToggleSessionPin: (sessionId: SessionId) => void
+  acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
+  onStartImplementSession?: (workstreamId: string) => Promise<void>
 }
 
 export function SessionArea({
@@ -60,6 +63,8 @@ export function SessionArea({
   sessionConfiguration,
   sessionSkills,
   onToggleSessionPin,
+  acceptActionCard = async () => false,
+  onStartImplementSession = async () => {},
 }: SessionAreaProperties) {
   const sessionPaneRefs = useRef(new Map<SessionId, HTMLDivElement>())
 
@@ -115,6 +120,8 @@ export function SessionArea({
             sessionConfiguration={sessionConfiguration}
             sessionSkills={sessionSkills}
             onTogglePin={() => onToggleSessionPin(session.id)}
+            acceptActionCard={acceptActionCard}
+            onStartImplementSession={onStartImplementSession}
           />
         </div>
       ))}

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -4,6 +4,8 @@ import type { ComposerBridge } from '@/src/composer'
 import type { OwnedSession, WorkstreamLifecycle } from '@/src/domain/workstream'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
+import type { SessionActionCard } from '@/src/session-action-cards'
+import type { SessionTranscriptBridge } from '@/src/session-transcript'
 import { Composer } from '@/src/renderer/components/composer'
 import { QueuedFollowUpTray } from '@/src/renderer/components/queued-follow-up-tray'
 import { SessionMessages } from '@/src/renderer/components/session-messages'
@@ -33,6 +35,8 @@ type SessionContainerProperties = {
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
   onTogglePin: () => void
+  acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
+  onStartImplementSession?: (workstreamId: string) => Promise<void>
 }
 
 export function SessionContainer({
@@ -56,6 +60,8 @@ export function SessionContainer({
   sessionConfiguration,
   sessionSkills,
   onTogglePin,
+  acceptActionCard = async () => false,
+  onStartImplementSession = async () => {},
 }: SessionContainerProperties) {
   const headingId = useId()
   const transcriptState = useSessionTranscript(session.id)
@@ -136,6 +142,23 @@ export function SessionContainer({
         timelineAnnouncement={transcriptState.announcement}
         timelineError={transcriptState.error}
         onReloadTimeline={transcriptState.reload}
+        onActionCard={async (card: SessionActionCard, option) => {
+          if (card.kind === 'start-implement-session') {
+            await onStartImplementSession(session.workstreamId)
+            return acceptActionCard(session.id, card.id)
+          }
+
+          const result = await submitMessage({
+            sessionId: session.id,
+            delivery: 'action',
+            text:
+              option === 'ready'
+                ? 'Create a pull request for the completed work. Review the current changes, validation results, and branch status, then prepare a clear title and description for my approval.'
+                : 'Create a draft pull request for the completed work. Review the current changes, validation results, and branch status, then prepare a clear title and description for my approval.',
+          })
+
+          return result.status === 'accepted' && (await acceptActionCard(session.id, card.id))
+        }}
       />
       {!composerUnavailable && transcriptState.snapshot?.queuedFollowUps && (
         <QueuedFollowUpTray

--- a/src/renderer/components/session-messages.test.tsx
+++ b/src/renderer/components/session-messages.test.tsx
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import { browser } from '@/src/renderer/test-dom'
-import { cleanup, render } from '@testing-library/react'
+import { act, cleanup, render } from '@testing-library/react'
 import { sessionId } from '@/src/domain/session'
 import type { SessionTranscriptSnapshot } from '@/src/session-transcript'
 import { SessionMessages } from './session-messages'
@@ -121,6 +121,72 @@ test('labels a steering message separately from an ordinary user message', () =>
 
   assert.ok(view.getByText('Steering', { exact: true }))
   assert.ok(view.getByText('Prioritize transcript delivery.', { exact: true }))
+})
+
+test('hides an accepted action card', () => {
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking={false}
+      transcript={{
+        ...transcript([]),
+        actionCards: [
+          {
+            id: 'card-1',
+            sessionId: id,
+            kind: 'start-implement-session',
+            title: 'Start implementation',
+            description: 'Create an Implement Session.',
+            status: 'accepted',
+            createdAt: 1,
+          },
+        ],
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  assert.equal(view.queryByText('Start implementation', { exact: true }), null)
+})
+
+test('allows retrying an action after its request fails', async () => {
+  let attempts = 0
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking={false}
+      transcript={{
+        ...transcript([]),
+        actionCards: [
+          {
+            id: 'card-1',
+            sessionId: id,
+            kind: 'start-implement-session',
+            title: 'Start implementation',
+            description: 'Create an Implement Session.',
+            status: 'available',
+            createdAt: 1,
+          },
+        ],
+      }}
+      onActionCard={async () => {
+        attempts += 1
+        throw new Error('Session unavailable')
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await act(async () => {
+    await view.getByRole('button', { name: 'Start Implement Session' }).click()
+  })
+  assert.equal(attempts, 1)
+  assert.ok(view.getByText('Could not start this action.', { exact: true }))
+
+  await act(async () => {
+    await view.getByRole('button', { name: 'Start Implement Session' }).click()
+  })
+  assert.equal(attempts, 2)
 })
 
 test('keeps a streaming assistant message in one identity when it completes', () => {

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -2,6 +2,7 @@ import { LoaderCircle } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui-kit/button'
 import type { SessionId } from '@/src/domain/session'
+import type { SessionActionCard } from '@/src/session-action-cards'
 import { AgentActivityCard } from '@/src/renderer/components/agent-activity-card'
 import { SkillMentionText } from '@/src/renderer/components/skill-mention-text'
 import type { AgentActivity } from '@/src/session-timeline'
@@ -14,6 +15,7 @@ type SessionMessagesProperties = Readonly<{
   timelineAnnouncement?: string
   timelineError?: string
   onReloadTimeline?: () => void
+  onActionCard?: (card: SessionActionCard, option?: 'draft' | 'ready') => Promise<boolean>
 }>
 
 type TranscriptEntry =
@@ -32,6 +34,7 @@ export function SessionMessages({
   timelineAnnouncement,
   timelineError,
   onReloadTimeline,
+  onActionCard = async () => false,
 }: SessionMessagesProperties) {
   const isLoading = !canonicalTranscript
   const loadError = Boolean(timelineError)
@@ -113,6 +116,12 @@ export function SessionMessages({
                 />
               )
             )}
+          {!isLoading &&
+            canonicalTranscript?.actionCards
+              ?.filter((card) => card.status === 'available')
+              .map((card) => (
+                <SessionActionCardView key={card.id} card={card} onAction={(option) => onActionCard(card, option)} />
+              ))}
           {!isLoading && runFailureReason ? (
             <SessionRunFailure reason={runFailureReason} />
           ) : !isLoading && isWorking ? (
@@ -163,6 +172,69 @@ export function SessionMessages({
         {timelineAnnouncement}
       </p>
     </div>
+  )
+}
+
+function SessionActionCardView({
+  card,
+  onAction,
+}: Readonly<{ card: SessionActionCard; onAction: (option?: 'draft' | 'ready') => Promise<boolean> }>) {
+  const [state, setState] = useState<'idle' | 'working' | 'complete' | 'failed'>('idle')
+  const runAction = async (option?: 'draft' | 'ready') => {
+    setState('working')
+
+    try {
+      setState((await onAction(option)) ? 'complete' : 'failed')
+    } catch {
+      setState('failed')
+    }
+  }
+
+  return (
+    <aside
+      className="rounded-xl border border-activity-border bg-activity-background px-4 py-3"
+      aria-label="Suggested action"
+    >
+      <p className="text-xs/5 font-medium text-content-muted-foreground">Suggested by Pi</p>
+      <h2 className="mt-1 text-sm/5 font-medium text-content-foreground">{card.title}</h2>
+      <p className="mt-1 text-sm/5 text-content-muted-foreground">{card.description}</p>
+      {card.kind === 'start-implement-session' ? (
+        <>
+          <Button
+            className="mt-3"
+            disabled={state === 'working' || state === 'complete'}
+            onClick={() => void runAction()}
+          >
+            {state === 'working'
+              ? 'Starting…'
+              : state === 'complete'
+                ? 'Implement Session started'
+                : 'Start Implement Session'}
+          </Button>
+          {state === 'failed' ? (
+            <p className="mt-2 text-sm/5 text-activity-failed">Could not start this action.</p>
+          ) : null}
+        </>
+      ) : (
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button disabled={state === 'working' || state === 'complete'} onClick={() => void runAction('draft')}>
+            {state === 'working'
+              ? 'Preparing pull request…'
+              : state === 'complete'
+                ? 'Pull request request sent'
+                : 'Prepare draft pull request'}
+          </Button>
+          <Button
+            outline
+            disabled={state === 'working' || state === 'complete'}
+            onClick={() => void runAction('ready')}
+          >
+            Prepare pull request
+          </Button>
+          {state === 'failed' ? <p className="text-sm/5 text-activity-failed">Could not start this request.</p> : null}
+        </div>
+      )}
+    </aside>
   )
 }
 

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -473,6 +473,8 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             sessionConfiguration={window.piWorkspace.sessionConfiguration}
             sessionSkills={window.piWorkspace.sessionSkills}
             onToggleSessionPin={toggleSessionPin}
+            acceptActionCard={window.piWorkspace.transcript.acceptActionCard}
+            onStartImplementSession={(workstreamId) => createSession(workstreamId, { mode: 'implement' })}
           />
         ) : selectedWorkstream?.goal ? (
           <WorkstreamSelectionScreen workstream={selectedWorkstream} />

--- a/src/session-action-cards.test.ts
+++ b/src/session-action-cards.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseSessionActionCardToolInput } from './session-action-cards'
+
+test('accepts an allowlisted action card', () => {
+  assert.deepEqual(
+    parseSessionActionCardToolInput({
+      kind: 'prepare-pull-request',
+      title: 'Create a pull request',
+      description: 'Prepare a draft for review.',
+    }),
+    {
+      kind: 'prepare-pull-request',
+      title: 'Create a pull request',
+      description: 'Prepare a draft for review.',
+    }
+  )
+})
+
+test('rejects unknown action kinds', () => {
+  assert.equal(
+    parseSessionActionCardToolInput({ kind: 'run-shell-command', title: 'Run it', description: 'Run a command.' }),
+    undefined
+  )
+})

--- a/src/session-action-cards.ts
+++ b/src/session-action-cards.ts
@@ -1,0 +1,42 @@
+import type { SessionId } from '@/src/domain/session'
+
+export const sessionActionKinds = ['start-implement-session', 'prepare-pull-request'] as const
+export type SessionActionKind = (typeof sessionActionKinds)[number]
+
+export const sessionActionCardStatuses = ['available', 'accepted', 'dismissed'] as const
+export type SessionActionCardStatus = (typeof sessionActionCardStatuses)[number]
+
+export type SessionActionCard = Readonly<{
+  id: string
+  sessionId: SessionId
+  kind: SessionActionKind
+  title: string
+  description: string
+  status: 'available' | 'accepted' | 'dismissed'
+  createdAt: number
+}>
+
+export type SessionActionCardToolInput = Readonly<{
+  kind: SessionActionKind
+  title: string
+  description: string
+}>
+
+export function isSessionActionKind(value: unknown): value is SessionActionKind {
+  return typeof value === 'string' && sessionActionKinds.includes(value as SessionActionKind)
+}
+
+export function parseSessionActionCardToolInput(value: unknown): SessionActionCardToolInput | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const input = value as Record<string, unknown>
+  if (!isSessionActionKind(input.kind)) return undefined
+  if (typeof input.title !== 'string' || !input.title.trim()) return undefined
+  if (typeof input.description !== 'string' || !input.description.trim()) return undefined
+
+  return {
+    kind: input.kind,
+    title: input.title.trim(),
+    description: input.description.trim(),
+  }
+}

--- a/src/session-transcript-ipc.test.ts
+++ b/src/session-transcript-ipc.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseActionCardAcceptanceRequest } from './session-transcript-ipc'
+
+test('accepts a bounded action-card acceptance request', () => {
+  assert.deepEqual(parseActionCardAcceptanceRequest({ sessionId: 'session-a', actionCardId: 'card-1' }), {
+    sessionId: 'session-a',
+    actionCardId: 'card-1',
+  })
+})
+
+test('rejects an empty or oversized action-card id', () => {
+  assert.equal(parseActionCardAcceptanceRequest({ sessionId: 'session-a', actionCardId: '' }), undefined)
+  assert.equal(parseActionCardAcceptanceRequest({ sessionId: 'session-a', actionCardId: 'x'.repeat(257) }), undefined)
+})

--- a/src/session-transcript-ipc.ts
+++ b/src/session-transcript-ipc.ts
@@ -4,6 +4,7 @@ export const sessionTranscriptIpcChannels = {
   getSnapshot: 'session-transcript:get-snapshot',
   getWorkingStateSnapshots: 'session-transcript:get-working-state-snapshots',
   loadActivityDetails: 'session-transcript:load-activity-details',
+  acceptActionCard: 'session-transcript:accept-action-card',
   openExternalLink: 'session-transcript:open-external-link',
   changed: 'session-transcript:changed',
 } as const
@@ -14,6 +15,17 @@ export function parseSessionTranscriptRequest(value: unknown): { sessionId: stri
   const sessionId = (value as Record<string, unknown>).sessionId
 
   return isSessionId(sessionId) ? { sessionId } : undefined
+}
+
+export function parseActionCardAcceptanceRequest(
+  value: unknown
+): { sessionId: string; actionCardId: string } | undefined {
+  const request = parseSessionTranscriptRequest(value)
+  if (!request || typeof (value as Record<string, unknown>).actionCardId !== 'string') return undefined
+
+  const actionCardId = (value as Record<string, unknown>).actionCardId as string
+
+  return actionCardId.length > 0 && actionCardId.length <= 256 ? { ...request, actionCardId } : undefined
 }
 
 export function parseTranscriptActivityDetailsRequest(

--- a/src/session-transcript.ts
+++ b/src/session-transcript.ts
@@ -1,6 +1,7 @@
 import type { SessionId } from '@/src/domain/session'
 import type { QueuedFollowUp } from '@/src/queued-follow-up'
 import type { SessionSkillMention } from '@/src/session-skills'
+import type { SessionActionCard } from '@/src/session-action-cards'
 
 const allowedExternalUrlProtocols = new Set(['http:', 'https:', 'mailto:'])
 export const maximumExternalUrlLength = 8_192
@@ -43,6 +44,7 @@ export type SessionTranscriptSnapshot = Readonly<{
   contextUsage?: SessionContextUsage
   runs: readonly AgentRun[]
   entries: readonly SessionTranscriptEntry[]
+  actionCards?: readonly SessionActionCard[]
   queuedFollowUps?: readonly QueuedFollowUp[]
   queuedFollowUpsPaused?: boolean
   runFailureReason?: 'failed' | 'cancelled'
@@ -59,6 +61,7 @@ export interface SessionTranscriptBridge {
   getSnapshot(sessionId: SessionId): Promise<SessionTranscriptSnapshot>
   getWorkingStateSnapshots(): Promise<readonly SessionWorkingStateSnapshot[]>
   loadActivityDetails(sessionId: SessionId, activityId: string): Promise<AgentActivityDetails | undefined>
+  acceptActionCard(sessionId: SessionId, actionCardId: string): Promise<boolean>
   openExternalLink(url: string): Promise<void>
   subscribe(listener: (mutation: SessionTranscriptMutation) => void): () => void
 }


### PR DESCRIPTION
## Summary
- add optional Session action cards for implementation next steps
- isolate `bun run dev` user data by Git branch so worktrees can run concurrently
- retain normal Railyard user data for `bun run start`

## Validation
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`