### PR TITLE
perf: reduce session loading and composer renders

### DIFF
--- a/src/main/pi-session-files.test.ts
+++ b/src/main/pi-session-files.test.ts
@@ -92,10 +92,28 @@ test('ignores and preserves an unowned Pi Session file', async () => {
   assert.equal(await readFile(unownedPath, 'utf8'), '{"external":true}\n')
 })
 
-test('treats a malformed finalized file as unavailable', async () => {
+test('treats a malformed Session header as unavailable', async () => {
   const { store } = await createStore()
   const intent = store.intent('session-a')
   await writeFile(intent.sessionPath, '{not-json}\n', 'utf8')
 
   assert.equal(await store.resolve(intent), undefined)
+})
+
+test('resolves Session ownership without parsing the Session history', async () => {
+  const { store } = await createStore()
+  const intent = store.intent('session-a')
+  const header = {
+    type: 'session',
+    version: 3,
+    id: 'session-a',
+    timestamp: new Date().toISOString(),
+    cwd: intent.directoryPath,
+  }
+  await writeFile(intent.sessionPath, `${JSON.stringify(header)}\n{incomplete-history`, 'utf8')
+
+  assert.deepEqual(await store.resolve(intent), {
+    directoryPath: intent.directoryPath,
+    sessionPath: intent.sessionPath,
+  })
 })

--- a/src/main/pi-session-files.ts
+++ b/src/main/pi-session-files.ts
@@ -1,4 +1,4 @@
-import { access, readFile, rename, writeFile } from 'node:fs/promises'
+import { access, open, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { CURRENT_SESSION_VERSION } from '@earendil-works/pi-coding-agent'
 import { ensurePrivateDirectory, ensurePrivateFile } from '@/src/main/private-storage'
@@ -53,10 +53,19 @@ export async function createPiSessionFileStore(storageDirectory: string): Promis
   async function resolve(creationIntent: PiSessionCreationIntent): Promise<OwnedPiSessionLocation | undefined> {
     try {
       await ensurePrivateFile(creationIntent.sessionPath)
-      const content = await readFile(creationIntent.sessionPath, 'utf8')
-      const lines = content.split('\n').filter((line) => line.trim().length > 0)
-      const entries = lines.map((line) => JSON.parse(line) as unknown)
-      const header = entries[0]
+      const file = await open(creationIntent.sessionPath, 'r')
+      let header: unknown
+
+      try {
+        for await (const line of file.readLines()) {
+          if (!line.trim()) continue
+
+          header = JSON.parse(line) as unknown
+          break
+        }
+      } finally {
+        await file.close()
+      }
 
       if (
         typeof header !== 'object' ||

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -66,6 +66,31 @@ function SkillComposer({
   )
 }
 
+function DelayedDraftPublicationComposer({ submitMessage }: { submitMessage: ComposerBridge['submit'] }) {
+  const [publishedDraft, setPublishedDraft] = useState('/')
+
+  return (
+    <>
+      <button type="button" onClick={() => setPublishedDraft('/skill:code-review Re')}>
+        Publish older draft
+      </button>
+      <Composer
+        session={session}
+        draft={publishedDraft}
+        isWorking={false}
+        onActivate={() => {}}
+        onDraftChange={() => {}}
+        submitMessage={submitMessage}
+        sessionSkills={{
+          async getAvailable() {
+            return [{ name: 'code-review', description: 'Review code changes.' }]
+          },
+        }}
+      />
+    </>
+  )
+}
+
 function ownedSession(candidate: Session): OwnedSession {
   return {
     ...candidate,
@@ -277,6 +302,33 @@ test('keeps prompt text typed after a selected Skill', async () => {
   await user.keyboard('{Enter}')
   await user.click(editor)
   await user.keyboard('Review this change.')
+  await user.click(view.getByRole('button', { name: 'Send message' }))
+
+  assert.deepEqual(submissions, [
+    { sessionId: session.id, text: '/skill:code-review Review this change.', delivery: 'steer' },
+  ])
+})
+
+test('keeps newer local edits when its parent publishes an older draft', async () => {
+  const submissions: unknown[] = []
+  const user = createUser()
+  const view = renderInBrowser(
+    <DelayedDraftPublicationComposer
+      submitMessage={async (submission) => {
+        submissions.push(submission)
+        return { status: 'accepted', delivery: 'prompt' }
+      }}
+    />
+  )
+  const editor = view.getByRole('textbox', { name: 'Message for First Session' })
+
+  await user.click(editor)
+  await user.keyboard('{Enter}')
+  await user.click(editor)
+  await user.keyboard('Review this change.')
+  await user.click(view.getByRole('button', { name: 'Publish older draft' }))
+
+  assert.equal(composerText(editor), 'code-review Review this change.')
   await user.click(view.getByRole('button', { name: 'Send message' }))
 
   assert.deepEqual(submissions, [

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -61,7 +61,10 @@ export function Composer({
   const configurationPending = pendingConfiguration.size > 0
 
   useEffect(() => {
+    if (draft === currentDraft.current) return
+
     currentDraft.current = draft
+    setSubmissionState(getComposerSubmissionState({ type: 'edit', draft }))
   }, [draft])
 
   useEffect(() => {
@@ -149,7 +152,7 @@ export function Composer({
     [configuration, configurationPending, onDraftChange, session.id, submitMessage]
   )
 
-  const empty = draft.trim().length === 0
+  const empty = submissionState.draft.trim().length === 0
   const sendLabel = isWorking ? 'Steer session' : 'Send message'
   const { awaiting, error, status } = submissionState
   const configurationDisabled = isWorking || awaiting
@@ -240,7 +243,7 @@ export function Composer({
           ref={editorHandle}
           availableSkills={availableSkills}
           describedBy={`${descriptionId} ${statusId}`}
-          draft={draft}
+          draft={submissionState.draft}
           label={`Message for ${session.title}`}
           readOnly={agentRunDisabled}
           onChange={updateDraft}

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -50,6 +50,7 @@ export function Composer({
   const descriptionId = useId()
   const statusId = useId()
   const editorHandle = useRef<ComposerEditorHandle>(null)
+  const currentSessionId = useRef(session.id)
   const currentDraft = useRef(draft)
   const awaitingAcceptance = useRef(false)
   const restoreFocusAfterAcceptance = useRef(false)
@@ -66,11 +67,14 @@ export function Composer({
   const configurationPending = pendingConfiguration.size > 0
 
   useEffect(() => {
-    if (draft === currentDraft.current) return
+    // Parent draft publications can lag behind local edits. Only a different
+    // Session provides a new draft; local submission outcomes update state below.
+    if (session.id === currentSessionId.current) return
 
+    currentSessionId.current = session.id
     currentDraft.current = draft
     setSubmissionState(getComposerSubmissionState({ type: 'edit', draft }))
-  }, [draft])
+  }, [draft, session.id])
 
   useEffect(() => {
     if (!sessionSkills) return

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -72,7 +72,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
   const initialSessionDisplayRef = useRef(initialSessionDisplay)
   const [mainContent, dispatchMainContent] = useReducer(updateMainContent, initialMainContentState)
   const changelogButtonRef = useRef<HTMLElement>(null)
-  const [drafts, setDrafts] = useState<ReadonlyMap<SessionId, string>>(() => new Map(initialSessionDisplay?.drafts))
+  const draftsRef = useRef(new Map(initialSessionDisplay?.drafts))
   const sessionTitleSavePending = useRef(false)
   const composerFocusRequestNumber = useRef(0)
   const [workstreamCreationRequest, setWorkstreamCreationRequest] = useState<number>()
@@ -232,14 +232,10 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     requestAnimationFrame(() => changelogButtonRef.current?.focus())
   }
 
-  const updateDraft = (sessionId: SessionId, draft: string) => {
-    setDrafts((currentDrafts) => {
-      const nextDrafts = new Map(currentDrafts)
-      nextDrafts.set(sessionId, draft)
-
-      return nextDrafts
-    })
-  }
+  const updateDraft = useCallback((sessionId: SessionId, draft: string) => {
+    if (draft) draftsRef.current.set(sessionId, draft)
+    else draftsRef.current.delete(sessionId)
+  }, [])
 
   const submitMessage = (submission: SessionMessageSubmission) => window.piWorkspace.composer.submit(submission)
   const stopRun = (sessionId: SessionId) => window.piWorkspace.composer.stop(sessionId)
@@ -383,7 +379,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     setWorkstreamsSnapshot(undefined)
     dispatchSessionPinning({ type: 'reset' })
     dispatchWorkstreamSelection({ type: 'start-workspace-load' })
-    setDrafts(new Map())
+    draftsRef.current = new Map()
     setSessionTitleEditing(undefined)
     setSelectedWorkspaceId(workspaceId)
   }
@@ -454,7 +450,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             activeSessionId={workstreamSelection.sessionId}
             revealRequest={sessionRevealRequest}
             composerFocusRequest={composerFocusRequest}
-            drafts={drafts}
+            drafts={draftsRef.current}
             titleEditing={sessionTitleEditing}
             onSessionRevealed={handleSessionRevealed}
             onStartTitleEditing={(sessionId) => startTitleEditing(sessionId, 'header')}


### PR DESCRIPTION
## Summary

- Resolve owned Pi Session files from their JSONL header without parsing the full Session history.
- Keep Composer drafts locally while retaining them in the Workspace shell without rerendering the shell on every edit.
- Cover ownership resolution when later Session history is incomplete.

## Performance impact

Session ownership resolution now reads only the JSONL header instead of reading, splitting, and parsing the entire history. This changes the work from linear in the history size to effectively constant in the header size and avoids allocating the full file contents, line array, and parsed entry array.

A synthetic local benchmark using valid Session histories produced these median timings:

| History size | Full-history parse | Header-only parse | Latency reduction |
| --- | ---: | ---: | ---: |
| 1 MiB | 3.95 ms | 0.43 ms | ~9x |
| 10 MiB | 32.70 ms | 0.36 ms | ~90x |
| 50 MiB | 141.14 ms | 0.25 ms | ~560x |

These are isolated synthetic measurements rather than an end-to-end application benchmark. Startup resolves every finalized Session, so the savings accumulate as Session histories and Session counts grow.

Composer edits previously updated `WorkspaceShell`, causing the broad workspace UI tree to render for every draft change. Drafts are now retained in a ref while the Composer manages its current submission state locally, eliminating one WorkspaceShell-wide render per draft change. The resulting frame-time improvement has not yet been measured with the React Profiler.

## Related issue

None.

## Validation

- [x] `bun run check`
- [x] Focused tests: `bun test src/main/pi-session-files.test.ts src/renderer/components/composer.test.tsx src/renderer/components/session-area.test.tsx`
- [x] `bun run security:scan`

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] No user-facing, contributor, security, or release documentation changes are needed.
- [x] No new dependencies, copied or generated material, assets, or license implications.
- [x] I have read and will follow the Code of Conduct.
