### PR TITLE
chore(release): prepare 2.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "railyard",
-  "version": "1.0.0-beta.1",
+  "version": "2.0.0-beta.1",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "bun@1.3.14",

--- a/scripts/release-note-markdown.test.ts
+++ b/scripts/release-note-markdown.test.ts
@@ -8,5 +8,5 @@ test('formats the latest bundled Release Note for a GitHub Release', () => {
 
   assert.match(markdown, new RegExp(`^${bundledReleaseNotes[0]!.summary}`, 'm'))
   assert.match(markdown, /^## Improved$/m)
-  assert.match(markdown, /^- Pi Workspace is now Railyard, with a renamed app and packages,/m)
+  assert.match(markdown, /^- Sessions load faster as their histories grow,/m)
 })

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -20,6 +20,33 @@ export function isSemanticVersion(version: string): boolean {
 
 export const bundledReleaseNotes: readonly ReleaseNote[] = [
   {
+    version: '2.0.0-beta.1',
+    releaseDate: '2026-07-27',
+    summary:
+      'This beta gives each Workstream a clearer Repository boundary and puts branching, review, and delivery controls directly in every Session.',
+    changes: {
+      new: [
+        'Compact eligible Session context on demand and revisit the retained summary in the Session transcript.',
+        'Act on or dismiss a suggested next step to prepare a draft pull request after completing changes.',
+        'See automatically maintained descriptions of each Session’s current focus in the sidebar.',
+        'Review Session Repository changes in expandable diffs, stage whole files, add hunk comments or follow-ups, and revisit operation-time code previews from Agent Activities.',
+        'Fork a Session from any completed user message while preserving the original Session and carrying its earlier history into an independent Session.',
+        'Reference scoped files and folders with @ in Composer to include their current context in messages and follow-ups.',
+      ],
+      improved: [
+        'Workstreams now select their own Repositories and share the goal and Repository context across mode-free Sessions; Brainstorm and Implement modes and the Workstream Knowledge panel have been removed.',
+        'Workstream Sessions now use current checkouts by default, show each Repository’s live branch and working location beneath Composer, and let you explicitly create an isolated Session Worktree.',
+        'Sessions load faster as their histories grow, and Composer stays responsive without losing current edits.',
+        'Repository work now receives a final pass of relevant locally runnable CI and GitHub Actions before completion.',
+        'Sidebar controls are simpler, and Composer now floats above the transcript on a translucent surface.',
+      ],
+      fixed: [
+        'Linux app stores now show Railyard’s package description without stray replacement characters.',
+        'Agent Activities can now start and complete after Workspace Repository access changes.',
+      ],
+    },
+  },
+  {
     version: '1.0.0-beta.1',
     releaseDate: '2026-07-25',
     summary: 'This beta establishes the foundation for Railyard’s next stage of development.',


### PR DESCRIPTION
## Summary

- bump Railyard from `1.0.0-beta.1` to `2.0.0-beta.1`
- add the 2026-07-27 Release Note covering Repository-scoped mode-free Workstreams, explicit Session Worktrees, context compaction, Session descriptions, code review, Session forking, file references, performance, validation, interface refinements, and fixes
- update the focused GitHub Release markdown test while preserving historical Release Notes

Release baseline: `v1.0.0-beta.1` (`ce72f5b0417f01e221ef057fb3b6c61329e4d70e`). The major version reflects the removal of previously released Brainstorm and Implement modes and the Workstream Knowledge interface. The changed core resets the prerelease counter to `beta.1`.

The release ledger covers all 14 product commits and 14 associated pull requests merged since the baseline through `705ee0ce83b2c08cd315fa267282490ac955a2f5`; none link issues.

## Related issue

None.

## Validation

- `bun run release:validate`
- `bun test --max-concurrency=1 --preload ./src/renderer/test-dom.ts` — 633 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- generated Release markdown reviewed with `bun run release:notes`

- [x] `bun run check`
- [x] Focused tests or manual validation are described above.
- [x] `bun run security:scan` was run, or this change does not affect dependencies or security-sensitive behavior.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed.
- [x] I have read and will follow the Code of Conduct.

No new dependencies, copied material, generated assets, or license implications.
