### PR TITLE
feat: add Session forking

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,9 @@ An ordinary Git worktree owned by one Implement Session for one Repository. It i
 A persistent Pi interaction associated with one Workstream. Each Session has an immutable mode and Repository access: direct access to one selected Repository working location for Default or automatic access to every current Workspace Repository for Brainstorm and Implement. Implement changes use that Session's lazily created Implement Session Worktrees.
 _Avoid_: Chat, thread
 
+**Session Fork**:
+A new Session whose history is copied through the response before one selected user message from a source Session. The selected message becomes an editable draft, the source remains unchanged, and Repository state is not rewound. A goal-based Session Fork remains in its Workstream and mode. A Quick Session Fork owns a new goal-less Workstream and preserves the source working-location policy without sharing a dedicated worktree.
+
 **Changelog**:
 The complete chronological collection shown by the Changelog page.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Railyard is a local desktop app for working with [Pi](https://github.com/earendi
 - Create a goal-based **Workstream** with shared context that carries across multiple Sessions.
 - Use **Brainstorm** Sessions to investigate and plan, then **Implement** Sessions to make and validate changes.
 - Pin Sessions side by side when work spans multiple conversations or Repositories.
+- Fork a Session from an earlier user message while keeping the original path intact.
 - Reopen Railyard and continue from locally stored Session history.
 
 ## Install the beta

--- a/src/application-state.ts
+++ b/src/application-state.ts
@@ -1,4 +1,4 @@
-export const applicationStateSchemaVersion = 5
+export const applicationStateSchemaVersion = 6
 
 export type InstallationMarker = Readonly<{
   generationId: string

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -343,6 +343,71 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
 
         return { status: 'available', sessionId: createdSessionId, snapshot: workstreamsSnapshot }
       },
+      async getSessionForkPoints(sourceSessionId) {
+        const userMessages = (transcriptsBySessionId[sourceSessionId]?.entries ?? []).flatMap((entry) =>
+          entry.type === 'message' && entry.message.role === 'user' ? [entry.message] : []
+        )
+
+        return userMessages.map((message, index) => ({
+          entryId: message.id,
+          text: message.text,
+          position: index + 1,
+          total: userMessages.length,
+        }))
+      },
+      async forkSession(sourceSessionId, options) {
+        const owner = workstreamsSnapshot.workstreams.find((workstream) =>
+          workstream.sessions.some((session) => session.id === sourceSessionId)
+        )
+        const source = owner?.sessions.find((session) => session.id === sourceSessionId)
+        const point = (await this.getSessionForkPoints(sourceSessionId)).find(
+          (candidate) => candidate.entryId === options.entryId
+        )
+        if (!owner || !source || !point) throw new TypeError('Select a user message from the Session history.')
+
+        createdSessionNumber += 1
+        const createdSessionId = sessionId(`forked-session-${createdSessionNumber}`)
+        const target = { ...source, id: createdSessionId, title: options.title.trim() }
+
+        if (source.mode === 'default') {
+          const workstreamId = `forked-quick-workstream-${createdSessionNumber}`
+          workstreamsSnapshot = {
+            revision: workstreamsSnapshot.revision + 1,
+            workstreams: [
+              ...workstreamsSnapshot.workstreams,
+              { ...owner, id: workstreamId, sessions: [{ ...target, workstreamId }] },
+            ],
+          }
+        } else {
+          workstreamsSnapshot = {
+            revision: workstreamsSnapshot.revision + 1,
+            workstreams: workstreamsSnapshot.workstreams.map((workstream) =>
+              workstream.id === owner.id ? { ...workstream, sessions: [...workstream.sessions, target] } : workstream
+            ),
+          }
+        }
+
+        const sourceTranscript = transcriptsBySessionId[sourceSessionId]
+        if (sourceTranscript) {
+          let userPosition = 0
+          transcriptsBySessionId[createdSessionId] = {
+            ...sourceTranscript,
+            sessionId: createdSessionId,
+            entries: sourceTranscript.entries.filter((entry) => {
+              if (entry.type !== 'message' || entry.message.role !== 'user') return userPosition < point.position
+              userPosition += 1
+              return userPosition < point.position
+            }),
+          }
+        }
+
+        return {
+          status: 'available',
+          sessionId: createdSessionId,
+          snapshot: workstreamsSnapshot,
+          draft: point.text,
+        }
+      },
       async setLifecycle(workstreamId, lifecycle) {
         workstreamsSnapshot = {
           revision: workstreamsSnapshot.revision + 1,

--- a/src/domain/workstream.ts
+++ b/src/domain/workstream.ts
@@ -74,6 +74,18 @@ export type WorktreeLocationsPreview = Readonly<{
   repositories: readonly WorktreeLocationPreview[]
 }>
 
+export type SessionForkPoint = Readonly<{
+  entryId: string
+  text: string
+  position: number
+  total: number
+}>
+
+export type ForkSessionOptions = Readonly<{
+  entryId: string
+  title: string
+}>
+
 export type CreateWorkstreamOptions = Readonly<{
   goal: string
   mode?: ManagedSessionMode

--- a/src/main/application-state/application-state-store.ts
+++ b/src/main/application-state/application-state-store.ts
@@ -72,16 +72,23 @@ function tableExists(database: SqliteDatabase, name: string): boolean {
   return Boolean(database.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(name))
 }
 
+function columnExists(database: SqliteDatabase, table: string, column: string): boolean {
+  return database
+    .prepare(`PRAGMA table_info(${table})`)
+    .all()
+    .some((row) => row.name === column)
+}
+
 function migrateApplicationState(database: SqliteDatabase): void {
   database.exec('PRAGMA foreign_keys = ON;')
   const schemaVersion = Number(database.prepare("SELECT value FROM metadata WHERE key = 'schema_version'").get()?.value)
 
-  if (schemaVersion !== 3 && schemaVersion !== 4) return
+  if (schemaVersion !== 3 && schemaVersion !== 4 && schemaVersion !== 5) return
 
   database.exec('BEGIN IMMEDIATE;')
 
   try {
-    if (tableExists(database, 'workstream_run_leases')) {
+    if (schemaVersion <= 4 && tableExists(database, 'workstream_run_leases')) {
       database.exec(`
         CREATE TABLE session_run_leases_new (session_id TEXT PRIMARY KEY REFERENCES sessions(id), workstream_id TEXT NOT NULL REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL);
         INSERT INTO session_run_leases_new (session_id, workstream_id, lease_id, purpose, acquired_at)
@@ -89,37 +96,47 @@ function migrateApplicationState(database: SqliteDatabase): void {
         DROP TABLE workstream_run_leases;
         ALTER TABLE session_run_leases_new RENAME TO session_run_leases;
       `)
-    } else if (!tableExists(database, 'session_run_leases')) {
+    } else if (schemaVersion <= 4 && !tableExists(database, 'session_run_leases')) {
       database.exec(
         'CREATE TABLE session_run_leases (session_id TEXT PRIMARY KEY REFERENCES sessions(id), workstream_id TEXT NOT NULL REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL);'
       )
     }
 
-    if (!tableExists(database, 'session_repository_locations')) {
+    if (schemaVersion <= 4 && !tableExists(database, 'session_repository_locations')) {
       database.exec(
         `CREATE TABLE session_repository_locations (session_id TEXT NOT NULL REFERENCES sessions(id), repository_id TEXT NOT NULL REFERENCES repositories(id), kind TEXT NOT NULL, working_path TEXT NOT NULL, branch TEXT, base_commit TEXT, availability TEXT NOT NULL, PRIMARY KEY (session_id, repository_id));`
       )
     }
 
-    database.exec(`
-      INSERT INTO session_repository_locations
-        (session_id, repository_id, kind, working_path, branch, base_commit, availability)
-      SELECT session.id, location.repository_id, location.kind, location.working_path,
-             location.branch, location.base_commit, location.availability
-        FROM sessions session
-        JOIN workstream_repository_locations location ON location.workstream_id = session.workstream_id
-       WHERE (
-               session.access_kind = 'managed' AND session.id = (
-                 SELECT first_session.id
-                   FROM sessions first_session
-                  WHERE first_session.workstream_id = session.workstream_id
-                  ORDER BY first_session.created_at, first_session.rowid
-                  LIMIT 1
+    if (schemaVersion <= 4) {
+      database.exec(`
+        INSERT INTO session_repository_locations
+          (session_id, repository_id, kind, working_path, branch, base_commit, availability)
+        SELECT session.id, location.repository_id, location.kind, location.working_path,
+               location.branch, location.base_commit, location.availability
+          FROM sessions session
+          JOIN workstream_repository_locations location ON location.workstream_id = session.workstream_id
+         WHERE (
+                 session.access_kind = 'managed' AND session.id = (
+                   SELECT first_session.id
+                     FROM sessions first_session
+                    WHERE first_session.workstream_id = session.workstream_id
+                    ORDER BY first_session.created_at, first_session.rowid
+                    LIMIT 1
+                 )
                )
-             )
-          OR session.repository_id = location.repository_id
-      ON CONFLICT (session_id, repository_id) DO NOTHING;
-    `)
+            OR session.repository_id = location.repository_id
+        ON CONFLICT (session_id, repository_id) DO NOTHING;
+      `)
+    }
+
+    if (!columnExists(database, 'sessions', 'parent_session_id')) {
+      database.exec('ALTER TABLE sessions ADD COLUMN parent_session_id TEXT REFERENCES sessions(id);')
+    }
+    if (!columnExists(database, 'sessions', 'forked_from_entry_id')) {
+      database.exec('ALTER TABLE sessions ADD COLUMN forked_from_entry_id TEXT;')
+    }
+
     database
       .prepare("UPDATE metadata SET value = ? WHERE key = 'schema_version'")
       .run(String(applicationStateSchemaVersion))
@@ -141,7 +158,7 @@ function initializeSchema(database: SqliteDatabase, generationId: string): void 
     CREATE TABLE repositories (id TEXT PRIMARY KEY, directory_path TEXT NOT NULL UNIQUE, common_directory_path TEXT NOT NULL, availability TEXT NOT NULL DEFAULT 'available');
     CREATE TABLE workspace_repositories (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL REFERENCES workspaces(id), repository_id TEXT NOT NULL REFERENCES repositories(id), role TEXT NOT NULL DEFAULT '', relationships TEXT NOT NULL DEFAULT '[]', validation_commands TEXT NOT NULL DEFAULT '[]', UNIQUE(workspace_id, repository_id));
     CREATE TABLE workstreams (id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL REFERENCES workspaces(id), goal TEXT, lifecycle TEXT NOT NULL, working_location TEXT NOT NULL, working_location_revision INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL);
-    CREATE TABLE sessions (id TEXT PRIMARY KEY, workstream_id TEXT NOT NULL REFERENCES workstreams(id), title TEXT NOT NULL, mode TEXT NOT NULL, availability TEXT NOT NULL, access_kind TEXT NOT NULL, repository_id TEXT REFERENCES repositories(id), pi_session_id TEXT NOT NULL UNIQUE, expected_jsonl_path TEXT NOT NULL UNIQUE, creation_status TEXT NOT NULL, created_at INTEGER NOT NULL);
+    CREATE TABLE sessions (id TEXT PRIMARY KEY, workstream_id TEXT NOT NULL REFERENCES workstreams(id), title TEXT NOT NULL, mode TEXT NOT NULL, availability TEXT NOT NULL, access_kind TEXT NOT NULL, repository_id TEXT REFERENCES repositories(id), pi_session_id TEXT NOT NULL UNIQUE, expected_jsonl_path TEXT NOT NULL UNIQUE, creation_status TEXT NOT NULL, created_at INTEGER NOT NULL, parent_session_id TEXT REFERENCES sessions(id), forked_from_entry_id TEXT);
     CREATE TABLE workstream_repository_locations (workstream_id TEXT NOT NULL REFERENCES workstreams(id), repository_id TEXT NOT NULL REFERENCES repositories(id), kind TEXT NOT NULL, working_path TEXT NOT NULL, branch TEXT, base_commit TEXT, availability TEXT NOT NULL, PRIMARY KEY (workstream_id, repository_id));
     CREATE TABLE session_run_leases (session_id TEXT PRIMARY KEY REFERENCES sessions(id), workstream_id TEXT NOT NULL REFERENCES workstreams(id), lease_id TEXT NOT NULL UNIQUE, purpose TEXT NOT NULL, acquired_at INTEGER NOT NULL);
     CREATE TABLE session_repository_locations (session_id TEXT NOT NULL REFERENCES sessions(id), repository_id TEXT NOT NULL REFERENCES repositories(id), kind TEXT NOT NULL, working_path TEXT NOT NULL, branch TEXT, base_commit TEXT, availability TEXT NOT NULL, PRIMARY KEY (session_id, repository_id));
@@ -174,7 +191,9 @@ function readMetadata(database: SqliteDatabase): ApplicationStateMetadata | unde
       .get()
     database
       .prepare(
-        'SELECT mode, availability, access_kind, repository_id, pi_session_id, expected_jsonl_path, creation_status, created_at FROM sessions LIMIT 1'
+        schemaVersionNumber >= 6
+          ? 'SELECT mode, availability, access_kind, repository_id, pi_session_id, expected_jsonl_path, creation_status, created_at, parent_session_id, forked_from_entry_id FROM sessions LIMIT 1'
+          : 'SELECT mode, availability, access_kind, repository_id, pi_session_id, expected_jsonl_path, creation_status, created_at FROM sessions LIMIT 1'
       )
       .get()
     database
@@ -241,7 +260,7 @@ export async function initializeApplicationStateStore(storageDirectory: string, 
         marker &&
         metadata.integrity === 'ok' &&
         metadata.generationId === marker.generationId &&
-        (metadata.schemaVersion === 3 || metadata.schemaVersion === 4)
+        (metadata.schemaVersion === 3 || metadata.schemaVersion === 4 || metadata.schemaVersion === 5)
       ) {
         migrateApplicationState(database)
       }
@@ -258,10 +277,12 @@ export async function initializeApplicationStateStore(storageDirectory: string, 
 
     try {
       database.exec('BEGIN IMMEDIATE;')
-      const leases = database.prepare("SELECT lease_id FROM session_run_leases WHERE purpose = 'agent-run'").all()
+      const leases = database
+        .prepare("SELECT lease_id FROM session_run_leases WHERE purpose IN ('agent-run', 'session-fork')")
+        .all()
 
       if (leases.length > 0) {
-        database.prepare("DELETE FROM session_run_leases WHERE purpose = 'agent-run'").run()
+        database.prepare("DELETE FROM session_run_leases WHERE purpose IN ('agent-run', 'session-fork')").run()
         incrementRevision(database)
       }
 

--- a/src/main/application-state/index.ts
+++ b/src/main/application-state/index.ts
@@ -9,6 +9,8 @@ import type {
   CreateQuickSessionOptions,
   CreateSessionOptions,
   CreateWorkstreamOptions,
+  ForkSessionOptions,
+  SessionForkPoint,
   WorkstreamLifecycle,
   WorkstreamsSnapshot,
   WorktreeLocationsPreview,
@@ -30,6 +32,7 @@ import {
   createWorkstreamSessionStore,
   type OwnedSessionResolution,
   type PreparedSessionRepository,
+  type SessionForkResult,
   type WorkstreamCreationResult,
 } from './workstream-session-store'
 import { incrementRevision, initializeApplicationStateStore, loadSqlite } from './application-state-store'
@@ -48,6 +51,7 @@ export type ApplicationAuthorityOptions = Readonly<{
 export type {
   OwnedSessionResolution,
   PreparedSessionRepository,
+  SessionForkResult,
   WorkstreamCreationResult,
 } from './workstream-session-store'
 
@@ -71,6 +75,8 @@ export type ApplicationAuthority = Readonly<{
   createQuickSession(workspaceId: string, options: CreateQuickSessionOptions): Promise<WorkstreamCreationResult>
   prepareSessionRepository(sessionId: SessionId, repositoryId: string): Promise<PreparedSessionRepository>
   createWorkstreamSession(workstreamId: string, options: CreateSessionOptions): Promise<WorkstreamCreationResult>
+  getSessionForkPoints(sessionId: SessionId): Promise<readonly SessionForkPoint[]>
+  forkSession(sessionId: SessionId, options: ForkSessionOptions): Promise<SessionForkResult>
   setWorkstreamLifecycle(workstreamId: string, lifecycle: WorkstreamLifecycle): Promise<WorkstreamsSnapshot>
   renameWorkstreamSession(sessionId: SessionId, title: string): Promise<WorkstreamsSnapshot>
   resolveOwnedSession(sessionId: SessionId): Promise<OwnedSessionResolution | undefined>
@@ -151,6 +157,8 @@ export async function initializeApplicationAuthority(
     createQuickSession,
     prepareSessionRepository,
     createWorkstreamSession,
+    getSessionForkPoints,
+    forkSession,
     setWorkstreamLifecycle,
     renameWorkstreamSession,
     resolveOwnedSession,
@@ -176,6 +184,8 @@ export async function initializeApplicationAuthority(
     createQuickSession,
     prepareSessionRepository,
     createWorkstreamSession,
+    getSessionForkPoints,
+    forkSession,
     setWorkstreamLifecycle,
     renameWorkstreamSession,
     resolveOwnedSession,

--- a/src/main/application-state/run-lease-store.ts
+++ b/src/main/application-state/run-lease-store.ts
@@ -25,11 +25,7 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
         database.exec('ROLLBACK;')
         return false
       }
-      if (
-        database
-          .prepare("SELECT lease_id FROM session_run_leases WHERE session_id = ? AND purpose = 'agent-run'")
-          .get(sessionId)
-      ) {
+      if (database.prepare('SELECT lease_id FROM session_run_leases WHERE session_id = ?').get(sessionId)) {
         database.exec('ROLLBACK;')
         return false
       }

--- a/src/main/application-state/session-file-reconciliation.ts
+++ b/src/main/application-state/session-file-reconciliation.ts
@@ -1,5 +1,9 @@
 import type { SessionId } from '@/src/domain/session'
-import { type PiSessionCreationIntent, type PiSessionFileStore } from '@/src/main/pi-session-files'
+import {
+  type PiSessionCreationIntent,
+  type PiSessionFileStore,
+  type PiSessionForkIntent,
+} from '@/src/main/pi-session-files'
 import type { SqliteDatabase } from './sqlite'
 
 type SessionFileReconciliationOptions = Readonly<{
@@ -21,11 +25,16 @@ export function createSessionFileReconciliation({
   ): Promise<SessionCreationStatus | undefined> {
     const intents = database
       .prepare(
-        `SELECT id, session_id, pi_session_id, directory_path, session_path
-           FROM external_side_effect_intents
-          WHERE kind = 'create-pi-session-file' AND status = 'pending'
-            AND (? IS NULL OR session_id = ?)
-          ORDER BY id`
+        `SELECT intent.id, intent.kind, intent.session_id, intent.pi_session_id, intent.directory_path,
+                intent.session_path, session.title, session.mode, session.forked_from_entry_id,
+                workstream.working_location, parent.expected_jsonl_path AS parent_session_path
+           FROM external_side_effect_intents intent
+           JOIN sessions session ON session.id = intent.session_id
+           JOIN workstreams workstream ON workstream.id = session.workstream_id
+           LEFT JOIN sessions parent ON parent.id = session.parent_session_id
+          WHERE intent.kind IN ('create-pi-session-file', 'fork-pi-session-file') AND intent.status = 'pending'
+            AND (? IS NULL OR intent.session_id = ?)
+          ORDER BY intent.id`
       )
       .all(targetSessionId ?? null, targetSessionId ?? null)
     let targetStatus: SessionCreationStatus | undefined
@@ -39,7 +48,34 @@ export function createSessionFileReconciliation({
       }
 
       try {
-        const outcome = await sessionFiles.create(intent)
+        let outcome
+
+        if (row.kind === 'fork-pi-session-file') {
+          if (
+            typeof row.parent_session_path !== 'string' ||
+            typeof row.forked_from_entry_id !== 'string' ||
+            typeof row.title !== 'string'
+          ) {
+            throw new Error('The persisted Session fork intent is malformed.')
+          }
+
+          const contextMessage =
+            row.mode === 'implement'
+              ? 'This is a forked Implement Session. Earlier Session worktree paths in the copied history are reference only. Call workspace_overview and prepare_repository before modifying a Repository in this Session.'
+              : row.mode === 'default' && row.working_location === 'worktrees'
+                ? 'This is a forked Quick Session with a new dedicated worktree. Earlier working paths in the copied history are reference only.'
+                : undefined
+          const forkIntent: PiSessionForkIntent = {
+            ...intent,
+            sourceSessionPath: row.parent_session_path,
+            sourceEntryId: row.forked_from_entry_id,
+            title: row.title,
+            ...(contextMessage ? { contextMessage } : {}),
+          }
+          outcome = await sessionFiles.fork(forkIntent)
+        } else {
+          outcome = await sessionFiles.create(intent)
+        }
 
         if (outcome.status === 'available' && !(await sessionFiles.resolve(intent))) {
           throw new Error('The created Pi Session file did not match its persisted intent.')

--- a/src/main/application-state/workstream-session-store.ts
+++ b/src/main/application-state/workstream-session-store.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { SessionManager } from '@earendil-works/pi-coding-agent'
 import { createWorkstreamId } from '@/src/main/workstream-id'
 import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
 import type { SessionId } from '@/src/domain/session'
@@ -8,7 +9,9 @@ import {
   type CreateQuickSessionOptions,
   type CreateSessionOptions,
   type CreateWorkstreamOptions,
+  type ForkSessionOptions,
   type ManagedSessionMode,
+  type SessionForkPoint,
   type SessionMode,
   type Workstream,
   type WorkstreamLifecycle,
@@ -22,6 +25,7 @@ import {
   type InspectedGitRepository,
   type WorktreeProposal,
 } from '@/src/main/git-repositories'
+import { restorePiUserMessageDraft } from '@/src/main/pi-session-message-mapping'
 import { normalizeSessionTitle } from '@/src/session-title'
 import type { OwnedPiSessionLocation, PiSessionCreationIntent, PiSessionFileStore } from '@/src/main/pi-session-files'
 import type { SqliteDatabase } from './sqlite'
@@ -74,6 +78,8 @@ export type WorkstreamCreationResult = Readonly<{
   sessionId: SessionId
   snapshot: WorkstreamsSnapshot
 }>
+
+export type SessionForkResult = WorkstreamCreationResult & Readonly<{ draft: string }>
 
 export type PreparedSessionRepository = Readonly<{
   repositoryId: string
@@ -320,7 +326,7 @@ export function createWorkstreamSessionStore({
     database: SqliteDatabase,
     workstreamId: string,
     options: Readonly<
-      { title?: string } & (
+      { title?: string; fork?: Readonly<{ parentSessionId: SessionId; entryId: string }> } & (
         { mode: 'default'; repositoryId: string } | { mode: ManagedSessionMode; repositoryId?: never }
       )
     >
@@ -333,8 +339,9 @@ export function createWorkstreamSessionStore({
     database
       .prepare(
         `INSERT INTO sessions
-        (id, workstream_id, title, mode, availability, access_kind, repository_id, pi_session_id, expected_jsonl_path, creation_status, created_at)
-       VALUES (?, ?, ?, ?, 'unavailable', ?, ?, ?, ?, 'pending', ?)`
+        (id, workstream_id, title, mode, availability, access_kind, repository_id, pi_session_id,
+         expected_jsonl_path, creation_status, created_at, parent_session_id, forked_from_entry_id)
+       VALUES (?, ?, ?, ?, 'unavailable', ?, ?, ?, ?, 'pending', ?, ?, ?)`
       )
       .run(
         sessionId,
@@ -345,15 +352,24 @@ export function createWorkstreamSessionStore({
         options.mode === 'default' ? options.repositoryId : null,
         piSessionId,
         intent.sessionPath,
-        Date.now()
+        Date.now(),
+        options.fork?.parentSessionId ?? null,
+        options.fork?.entryId ?? null
       )
     database
       .prepare(
         `INSERT INTO external_side_effect_intents
         (id, kind, status, session_id, pi_session_id, directory_path, session_path)
-       VALUES (?, 'create-pi-session-file', 'pending', ?, ?, ?, ?)`
+       VALUES (?, ?, 'pending', ?, ?, ?, ?)`
       )
-      .run(intentId, sessionId, intent.piSessionId, intent.directoryPath, intent.sessionPath)
+      .run(
+        intentId,
+        options.fork ? 'fork-pi-session-file' : 'create-pi-session-file',
+        sessionId,
+        intent.piSessionId,
+        intent.directoryPath,
+        intent.sessionPath
+      )
 
     return sessionId
   }
@@ -395,7 +411,8 @@ export function createWorkstreamSessionStore({
   async function previewWorktreeProposal(
     workspaceId: string,
     workstreamId: string,
-    repositoryId: string
+    repositoryId: string,
+    sourcePath?: string
   ): Promise<readonly WorktreeProposal[]> {
     const database = openDatabase()
 
@@ -424,7 +441,7 @@ export function createWorkstreamSessionStore({
         repositories.map((repository) =>
           proposeWorktree({
             repositoryId: String(repository.id),
-            repositoryPath: String(repository.directory_path),
+            repositoryPath: sourcePath ?? String(repository.directory_path),
             worktreeId: workstreamId,
           })
         )
@@ -456,9 +473,10 @@ export function createWorkstreamSessionStore({
   async function prepareWorktreeBackedQuickSession(
     workspaceId: string,
     workstreamId: string,
-    repositoryId: string
+    repositoryId: string,
+    sourcePath?: string
   ): Promise<void> {
-    const proposals = await previewWorktreeProposal(workspaceId, workstreamId, repositoryId)
+    const proposals = await previewWorktreeProposal(workspaceId, workstreamId, repositoryId, sourcePath)
     const database = openDatabase()
     let resumingCreation = false
 
@@ -889,6 +907,195 @@ export function createWorkstreamSessionStore({
     return { repositoryId, workingPath: proposal.worktreePath, resourcePolicyRevision }
   }
 
+  async function getSessionForkPoints(sessionId: SessionId): Promise<readonly SessionForkPoint[]> {
+    const resolution = await resolveOwnedSession(sessionId)
+    if (!resolution) throw new TypeError('The Session is unavailable.')
+
+    const manager = SessionManager.open(resolution.sessionPath, undefined, resolution.directoryPath)
+    const messages = manager.getBranch().flatMap((entry) => {
+      if (entry.type !== 'message' || entry.message.role !== 'user') return []
+
+      const text = restorePiUserMessageDraft(userMessageText(entry.message.content))
+      return text ? [{ entryId: entry.id, text }] : []
+    })
+
+    return messages.map((message, index) => ({
+      ...message,
+      position: index + 1,
+      total: messages.length,
+    }))
+  }
+
+  async function forkSession(sessionId: SessionId, options: ForkSessionOptions): Promise<SessionForkResult> {
+    const title = normalizeSessionTitle(options.title)
+    if (!title) throw new TypeError('A Session title is required.')
+
+    const forkPoint = (await getSessionForkPoints(sessionId)).find((point) => point.entryId === options.entryId)
+    if (!forkPoint) throw new TypeError('Select a user message from the current Session history.')
+    const sourceResolution = await resolveOwnedSession(sessionId)
+    if (!sourceResolution) throw new TypeError('The Session is unavailable.')
+
+    const leaseId = randomUUID()
+    let sourceWorkstreamId: string
+    let sourceMode: SessionMode
+    let sourceRepositoryId: string | undefined
+    let sourceWorkingLocation: WorkstreamWorkingLocation
+    let workspaceId: string
+    const authority = openDatabase()
+
+    try {
+      authority.exec('BEGIN IMMEDIATE;')
+      const source = authority
+        .prepare(
+          `SELECT session.workstream_id, session.mode, session.repository_id, session.creation_status,
+                  session.availability, workstream.workspace_id, workstream.goal, workstream.lifecycle,
+                  workstream.working_location
+             FROM sessions session
+             JOIN workstreams workstream ON workstream.id = session.workstream_id
+            WHERE session.id = ?`
+        )
+        .get(sessionId)
+
+      if (
+        !source ||
+        source.creation_status !== 'finalized' ||
+        source.availability !== 'available' ||
+        source.lifecycle !== 'active'
+      ) {
+        throw new TypeError('The Session must be available and active before it can be forked.')
+      }
+      if (source.mode !== 'default' && source.mode !== 'brainstorm' && source.mode !== 'implement') {
+        throw new TypeError('This Session mode cannot be forked.')
+      }
+      if (source.mode === 'default' && (source.goal !== null || typeof source.repository_id !== 'string')) {
+        throw new TypeError('The Quick Session ownership is malformed.')
+      }
+      if (source.mode !== 'default' && typeof source.goal !== 'string') {
+        throw new TypeError('The Session must belong to a goal-based Workstream.')
+      }
+      if (source.working_location !== 'current-checkouts' && source.working_location !== 'worktrees') {
+        throw new TypeError('The Session working location is malformed.')
+      }
+      if (authority.prepare('SELECT 1 FROM session_run_leases WHERE session_id = ?').get(sessionId)) {
+        throw new TypeError('Wait for the Session to become idle before forking it.')
+      }
+
+      sourceWorkstreamId = String(source.workstream_id)
+      sourceMode = source.mode
+      sourceRepositoryId = typeof source.repository_id === 'string' ? source.repository_id : undefined
+      sourceWorkingLocation = source.working_location
+      workspaceId = String(source.workspace_id)
+      authority
+        .prepare(
+          `INSERT INTO session_run_leases (workstream_id, lease_id, session_id, purpose, acquired_at)
+           VALUES (?, ?, ?, 'session-fork', ?)`
+        )
+        .run(sourceWorkstreamId, leaseId, sessionId, Date.now())
+      authority.exec('COMMIT;')
+    } catch (error) {
+      try {
+        authority.exec('ROLLBACK;')
+      } catch {
+        // No transaction remains after a successful commit.
+      }
+      throw error
+    } finally {
+      authority.close()
+    }
+
+    try {
+      let targetWorkstreamId = sourceWorkstreamId
+
+      if (sourceMode === 'default') {
+        if (!sourceRepositoryId) throw new TypeError('The Quick Session Repository is unavailable.')
+
+        targetWorkstreamId = createWorkstreamId()
+        if (sourceWorkingLocation === 'worktrees') {
+          await prepareWorktreeBackedQuickSession(
+            workspaceId,
+            targetWorkstreamId,
+            sourceRepositoryId,
+            sourceResolution.directoryPath
+          )
+        }
+      }
+
+      const creation = openDatabase()
+      let targetSessionId: SessionId
+
+      try {
+        creation.exec('BEGIN IMMEDIATE;')
+        const lease = creation
+          .prepare("SELECT lease_id FROM session_run_leases WHERE session_id = ? AND purpose = 'session-fork'")
+          .get(sessionId)
+        if (lease?.lease_id !== leaseId) throw new TypeError('The Session fork authority expired.')
+
+        if (sourceMode === 'default' && sourceWorkingLocation === 'current-checkouts') {
+          creation
+            .prepare(
+              "INSERT INTO workstreams (id, workspace_id, goal, lifecycle, working_location, created_at) VALUES (?, ?, NULL, 'active', 'current-checkouts', ?)"
+            )
+            .run(targetWorkstreamId, workspaceId, Date.now())
+        }
+
+        targetSessionId =
+          sourceMode === 'default'
+            ? insertOwnedSession(creation, targetWorkstreamId, {
+                mode: 'default',
+                repositoryId: sourceRepositoryId!,
+                title,
+                fork: { parentSessionId: sessionId, entryId: options.entryId },
+              })
+            : insertOwnedSession(creation, targetWorkstreamId, {
+                mode: sourceMode,
+                title,
+                fork: { parentSessionId: sessionId, entryId: options.entryId },
+              })
+        if (sourceMode === 'default') {
+          if (sourceWorkingLocation === 'current-checkouts') {
+            insertCurrentCheckoutSessionLocation(creation, targetSessionId, sourceRepositoryId!)
+          } else {
+            insertSessionWorkingLocationsFromWorkstream(
+              creation,
+              targetSessionId,
+              targetWorkstreamId,
+              sourceRepositoryId!
+            )
+          }
+        }
+        incrementRevision(creation)
+        creation.exec('COMMIT;')
+      } catch (error) {
+        try {
+          creation.exec('ROLLBACK;')
+        } catch {
+          // The durable fork intent may already have committed.
+        }
+        throw error
+      } finally {
+        creation.close()
+      }
+
+      const status = await reconcileCommittedSession(targetSessionId)
+
+      return {
+        status,
+        sessionId: targetSessionId,
+        draft: forkPoint.text,
+        snapshot: await getWorkstreamSnapshot(workspaceId, false),
+      }
+    } finally {
+      const settled = openDatabase()
+      try {
+        settled
+          .prepare("DELETE FROM session_run_leases WHERE session_id = ? AND purpose = 'session-fork' AND lease_id = ?")
+          .run(sessionId, leaseId)
+      } finally {
+        settled.close()
+      }
+    }
+  }
+
   async function createWorkstreamSession(
     workstreamId: string,
     options: CreateSessionOptions
@@ -1270,12 +1477,27 @@ export function createWorkstreamSessionStore({
     createQuickSession,
     prepareSessionRepository,
     createWorkstreamSession,
+    getSessionForkPoints,
+    forkSession,
     setWorkstreamLifecycle,
     renameWorkstreamSession,
     resolveOwnedSession,
     resolveWorkstreamWorkingLocation,
     getCurrentWorkstreamRepositorySet,
   }
+}
+
+function userMessageText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+
+  return content
+    .flatMap((part) =>
+      typeof part === 'object' && part !== null && (part as { type?: unknown }).type === 'text'
+        ? [String((part as { text?: unknown }).text ?? '')]
+        : []
+    )
+    .join('')
 }
 
 function unavailableWorkstream(

--- a/src/main/application-state/workstreams.test.ts
+++ b/src/main/application-state/workstreams.test.ts
@@ -140,6 +140,181 @@ test('reset backs up the prior SQLite generation before replacing it', async () 
   assert.equal(backedUpGeneration, before.generationId)
 })
 
+test('forks an owned Session before a selected user message', async () => {
+  const { authority, workspace } = await createFixture()
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Explore two approaches' })
+  const source = await authority.resolveOwnedSession(created.sessionId)
+  assert.ok(source)
+  const header = JSON.parse((await readFile(source.sessionPath, 'utf8')).trim()) as Record<string, unknown>
+  const timestamp = new Date().toISOString()
+  const usage = {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }
+  await writeFile(
+    source.sessionPath,
+    [
+      header,
+      {
+        type: 'message',
+        id: 'aaaa0001',
+        parentId: null,
+        timestamp,
+        message: { role: 'user', content: 'Build it one way', timestamp: Date.now() },
+      },
+      {
+        type: 'message',
+        id: 'bbbb0002',
+        parentId: 'aaaa0001',
+        timestamp,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'First approach' }],
+          api: 'openai-responses',
+          provider: 'openai',
+          model: 'test-model',
+          usage,
+          stopReason: 'stop',
+          timestamp: Date.now(),
+        },
+      },
+      {
+        type: 'message',
+        id: 'cccc0003',
+        parentId: 'bbbb0002',
+        timestamp,
+        message: { role: 'user', content: 'Try the alternative', timestamp: Date.now() },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join('\n') + '\n',
+    'utf8'
+  )
+
+  const points = await authority.getSessionForkPoints(created.sessionId)
+  const forked = await authority.forkSession(created.sessionId, {
+    entryId: points[1]!.entryId,
+    title: 'Alternative approach',
+  })
+
+  assert.deepEqual(
+    points.map(({ text }) => text),
+    ['Build it one way', 'Try the alternative']
+  )
+  assert.equal(forked.draft, 'Try the alternative')
+  assert.notEqual(forked.sessionId, created.sessionId)
+  const workstream = forked.snapshot.workstreams[0]
+  assert.equal(workstream?.sessions.length, 2)
+  assert.equal(workstream?.sessions[1]?.mode, 'implement')
+  assert.equal(workstream?.sessions[1]?.title, 'Alternative approach')
+  const target = await authority.resolveOwnedSession(forked.sessionId)
+  assert.ok(target)
+  assert.deepEqual(
+    SessionManager.open(target.sessionPath, undefined, target.directoryPath)
+      .getBranch()
+      .flatMap((entry) =>
+        entry.type === 'message' && (entry.message.role === 'user' || entry.message.role === 'assistant')
+          ? [entry.message.role]
+          : []
+      ),
+    ['user', 'assistant']
+  )
+})
+
+test('forks a current-checkout Quick Session into a new goal-less Workstream', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  const created = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+  const source = await authority.resolveOwnedSession(created.sessionId)
+  assert.ok(source)
+  const header = JSON.parse((await readFile(source.sessionPath, 'utf8')).trim()) as Record<string, unknown>
+  const timestamp = new Date().toISOString()
+  await writeFile(
+    source.sessionPath,
+    [
+      header,
+      {
+        type: 'message',
+        id: 'aaaa0001',
+        parentId: null,
+        timestamp,
+        message: { role: 'user', content: 'Try another frontend', timestamp: Date.now() },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join('\n') + '\n',
+    'utf8'
+  )
+
+  const [point] = await authority.getSessionForkPoints(created.sessionId)
+  assert.ok(point)
+  const forked = await authority.forkSession(created.sessionId, {
+    entryId: point.entryId,
+    title: 'Alternative frontend',
+  })
+
+  assert.equal(forked.snapshot.workstreams.length, 2)
+  const targetWorkstream = forked.snapshot.workstreams.find((workstream) =>
+    workstream.sessions.some((session) => session.id === forked.sessionId)
+  )
+  const target = targetWorkstream?.sessions[0]
+  assert.equal(targetWorkstream?.goal, undefined)
+  assert.equal(targetWorkstream?.workingLocation, 'current-checkouts')
+  assert.equal(target?.mode, 'default')
+  assert.equal(target?.repositoryAccess.kind, 'direct')
+  if (target?.repositoryAccess.kind === 'direct') {
+    assert.equal(target.repositoryAccess.repositoryId, repository.id)
+  }
+})
+
+test('forks a dedicated-worktree Quick Session into a separate worktree at the source HEAD', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'initial', 'Initial commit')
+  const preview = await authority.previewWorktreeLocations(workspace.id, repository.id)
+  const created = await authority.createQuickSession(workspace.id, {
+    repositoryId: repository.id,
+    workingLocation: 'worktrees',
+    workstreamId: preview.workstreamId,
+  })
+  const source = await authority.resolveOwnedSession(created.sessionId)
+  assert.ok(source)
+  await commitRepositoryFile(source.directoryPath, 'tracked.txt', 'source branch', 'Source worktree commit')
+  const sourceHead = (await exec('git', ['-C', source.directoryPath, 'rev-parse', 'HEAD'])).stdout.trim()
+  const header = JSON.parse((await readFile(source.sessionPath, 'utf8')).trim()) as Record<string, unknown>
+  const timestamp = new Date().toISOString()
+  await writeFile(
+    source.sessionPath,
+    [
+      header,
+      {
+        type: 'message',
+        id: 'aaaa0001',
+        parentId: null,
+        timestamp,
+        message: { role: 'user', content: 'Try this in another worktree', timestamp: Date.now() },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join('\n') + '\n',
+    'utf8'
+  )
+
+  const [point] = await authority.getSessionForkPoints(created.sessionId)
+  assert.ok(point)
+  const forked = await authority.forkSession(created.sessionId, { entryId: point.entryId, title: 'Forked worktree' })
+  const target = await authority.resolveOwnedSession(forked.sessionId)
+  assert.ok(target)
+
+  assert.notEqual(target.directoryPath, source.directoryPath)
+  assert.equal((await exec('git', ['-C', target.directoryPath, 'rev-parse', 'HEAD'])).stdout.trim(), sourceHead)
+  assert.equal(await readFile(join(target.directoryPath, 'tracked.txt'), 'utf8'), 'source branch')
+})
+
 test('creates a Workstream with exactly one default Implement Session', async () => {
   const { authority, workspace } = await createFixture()
 
@@ -1618,6 +1793,27 @@ test('blocks concurrent Agent Runs that share a Repository working path', async 
   assert.equal(await authority.acquireSessionRunLease(second.sessionId), false)
 
   await authority.settleSessionRunLease(first.sessionId)
+})
+
+test('migrates version 5 application state to persist Session fork lineage', async () => {
+  const { storageDirectory } = await createFixture()
+  const database = new Database(join(storageDirectory, 'application-state.sqlite'))
+  database.exec('ALTER TABLE sessions DROP COLUMN forked_from_entry_id')
+  database.exec('ALTER TABLE sessions DROP COLUMN parent_session_id')
+  database.prepare("UPDATE metadata SET value = '5' WHERE key = 'schema_version'").run()
+  database.close()
+
+  const restarted = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
+  const migrated = new Database(join(storageDirectory, 'application-state.sqlite'))
+  const columns = migrated
+    .prepare('PRAGMA table_info(sessions)')
+    .all()
+    .map((row) => String(row.name))
+  migrated.close()
+
+  assert.equal(restarted.startup.status, 'ready')
+  assert.equal(columns.includes('parent_session_id'), true)
+  assert.equal(columns.includes('forked_from_entry_id'), true)
 })
 
 test('migrates prior application state to Session work locations', async () => {

--- a/src/main/pi-session-files.test.ts
+++ b/src/main/pi-session-files.test.ts
@@ -3,6 +3,7 @@ import { access, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, test } from 'node:test'
+import { SessionManager } from '@earendil-works/pi-coding-agent'
 import { createPiSessionFileStore } from './pi-session-files'
 
 const temporaryDirectories: string[] = []
@@ -25,6 +26,172 @@ async function createStore() {
 
   return { storageDirectory, store: await createPiSessionFileStore(storageDirectory) }
 }
+
+test('forks history before a selected user message into a new app-owned Session', async () => {
+  const { store } = await createStore()
+  const sourceIntent = store.intent('source-session')
+  const targetIntent = store.intent('forked-session')
+  const timestamp = new Date().toISOString()
+  const usage = {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }
+  await writeFile(
+    sourceIntent.sessionPath,
+    [
+      { type: 'session', version: 3, id: 'source-session', timestamp, cwd: sourceIntent.directoryPath },
+      {
+        type: 'message',
+        id: 'aaaa0001',
+        parentId: null,
+        timestamp,
+        message: { role: 'user', content: 'Original request', timestamp: Date.now() },
+      },
+      {
+        type: 'message',
+        id: 'bbbb0002',
+        parentId: 'aaaa0001',
+        timestamp,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Original response' }],
+          api: 'openai-responses',
+          provider: 'openai',
+          model: 'test-model',
+          usage,
+          stopReason: 'stop',
+          timestamp: Date.now(),
+        },
+      },
+      {
+        type: 'message',
+        id: 'cccc0003',
+        parentId: 'bbbb0002',
+        timestamp,
+        message: { role: 'user', content: 'Try another approach', timestamp: Date.now() },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join('\n') + '\n',
+    'utf8'
+  )
+
+  const outcome = await store.fork({
+    ...targetIntent,
+    sourceSessionPath: sourceIntent.sessionPath,
+    sourceEntryId: 'cccc0003',
+    title: 'Fork of original',
+  })
+
+  assert.deepEqual(outcome, { status: 'available' })
+  const entries = (await readFile(targetIntent.sessionPath, 'utf8'))
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+  assert.deepEqual(entries[0], {
+    type: 'session',
+    version: 3,
+    id: 'forked-session',
+    timestamp: entries[0]?.timestamp,
+    cwd: targetIntent.directoryPath,
+    parentSession: sourceIntent.sessionPath,
+  })
+  assert.deepEqual(
+    entries.flatMap((entry) =>
+      entry.type === 'message' ? [(entry.message as { role: string; content: unknown }).content] : []
+    ),
+    ['Original request', [{ type: 'text', text: 'Original response' }]]
+  )
+  assert.equal(entries.at(-1)?.type, 'session_info')
+  assert.equal(entries.at(-1)?.name, 'Fork of original')
+  await assertPrivateMode(targetIntent.sessionPath, 0o600)
+})
+
+test('does not carry a pending Queued Follow-up into a forked Session', async () => {
+  const { store } = await createStore()
+  const sourceIntent = store.intent('source-queue-session')
+  const targetIntent = store.intent('forked-queue-session')
+  const timestamp = new Date().toISOString()
+  const usage = {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }
+  await writeFile(
+    sourceIntent.sessionPath,
+    [
+      { type: 'session', version: 3, id: 'source-queue-session', timestamp, cwd: sourceIntent.directoryPath },
+      {
+        type: 'message',
+        id: 'aaaa0001',
+        parentId: null,
+        timestamp,
+        message: { role: 'user', content: 'Original request', timestamp: Date.now() },
+      },
+      {
+        type: 'message',
+        id: 'bbbb0002',
+        parentId: 'aaaa0001',
+        timestamp,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Original response' }],
+          api: 'openai-responses',
+          provider: 'openai',
+          model: 'test-model',
+          usage,
+          stopReason: 'stop',
+          timestamp: Date.now(),
+        },
+      },
+      {
+        type: 'custom',
+        id: 'cccc0003',
+        parentId: 'bbbb0002',
+        timestamp,
+        customType: 'pi-workspace.activity-layer',
+        data: {
+          version: 1,
+          type: 'queued-follow-up',
+          followUp: { id: 'follow-up-a', text: 'Do this later', createdAt: Date.now() },
+        },
+      },
+      {
+        type: 'message',
+        id: 'dddd0004',
+        parentId: 'cccc0003',
+        timestamp,
+        message: { role: 'user', content: 'Fork here', timestamp: Date.now() },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join('\n') + '\n',
+    'utf8'
+  )
+
+  await store.fork({
+    ...targetIntent,
+    sourceSessionPath: sourceIntent.sessionPath,
+    sourceEntryId: 'dddd0004',
+    title: 'Fork without queue',
+  })
+
+  const records = SessionManager.open(targetIntent.sessionPath)
+    .getBranch()
+    .flatMap((entry) =>
+      entry.type === 'custom' && entry.customType === 'pi-workspace.activity-layer'
+        ? [entry.data as { type?: string; followUpId?: string }]
+        : []
+    )
+  assert.deepEqual(records.at(-1), { version: 1, type: 'queued-follow-up-removed', followUpId: 'follow-up-a' })
+})
 
 test('creates an app-owned Session at its deterministic path', async () => {
   const { store } = await createStore()

--- a/src/main/pi-session-files.ts
+++ b/src/main/pi-session-files.ts
@@ -1,6 +1,7 @@
-import { access, readFile, rename, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { access, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { CURRENT_SESSION_VERSION } from '@earendil-works/pi-coding-agent'
+import { CURRENT_SESSION_VERSION, SessionManager } from '@earendil-works/pi-coding-agent'
 import { ensurePrivateDirectory, ensurePrivateFile } from '@/src/main/private-storage'
 
 export type PiSessionCreationIntent = Readonly<{
@@ -14,11 +15,20 @@ export type OwnedPiSessionLocation = Readonly<{
   sessionPath: string
 }>
 
+export type PiSessionForkIntent = PiSessionCreationIntent &
+  Readonly<{
+    sourceSessionPath: string
+    sourceEntryId: string
+    title: string
+    contextMessage?: string
+  }>
+
 export type PiSessionFileCreationOutcome = Readonly<{ status: 'available' | 'quarantined' }>
 
 export interface PiSessionFileStore {
   intent(piSessionId: string): PiSessionCreationIntent
   create(intent: PiSessionCreationIntent): Promise<PiSessionFileCreationOutcome>
+  fork(intent: PiSessionForkIntent): Promise<PiSessionFileCreationOutcome>
   resolve(intent: PiSessionCreationIntent): Promise<OwnedPiSessionLocation | undefined>
 }
 
@@ -35,11 +45,13 @@ export async function createPiSessionFileStore(storageDirectory: string): Promis
   const directoryPath = join(storageDirectory, 'session-cwd')
   const sessionsDirectory = join(storageDirectory, 'sessions')
   const quarantineDirectory = join(storageDirectory, 'session-quarantine')
+  const stagingDirectory = join(storageDirectory, 'session-staging')
 
   await Promise.all([
     ensurePrivateDirectory(directoryPath),
     ensurePrivateDirectory(sessionsDirectory),
     ensurePrivateDirectory(quarantineDirectory),
+    ensurePrivateDirectory(stagingDirectory),
   ])
 
   function intent(piSessionId: string): PiSessionCreationIntent {
@@ -89,6 +101,121 @@ export async function createPiSessionFileStore(storageDirectory: string): Promis
     await rename(path, quarantinePath)
   }
 
+  function finalizeForkFile(forkIntent: PiSessionForkIntent): void {
+    const targetManager = SessionManager.open(forkIntent.sessionPath, undefined)
+    const queuedFollowUpIds = new Set<string>()
+    let hasContextMessage = false
+
+    for (const entry of targetManager.getBranch()) {
+      if (
+        entry.type === 'custom_message' &&
+        entry.customType === 'pi-workspace.session-fork' &&
+        entry.content === forkIntent.contextMessage
+      ) {
+        hasContextMessage = true
+      }
+      if (
+        entry.type !== 'custom' ||
+        entry.customType !== 'pi-workspace.activity-layer' ||
+        typeof entry.data !== 'object' ||
+        entry.data === null
+      ) {
+        continue
+      }
+
+      const record = entry.data as {
+        type?: unknown
+        followUp?: { id?: unknown }
+        followUpId?: unknown
+      }
+      if (record.type === 'queued-follow-up' && typeof record.followUp?.id === 'string') {
+        queuedFollowUpIds.add(record.followUp.id)
+      }
+      if (record.type === 'queued-follow-up-removed' && typeof record.followUpId === 'string') {
+        queuedFollowUpIds.delete(record.followUpId)
+      }
+    }
+
+    for (const followUpId of queuedFollowUpIds) {
+      targetManager.appendCustomEntry('pi-workspace.activity-layer', {
+        version: 1,
+        type: 'queued-follow-up-removed',
+        followUpId,
+      })
+    }
+    if (targetManager.getSessionName() !== forkIntent.title) {
+      targetManager.appendSessionInfo(forkIntent.title)
+    }
+    if (forkIntent.contextMessage && !hasContextMessage) {
+      targetManager.appendCustomMessageEntry('pi-workspace.session-fork', forkIntent.contextMessage, false)
+    }
+  }
+
+  async function fork(forkIntent: PiSessionForkIntent): Promise<PiSessionFileCreationOutcome> {
+    if (await fileExists(forkIntent.sessionPath)) {
+      if (await resolve(forkIntent)) {
+        finalizeForkFile(forkIntent)
+        return { status: 'available' }
+      }
+
+      await quarantine(forkIntent.sessionPath, forkIntent.piSessionId)
+      return { status: 'quarantined' }
+    }
+
+    const sourceManager = SessionManager.open(forkIntent.sourceSessionPath, undefined)
+    const selectedEntry = sourceManager.getEntry(forkIntent.sourceEntryId)
+    const selectedOnActiveBranch = sourceManager.getBranch().some((entry) => entry.id === forkIntent.sourceEntryId)
+
+    if (!selectedOnActiveBranch || selectedEntry?.type !== 'message' || selectedEntry.message.role !== 'user') {
+      throw new TypeError('Select a user message from the current Session history.')
+    }
+
+    const temporaryDirectory = await mkdtemp(join(stagingDirectory, 'fork-'))
+    const temporaryPath = `${forkIntent.sessionPath}.${randomUUID()}.tmp`
+
+    try {
+      let header: Record<string, unknown>
+      let entries: readonly unknown[]
+
+      if (selectedEntry.parentId === null) {
+        header = {
+          type: 'session',
+          version: CURRENT_SESSION_VERSION,
+          id: forkIntent.piSessionId,
+          timestamp: new Date().toISOString(),
+          cwd: forkIntent.directoryPath,
+          parentSession: forkIntent.sourceSessionPath,
+        }
+        entries = []
+      } else {
+        const branchManager = SessionManager.open(forkIntent.sourceSessionPath, temporaryDirectory)
+        branchManager.createBranchedSession(selectedEntry.parentId)
+        const branchedHeader = branchManager.getHeader()
+
+        if (!branchedHeader) throw new Error('Pi could not create the forked Session history.')
+
+        header = {
+          ...branchedHeader,
+          id: forkIntent.piSessionId,
+          cwd: forkIntent.directoryPath,
+          parentSession: forkIntent.sourceSessionPath,
+        }
+        entries = branchManager.getEntries()
+      }
+
+      const content = [header, ...entries].map((entry) => JSON.stringify(entry)).join('\n') + '\n'
+      await writeFile(temporaryPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+      await rename(temporaryPath, forkIntent.sessionPath)
+      await ensurePrivateFile(forkIntent.sessionPath)
+
+      finalizeForkFile(forkIntent)
+
+      return { status: 'available' }
+    } finally {
+      await Promise.all([rm(temporaryDirectory, { recursive: true, force: true }), rm(temporaryPath, { force: true })])
+    }
+  }
+
   async function create(creationIntent: PiSessionCreationIntent): Promise<PiSessionFileCreationOutcome> {
     const quarantinedPath = join(quarantineDirectory, `${creationIntent.piSessionId}.jsonl`)
 
@@ -118,5 +245,5 @@ export async function createPiSessionFileStore(storageDirectory: string): Promis
     return { status: 'available' }
   }
 
-  return { intent, create, resolve }
+  return { intent, create, fork, resolve }
 }

--- a/src/main/pi-session-message-mapping.test.ts
+++ b/src/main/pi-session-message-mapping.test.ts
@@ -6,6 +6,7 @@ import {
   createPiSessionMessageStream,
   mapPiSessionMessageHistory,
   projectPiUserMessage,
+  restorePiUserMessageDraft,
 } from './pi-session-message-mapping'
 
 test('maps every text message on the active branch, including messages before compaction', () => {
@@ -49,6 +50,15 @@ test('projects a persisted Pi Skill invocation without exposing its expanded ins
       },
     ],
   })
+})
+
+test('restores an expanded Pi Skill invocation as an editable Composer draft', () => {
+  assert.equal(
+    restorePiUserMessageDraft(
+      '<skill name="code-review" location="/private/code-review/SKILL.md">\nExpanded instructions\n</skill>\n\nReview this change.'
+    ),
+    '/skill:code-review Review this change.'
+  )
 })
 
 test('restores a persisted raw Skill token as an inline reference', () => {

--- a/src/main/pi-session-message-mapping.ts
+++ b/src/main/pi-session-message-mapping.ts
@@ -145,6 +145,25 @@ function toSessionMessage(
   }
 }
 
+export function restorePiUserMessageDraft(source: string): string {
+  const projected = projectPiUserMessage(source)
+  if (!projected.skills?.length) return projected.text
+
+  let draft = ''
+  let textOffset = 0
+
+  for (const mention of projected.skills) {
+    draft += projected.text.slice(textOffset, mention.offset)
+    draft += `/skill:${mention.skill.name}`
+    textOffset = mention.offset
+
+    const nextCharacter = projected.text[textOffset]
+    if (nextCharacter && !/\s/.test(nextCharacter)) draft += ' '
+  }
+
+  return draft + projected.text.slice(textOffset)
+}
+
 export function projectPiUserMessage(
   source: string,
   skills: readonly SessionSkill[] = []

--- a/src/main/workstreams-ipc.ts
+++ b/src/main/workstreams-ipc.ts
@@ -4,8 +4,10 @@ import {
   parseCreateQuickSessionRequest,
   parseCreateSessionRequest,
   parseCreateWorkstreamRequest,
+  parseForkSessionRequest,
   parsePreviewWorktreeLocationsRequest,
   parseRenameOwnedSessionRequest,
+  parseSessionForkPointsRequest,
   parseShowWorkingLocationRequest,
   parseWorkstreamLifecycleRequest,
   workstreamsIpcChannels,
@@ -54,6 +56,20 @@ export function initializeWorkstreams(authority: ApplicationAuthority, options: 
     return request
       ? authority.createWorkstreamSession(request.workstreamId, request.options)
       : Promise.reject(new TypeError('A Workstream and valid Session mode are required.'))
+  })
+  handleTrustedIpc(workstreamsIpcChannels.getSessionForkPoints, (_event, value: unknown) => {
+    const request = parseSessionForkPointsRequest(value)
+
+    return request
+      ? authority.getSessionForkPoints(request.sessionId)
+      : Promise.reject(new TypeError('A Session is required.'))
+  })
+  handleTrustedIpc(workstreamsIpcChannels.forkSession, (_event, value: unknown) => {
+    const request = parseForkSessionRequest(value)
+
+    return request
+      ? authority.forkSession(request.sessionId, request.options)
+      : Promise.reject(new TypeError('A Session, user message, and title are required.'))
   })
   handleTrustedIpc(workstreamsIpcChannels.setLifecycle, (_event, value: unknown) => {
     const request = parseWorkstreamLifecycleRequest(value)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,7 +15,7 @@ import type {
 } from '@/src/session-configuration'
 import { sessionConfigurationIpcChannels } from '@/src/session-configuration-ipc'
 import type { SettingsBridge, SettingsSnapshot, SettingsUpdate } from '@/src/settings'
-import type { WorkstreamsBridge, WorkstreamCreationOutcome } from '@/src/workstreams'
+import type { SessionForkOutcome, WorkstreamsBridge, WorkstreamCreationOutcome } from '@/src/workstreams'
 import { workstreamsIpcChannels } from '@/src/workstreams-ipc'
 import type { WorkstreamKnowledgeBridge } from '@/src/workstream-knowledge-ipc'
 import type { WorkstreamKnowledge } from '@/src/domain/workstream-knowledge-transitions'
@@ -119,6 +119,15 @@ const workstreamsBridge: WorkstreamsBridge = {
       workstreamId,
       ...options,
     }) as Promise<WorkstreamCreationOutcome>
+  },
+  getSessionForkPoints(sessionId) {
+    return ipcRenderer.invoke(workstreamsIpcChannels.getSessionForkPoints, { sessionId })
+  },
+  forkSession(sessionId, options) {
+    return ipcRenderer.invoke(workstreamsIpcChannels.forkSession, {
+      sessionId,
+      ...options,
+    }) as Promise<SessionForkOutcome>
   },
   setLifecycle(workstreamId, lifecycle) {
     return ipcRenderer.invoke(workstreamsIpcChannels.setLifecycle, { workstreamId, lifecycle })

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -363,6 +363,44 @@ test('selects and reveals a newly created Session from the returned snapshot', a
   )
 })
 
+test('reveals a forked Session with the selected message restored as its draft', async () => {
+  const forkedSessionId = sessionId('forked-session')
+  const updatedWorkstream: Workstream = {
+    ...workspaceAWorkstream,
+    sessions: [
+      ...workspaceAWorkstream.sessions,
+      {
+        ...workspaceAWorkstream.sessions[0]!,
+        id: forkedSessionId,
+        title: 'Fork of Session A',
+      },
+    ],
+  }
+  const bridge = createBridge({
+    getSessionForkPoints: async () => [{ entryId: 'aaaa0001', text: 'Try another approach', position: 1, total: 1 }],
+    forkSession: async () => ({
+      status: 'available',
+      sessionId: forkedSessionId,
+      snapshot: snapshot([updatedWorkstream], 2),
+      draft: 'Try another approach',
+    }),
+  })
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(bridge)
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Session A Implement' }))
+  await view.findByRole('heading', { name: 'Session A' })
+  await user.click(view.getByRole('button', { name: 'Session A options' }))
+  await user.click(await view.findByRole('menuitem', { name: 'Fork Session…' }))
+  await view.findByText('Try another approach', { exact: true })
+  await user.click(view.getByRole('button', { name: 'Fork Session' }))
+
+  await waitFor(() => assert.ok(view.getByRole('heading', { name: 'Fork of Session A' })))
+  const composer = view.getByLabelText('Message for Fork of Session A')
+  await waitFor(() => assert.equal(composer.textContent, 'Try another approach'))
+})
+
 test('ignores an older mutation response within the selected Workspace', async () => {
   const lifecycleUpdate = deferred<WorkstreamsSnapshot>()
   const newSessionId = sessionId('newer-session')

--- a/src/renderer/components/session-area.tsx
+++ b/src/renderer/components/session-area.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useRef } from 'react'
 import type { ComposerBridge } from '@/src/composer'
 import type { SessionId } from '@/src/domain/session'
-import type { OwnedSession, WorkstreamLifecycle } from '@/src/domain/workstream'
+import type {
+  ForkSessionOptions,
+  OwnedSession,
+  SessionForkPoint,
+  WorkstreamLifecycle,
+  WorkstreamWorkingLocation,
+} from '@/src/domain/workstream'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
 import { SessionContainer } from '@/src/renderer/components/session-container'
@@ -9,6 +15,7 @@ import { SessionContainer } from '@/src/renderer/components/session-container'
 type SessionAreaProperties = {
   sessions: readonly OwnedSession[]
   workstreamLifecycles?: ReadonlyMap<string, WorkstreamLifecycle>
+  workstreamWorkingLocations?: ReadonlyMap<string, WorkstreamWorkingLocation>
   activeSessionId?: SessionId
   revealRequest?: Readonly<{ sessionId: SessionId; request: number }>
   composerFocusRequest?: Readonly<{ sessionId: SessionId; request: number }>
@@ -34,12 +41,15 @@ type SessionAreaProperties = {
   resumeQueuedFollowUps?: NonNullable<ComposerBridge['resumeQueuedFollowUps']>
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
+  getSessionForkPoints?: (sessionId: SessionId) => Promise<readonly SessionForkPoint[]>
+  forkSession?: (sessionId: SessionId, options: ForkSessionOptions) => Promise<void>
   onToggleSessionPin: (sessionId: SessionId) => void
 }
 
 export function SessionArea({
   sessions,
   workstreamLifecycles = new Map(),
+  workstreamWorkingLocations = new Map(),
   activeSessionId,
   revealRequest,
   composerFocusRequest,
@@ -59,6 +69,8 @@ export function SessionArea({
   resumeQueuedFollowUps,
   sessionConfiguration,
   sessionSkills,
+  getSessionForkPoints,
+  forkSession,
   onToggleSessionPin,
 }: SessionAreaProperties) {
   const sessionPaneRefs = useRef(new Map<SessionId, HTMLDivElement>())
@@ -95,6 +107,7 @@ export function SessionArea({
           <SessionContainer
             session={session}
             workstreamLifecycle={workstreamLifecycles.get(session.workstreamId) ?? 'active'}
+            workingLocation={workstreamWorkingLocations.get(session.workstreamId) ?? 'current-checkouts'}
             active={session.id === activeSessionId}
             draft={drafts.get(session.id) ?? ''}
             composerFocusRequest={
@@ -114,6 +127,8 @@ export function SessionArea({
             resumeQueuedFollowUps={resumeQueuedFollowUps}
             sessionConfiguration={sessionConfiguration}
             sessionSkills={sessionSkills}
+            getForkPoints={getSessionForkPoints ? () => getSessionForkPoints(session.id) : undefined}
+            forkSession={forkSession ? (options) => forkSession(session.id, options) : undefined}
             onTogglePin={() => onToggleSessionPin(session.id)}
           />
         </div>

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -1,11 +1,19 @@
-import { useId } from 'react'
-import { LockKeyhole, Pencil, TriangleAlert } from 'lucide-react'
+import { useId, useState } from 'react'
+import { Ellipsis, GitFork, LockKeyhole, Pencil, TriangleAlert } from 'lucide-react'
+import { Dropdown, DropdownButton, DropdownItem, DropdownLabel, DropdownMenu } from '@/components/ui-kit/dropdown'
 import type { ComposerBridge } from '@/src/composer'
-import type { OwnedSession, WorkstreamLifecycle } from '@/src/domain/workstream'
+import type {
+  ForkSessionOptions,
+  OwnedSession,
+  SessionForkPoint,
+  WorkstreamLifecycle,
+  WorkstreamWorkingLocation,
+} from '@/src/domain/workstream'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
 import { Composer } from '@/src/renderer/components/composer'
 import { QueuedFollowUpTray } from '@/src/renderer/components/queued-follow-up-tray'
+import { SessionForkDialog } from '@/src/renderer/components/session-fork-dialog'
 import { SessionMessages } from '@/src/renderer/components/session-messages'
 import { SessionPinButton } from '@/src/renderer/components/session-pin-button'
 import { SessionTitleEditor } from '@/src/renderer/components/session-title-editor'
@@ -15,6 +23,7 @@ import { useSessionTranscript } from '@/src/renderer/session-transcript-state'
 type SessionContainerProperties = {
   session: OwnedSession
   workstreamLifecycle: WorkstreamLifecycle
+  workingLocation?: WorkstreamWorkingLocation
   active: boolean
   draft: string
   composerFocusRequest?: number
@@ -32,12 +41,15 @@ type SessionContainerProperties = {
   resumeQueuedFollowUps?: NonNullable<ComposerBridge['resumeQueuedFollowUps']>
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
+  getForkPoints?: () => Promise<readonly SessionForkPoint[]>
+  forkSession?: (options: ForkSessionOptions) => Promise<void>
   onTogglePin: () => void
 }
 
 export function SessionContainer({
   session,
   workstreamLifecycle,
+  workingLocation = 'current-checkouts',
   active,
   draft,
   composerFocusRequest,
@@ -55,9 +67,12 @@ export function SessionContainer({
   resumeQueuedFollowUps,
   sessionConfiguration,
   sessionSkills,
+  getForkPoints,
+  forkSession,
   onTogglePin,
 }: SessionContainerProperties) {
   const headingId = useId()
+  const [forkPosition, setForkPosition] = useState<number | 'latest'>()
   const transcriptState = useSessionTranscript(session.id)
   const isWorking = transcriptState.snapshot?.isWorking ?? false
   const unavailability = getSessionUnavailability(session)
@@ -120,12 +135,30 @@ export function SessionContainer({
             </button>
           </>
         )}
+        {getForkPoints && forkSession && !unavailability && workstreamLifecycle === 'active' && (
+          <Dropdown>
+            <DropdownButton
+              as="button"
+              aria-label={`${session.title} options`}
+              className="ml-auto shrink-0 rounded-sm p-1.5 text-session-pin hover:bg-session-interaction focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Ellipsis aria-hidden="true" className="size-4" />
+            </DropdownButton>
+            <DropdownMenu anchor="bottom end">
+              <DropdownItem disabled={isWorking} onClick={() => setForkPosition('latest')}>
+                <GitFork aria-hidden="true" data-slot="icon" />
+                <DropdownLabel>Fork Session…</DropdownLabel>
+              </DropdownItem>
+            </DropdownMenu>
+          </Dropdown>
+        )}
         <SessionPinButton
           sessionName={session.title}
           pinned={pinned}
           disabled={Boolean(unavailability) && !pinned}
           onToggle={onTogglePin}
-          className="ml-auto shrink-0"
+          className={`${getForkPoints && forkSession && !unavailability && workstreamLifecycle === 'active' ? '' : 'ml-auto'} shrink-0`}
         />
       </header>
 
@@ -136,6 +169,11 @@ export function SessionContainer({
         timelineAnnouncement={transcriptState.announcement}
         timelineError={transcriptState.error}
         onReloadTimeline={transcriptState.reload}
+        onForkFromMessage={
+          getForkPoints && forkSession && workstreamLifecycle === 'active' && !unavailability
+            ? (position) => setForkPosition(position)
+            : undefined
+        }
       />
       {!composerUnavailable && transcriptState.snapshot?.queuedFollowUps && (
         <QueuedFollowUpTray
@@ -145,6 +183,17 @@ export function SessionContainer({
           queuedFollowUpsPaused={transcriptState.snapshot.queuedFollowUpsPaused ?? false}
           removeQueuedFollowUp={removeQueuedFollowUp}
           resumeQueuedFollowUps={resumeQueuedFollowUps}
+        />
+      )}
+      {getForkPoints && forkSession && forkPosition !== undefined && (
+        <SessionForkDialog
+          open
+          session={session}
+          initialPosition={forkPosition === 'latest' ? undefined : forkPosition}
+          workingLocation={workingLocation}
+          getForkPoints={getForkPoints}
+          onFork={forkSession}
+          onClose={() => setForkPosition(undefined)}
         />
       )}
       {composerUnavailable ? (

--- a/src/renderer/components/session-fork-dialog.test.tsx
+++ b/src/renderer/components/session-fork-dialog.test.tsx
@@ -18,6 +18,11 @@ const source: OwnedSession = {
 
 afterEach(() => cleanup())
 
+const forkPoints = [
+  { entryId: 'aaaa0001', text: 'First approach', position: 1, total: 2 },
+  { entryId: 'bbbb0002', text: 'Second approach', position: 2, total: 2 },
+] as const
+
 test('forks from the preselected canonical user-message position', async () => {
   const user = userEvent.setup()
   const requests: unknown[] = []
@@ -27,10 +32,7 @@ test('forks from the preselected canonical user-message position', async () => {
       session={source}
       initialPosition={1}
       workingLocation="current-checkouts"
-      getForkPoints={async () => [
-        { entryId: 'aaaa0001', text: 'First approach', position: 1, total: 2 },
-        { entryId: 'bbbb0002', text: 'Second approach', position: 2, total: 2 },
-      ]}
+      getForkPoints={async () => forkPoints}
       onClose={() => {}}
       onFork={async (options) => {
         requests.push(options)
@@ -40,6 +42,30 @@ test('forks from the preselected canonical user-message position', async () => {
   )
 
   await waitFor(() => assert.ok(view.getByText('First approach', { exact: true })))
+  await user.click(view.getByRole('button', { name: 'Fork Session' }))
+
+  assert.deepEqual(requests, [{ entryId: 'aaaa0001', title: 'Fork of Source Session' }])
+})
+
+test('lets the user choose a history boundary when forking from the Session menu', async () => {
+  const user = userEvent.setup()
+  const requests: unknown[] = []
+  const view = render(
+    <SessionForkDialog
+      open
+      session={source}
+      workingLocation="current-checkouts"
+      getForkPoints={async () => forkPoints}
+      onClose={() => {}}
+      onFork={async (options) => {
+        requests.push(options)
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await waitFor(() => assert.ok(view.getByText('First approach', { exact: true })))
+  await user.click(view.getByText('First approach', { exact: true }))
   await user.click(view.getByRole('button', { name: 'Fork Session' }))
 
   assert.deepEqual(requests, [{ entryId: 'aaaa0001', title: 'Fork of Source Session' }])

--- a/src/renderer/components/session-fork-dialog.test.tsx
+++ b/src/renderer/components/session-fork-dialog.test.tsx
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { browser } from '@/src/renderer/test-dom'
+import { sessionId } from '@/src/domain/session'
+import type { OwnedSession } from '@/src/domain/workstream'
+import { SessionForkDialog } from './session-fork-dialog'
+
+const source: OwnedSession = {
+  id: sessionId('source-session'),
+  workstreamId: 'workstream-a',
+  title: 'Source Session',
+  mode: 'implement',
+  availability: 'available',
+  repositoryAccess: { kind: 'managed' },
+}
+
+afterEach(() => cleanup())
+
+test('forks from the preselected canonical user-message position', async () => {
+  const user = userEvent.setup()
+  const requests: unknown[] = []
+  const view = render(
+    <SessionForkDialog
+      open
+      session={source}
+      initialPosition={1}
+      workingLocation="current-checkouts"
+      getForkPoints={async () => [
+        { entryId: 'aaaa0001', text: 'First approach', position: 1, total: 2 },
+        { entryId: 'bbbb0002', text: 'Second approach', position: 2, total: 2 },
+      ]}
+      onClose={() => {}}
+      onFork={async (options) => {
+        requests.push(options)
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await waitFor(() => assert.ok(view.getByText('First approach', { exact: true })))
+  await user.click(view.getByRole('button', { name: 'Fork Session' }))
+
+  assert.deepEqual(requests, [{ entryId: 'aaaa0001', title: 'Fork of Source Session' }])
+})

--- a/src/renderer/components/session-fork-dialog.tsx
+++ b/src/renderer/components/session-fork-dialog.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui-kit/button'
 import { Dialog, DialogActions, DialogBody, DialogDescription, DialogTitle } from '@/components/ui-kit/dialog'
 import { Field, Label } from '@/components/ui-kit/fieldset'
-import { Input } from '@/components/ui-kit/input'
+import { Input, InputGroup } from '@/components/ui-kit/input'
 import type {
   ForkSessionOptions,
   OwnedSession,
@@ -20,6 +20,57 @@ type SessionForkDialogProperties = Readonly<{
   onFork(options: ForkSessionOptions): Promise<void>
   onClose(): void
 }>
+
+type ForkPointCardProperties = Readonly<{
+  point: SessionForkPoint
+  selected: boolean
+  onSelect(): void
+}>
+
+function ForkPointCard({ point, selected, onSelect }: ForkPointCardProperties) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className="group relative w-full overflow-hidden rounded-xl border border-content-border bg-content-background px-4 py-3 text-left outline-none transition-colors motion-reduce:transition-none hover:border-content-hover-border hover:bg-content-subtle-background focus-visible:ring-2 focus-visible:ring-focus-ring data-[selected=true]:border-accent data-[selected=true]:bg-content-subtle-background"
+      data-selected={selected ? 'true' : undefined}
+      onClick={onSelect}
+    >
+      <span
+        aria-hidden="true"
+        className="absolute inset-y-0 left-0 w-0.5 bg-accent opacity-0 transition-opacity motion-reduce:transition-none group-data-[selected=true]:opacity-100"
+      />
+      <span className="flex items-center justify-between gap-3 text-xs/4 text-content-muted-foreground">
+        <span>
+          Message {point.position} of {point.total}
+        </span>
+        {selected && <span className="font-medium text-content-foreground">Starts here</span>}
+      </span>
+      <span className="mt-1.5 line-clamp-3 whitespace-pre-wrap break-words text-sm/5 text-content-foreground">
+        {point.text}
+      </span>
+    </button>
+  )
+}
+
+function SelectedForkPoint({ point }: Readonly<{ point: SessionForkPoint }>) {
+  return (
+    <div className="relative ml-2 border-l-2 border-accent py-1 pl-5">
+      <span className="absolute top-0 -left-3 flex size-6 items-center justify-center rounded-full bg-accent text-accent-foreground ring-4 ring-content-background">
+        <GitFork aria-hidden="true" className="size-3.5" />
+      </span>
+      <p className="text-xs/4 font-medium text-content-muted-foreground">
+        Message {point.position} of {point.total}
+      </p>
+      <p className="mt-2 line-clamp-4 whitespace-pre-wrap break-words text-sm/5 text-content-foreground">
+        {point.text}
+      </p>
+      <p className="mt-2 text-xs/5 text-content-muted-foreground">
+        This message becomes an editable draft in the new Session.
+      </p>
+    </div>
+  )
+}
 
 export function SessionForkDialog({
   open,
@@ -60,6 +111,7 @@ export function SessionForkDialog({
       })
       .catch((operationError: unknown) => {
         if (active) {
+          setPoints([])
           setError(operationError instanceof Error ? operationError.message : 'Could not load Session messages.')
         }
       })
@@ -76,16 +128,18 @@ export function SessionForkDialog({
     return (points ?? []).filter((point) => point.text.toLocaleLowerCase().includes(normalizedQuery))
   }, [points, query])
 
+  const selectedPoint = points?.find((point) => point.entryId === selectedEntryId)
   const selectedPointVisible = visiblePoints.some((point) => point.entryId === selectedEntryId)
+  const choosingForkPoint = initialPosition === undefined
 
   const repositoryState =
     session.mode === 'implement'
-      ? 'The fork creates its own worktrees when it prepares Repositories. Earlier worktree paths are reference only.'
+      ? 'This fork stays in Implement mode and creates new worktrees when it prepares each Repository. Worktree paths in copied history are reference only.'
       : session.mode === 'brainstorm'
-        ? 'The fork remains a Brainstorm Session in this Workstream.'
+        ? 'This fork stays in Brainstorm mode and in the current Workstream.'
         : workingLocation === 'worktrees'
-          ? 'The fork gets a separate worktree from this working location’s current HEAD. Uncommitted changes are not copied.'
-          : 'The fork uses the same Repository checkout. Files are not returned to this earlier point.'
+          ? 'This fork starts from the current HEAD in a separate worktree. Uncommitted changes are not copied.'
+          : 'This fork uses the same Repository checkout. Your files stay as they are—they do not rewind with the Session history.'
 
   const close = () => {
     if (!saving) onClose()
@@ -107,83 +161,154 @@ export function SessionForkDialog({
   }
 
   return (
-    <Dialog open={open} onClose={close} size="xl" scrollable>
-      <DialogTitle className="flex items-center gap-2">
-        <GitFork aria-hidden="true" className="size-4 text-content-muted-foreground" />
-        Fork Session
-      </DialogTitle>
-      <DialogDescription>
-        Choose a user message. History before it is copied, and that message becomes an editable draft.
-      </DialogDescription>
-      <DialogBody className="min-w-0">
-        <div className="grid min-h-0 gap-5 sm:grid-cols-[minmax(0,1fr)_minmax(14rem,0.72fr)]">
-          <Field className="min-w-0">
-            <Label>User message</Label>
-            <div className="relative mt-2">
-              <Search
-                aria-hidden="true"
-                className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-content-muted-foreground"
-              />
-              <Input
-                id="session-fork-search"
-                className="pl-9"
-                placeholder="Search messages"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-              />
-            </div>
-            <div className="mt-3 max-h-72 space-y-2 overflow-y-auto pr-1">
-              {!points ? (
-                <p className="flex items-center gap-2 px-3 py-5 text-sm/5 text-content-muted-foreground" role="status">
-                  <LoaderCircle aria-hidden="true" className="size-4 animate-spin motion-reduce:animate-none" />
-                  Loading messages…
-                </p>
-              ) : visiblePoints.length === 0 ? (
-                <p className="px-3 py-5 text-sm/5 text-content-muted-foreground">
-                  {points.length === 0 ? 'No user messages are available to fork.' : 'No messages match this search.'}
-                </p>
-              ) : (
-                visiblePoints.map((point) => {
-                  const selected = point.entryId === selectedEntryId
+    <Dialog
+      className="flex max-h-full flex-col overflow-hidden p-0!"
+      open={open}
+      onClose={close}
+      size={choosingForkPoint ? '4xl' : 'xl'}
+      scrollable
+    >
+      <div className="shrink-0 border-b border-content-border px-6 py-4 sm:px-7">
+        <DialogTitle className="flex items-center gap-2.5">
+          <span className="flex size-7 items-center justify-center rounded-lg bg-content-subtle-background">
+            <GitFork aria-hidden="true" className="size-4 text-content-foreground" />
+          </span>
+          {choosingForkPoint ? 'Fork Session' : 'Fork from this message'}
+        </DialogTitle>
+        <DialogDescription className="max-w-2xl">
+          {choosingForkPoint
+            ? 'Choose where the new Session begins. Everything before that message is copied into its history.'
+            : 'Create a new Session from this point without changing the current Session.'}
+        </DialogDescription>
+      </div>
 
-                  return (
-                    <button
+      <DialogBody className="mt-0! min-h-0 overflow-y-auto px-6 py-5 sm:px-7">
+        {choosingForkPoint ? (
+          <div className="grid min-h-0 gap-7 sm:grid-cols-[minmax(0,1.2fr)_minmax(16rem,0.8fr)]">
+            <section aria-labelledby="session-fork-point-heading" className="min-w-0">
+              <div className="flex items-end justify-between gap-4">
+                <div>
+                  <h2 id="session-fork-point-heading" className="text-sm/5 font-semibold text-content-foreground">
+                    Start from
+                  </h2>
+                  <p className="mt-1 text-xs/5 text-content-muted-foreground">
+                    The selected message returns as your draft.
+                  </p>
+                </div>
+                {points && points.length > 0 && (
+                  <span className="shrink-0 text-xs/5 text-content-muted-foreground">
+                    {points.length} {points.length === 1 ? 'message' : 'messages'}
+                  </span>
+                )}
+              </div>
+
+              {points && points.length > 4 && (
+                <div className="mt-4">
+                  <InputGroup>
+                    <Search aria-hidden="true" data-slot="icon" />
+                    <Input
+                      aria-label="Search user messages"
+                      placeholder="Search user messages"
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                    />
+                  </InputGroup>
+                </div>
+              )}
+
+              <div className="mt-4 max-h-[min(25rem,48vh)] space-y-2.5 overflow-y-auto pr-1">
+                {!points ? (
+                  <p
+                    className="flex items-center gap-2 rounded-xl border border-content-border px-4 py-6 text-sm/5 text-content-muted-foreground"
+                    role="status"
+                  >
+                    <LoaderCircle aria-hidden="true" className="size-4 animate-spin motion-reduce:animate-none" />
+                    Loading messages…
+                  </p>
+                ) : visiblePoints.length === 0 ? (
+                  <p className="rounded-xl border border-dashed border-content-border px-4 py-6 text-sm/5 text-content-muted-foreground">
+                    {points.length === 0
+                      ? error
+                        ? 'Session messages could not be loaded.'
+                        : 'No user messages are available to fork.'
+                      : 'No messages match this search.'}
+                  </p>
+                ) : (
+                  visiblePoints.map((point) => (
+                    <ForkPointCard
                       key={point.entryId}
-                      type="button"
-                      aria-pressed={selected}
-                      className="w-full rounded-lg border border-content-border bg-content-background px-3 py-2.5 text-left text-sm/5 text-content-foreground outline-none transition-colors hover:bg-content-subtle-background focus-visible:ring-2 focus-visible:ring-focus-ring data-[selected=true]:border-focus-ring data-[selected=true]:bg-content-subtle-background"
-                      data-selected={selected ? 'true' : undefined}
-                      onClick={() => setSelectedEntryId(point.entryId)}
-                    >
-                      <span className="line-clamp-2 whitespace-pre-wrap break-words">{point.text}</span>
-                      <span className="mt-1 block text-xs/4 text-content-muted-foreground">
-                        Message {point.position} of {point.total}
-                      </span>
-                    </button>
-                  )
-                })
+                      point={point}
+                      selected={point.entryId === selectedEntryId}
+                      onSelect={() => setSelectedEntryId(point.entryId)}
+                    />
+                  ))
+                )}
+              </div>
+            </section>
+
+            <div className="min-w-0 space-y-5 rounded-xl border border-content-border bg-content-subtle-background p-4">
+              <Field>
+                <Label>New Session name</Label>
+                <Input value={title} onChange={(event) => setTitle(event.target.value)} />
+              </Field>
+              <div className="border-t border-content-border pt-4">
+                <p className="text-xs/5 font-semibold tracking-wide text-content-foreground uppercase">
+                  Repository handling
+                </p>
+                <p className="mt-2 text-sm/5 text-content-muted-foreground">{repositoryState}</p>
+              </div>
+              {error && (
+                <p className="border-t border-content-border pt-4 text-sm/5 text-form-error-foreground" role="alert">
+                  {error}
+                </p>
               )}
             </div>
-          </Field>
+          </div>
+        ) : (
+          <div className="space-y-5">
+            <section aria-labelledby="selected-fork-point-heading">
+              <h2 id="selected-fork-point-heading" className="mb-4 text-sm/5 font-semibold text-content-foreground">
+                New starting point
+              </h2>
+              {!points ? (
+                <p
+                  className="flex items-center gap-2 rounded-xl border border-content-border px-4 py-6 text-sm/5 text-content-muted-foreground"
+                  role="status"
+                >
+                  <LoaderCircle aria-hidden="true" className="size-4 animate-spin motion-reduce:animate-none" />
+                  Loading message…
+                </p>
+              ) : selectedPoint ? (
+                <SelectedForkPoint point={selectedPoint} />
+              ) : (
+                <p className="rounded-xl border border-dashed border-content-border px-4 py-6 text-sm/5 text-content-muted-foreground">
+                  {error ? 'This message could not be loaded.' : 'This message is no longer available to fork.'}
+                </p>
+              )}
+            </section>
 
-          <div className="min-w-0 space-y-5">
             <Field>
               <Label>New Session name</Label>
               <Input value={title} onChange={(event) => setTitle(event.target.value)} />
             </Field>
-            <div className="rounded-lg border border-content-border bg-content-subtle-background p-3 text-sm/5">
-              <p className="font-medium text-content-foreground">Repository state</p>
-              <p className="mt-1 text-content-muted-foreground">{repositoryState}</p>
+
+            <div className="rounded-xl border border-content-border bg-content-subtle-background p-4">
+              <p className="text-xs/5 font-semibold tracking-wide text-content-foreground uppercase">
+                Repository handling
+              </p>
+              <p className="mt-2 text-sm/5 text-content-muted-foreground">{repositoryState}</p>
             </div>
+
             {error && (
               <p className="text-sm/5 text-form-error-foreground" role="alert">
                 {error}
               </p>
             )}
           </div>
-        </div>
+        )}
       </DialogBody>
-      <DialogActions>
+
+      <DialogActions className="mt-0! shrink-0 border-t border-content-border bg-content-subtle-background px-6 py-4 sm:px-7">
         <Button plain disabled={saving} onClick={close}>
           Cancel
         </Button>

--- a/src/renderer/components/session-fork-dialog.tsx
+++ b/src/renderer/components/session-fork-dialog.tsx
@@ -1,0 +1,200 @@
+import { GitFork, LoaderCircle, Search } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Button } from '@/components/ui-kit/button'
+import { Dialog, DialogActions, DialogBody, DialogDescription, DialogTitle } from '@/components/ui-kit/dialog'
+import { Field, Label } from '@/components/ui-kit/fieldset'
+import { Input } from '@/components/ui-kit/input'
+import type {
+  ForkSessionOptions,
+  OwnedSession,
+  SessionForkPoint,
+  WorkstreamWorkingLocation,
+} from '@/src/domain/workstream'
+
+type SessionForkDialogProperties = Readonly<{
+  open: boolean
+  session: OwnedSession
+  initialPosition?: number
+  workingLocation: WorkstreamWorkingLocation
+  getForkPoints(): Promise<readonly SessionForkPoint[]>
+  onFork(options: ForkSessionOptions): Promise<void>
+  onClose(): void
+}>
+
+export function SessionForkDialog({
+  open,
+  session,
+  initialPosition,
+  workingLocation,
+  getForkPoints,
+  onFork,
+  onClose,
+}: SessionForkDialogProperties) {
+  const [points, setPoints] = useState<readonly SessionForkPoint[]>()
+  const [selectedEntryId, setSelectedEntryId] = useState<string>()
+  const [title, setTitle] = useState('')
+  const [query, setQuery] = useState('')
+  const [error, setError] = useState<string>()
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+
+    let active = true
+    setPoints(undefined)
+    setSelectedEntryId(undefined)
+    setTitle(`Fork of ${session.title}`)
+    setQuery('')
+    setError(undefined)
+    setSaving(false)
+
+    void getForkPoints()
+      .then((forkPoints) => {
+        if (!active) return
+
+        setPoints(forkPoints)
+        const selected = initialPosition
+          ? forkPoints.find((point) => point.position === initialPosition)
+          : forkPoints.at(-1)
+        setSelectedEntryId(selected?.entryId)
+      })
+      .catch((operationError: unknown) => {
+        if (active) {
+          setError(operationError instanceof Error ? operationError.message : 'Could not load Session messages.')
+        }
+      })
+
+    return () => {
+      active = false
+    }
+  }, [getForkPoints, initialPosition, open, session.title])
+
+  const visiblePoints = useMemo(() => {
+    const normalizedQuery = query.trim().toLocaleLowerCase()
+    if (!normalizedQuery) return points ?? []
+
+    return (points ?? []).filter((point) => point.text.toLocaleLowerCase().includes(normalizedQuery))
+  }, [points, query])
+
+  const selectedPointVisible = visiblePoints.some((point) => point.entryId === selectedEntryId)
+
+  const repositoryState =
+    session.mode === 'implement'
+      ? 'The fork creates its own worktrees when it prepares Repositories. Earlier worktree paths are reference only.'
+      : session.mode === 'brainstorm'
+        ? 'The fork remains a Brainstorm Session in this Workstream.'
+        : workingLocation === 'worktrees'
+          ? 'The fork gets a separate worktree from this working location’s current HEAD. Uncommitted changes are not copied.'
+          : 'The fork uses the same Repository checkout. Files are not returned to this earlier point.'
+
+  const close = () => {
+    if (!saving) onClose()
+  }
+
+  const fork = async () => {
+    if (!selectedEntryId || !selectedPointVisible || !title.trim() || saving) return
+
+    setSaving(true)
+    setError(undefined)
+
+    try {
+      await onFork({ entryId: selectedEntryId, title })
+      onClose()
+    } catch (operationError) {
+      setError(operationError instanceof Error ? operationError.message : 'Could not fork the Session.')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={close} size="xl" scrollable>
+      <DialogTitle className="flex items-center gap-2">
+        <GitFork aria-hidden="true" className="size-4 text-content-muted-foreground" />
+        Fork Session
+      </DialogTitle>
+      <DialogDescription>
+        Choose a user message. History before it is copied, and that message becomes an editable draft.
+      </DialogDescription>
+      <DialogBody className="min-w-0">
+        <div className="grid min-h-0 gap-5 sm:grid-cols-[minmax(0,1fr)_minmax(14rem,0.72fr)]">
+          <Field className="min-w-0">
+            <Label>User message</Label>
+            <div className="relative mt-2">
+              <Search
+                aria-hidden="true"
+                className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-content-muted-foreground"
+              />
+              <Input
+                id="session-fork-search"
+                className="pl-9"
+                placeholder="Search messages"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+              />
+            </div>
+            <div className="mt-3 max-h-72 space-y-2 overflow-y-auto pr-1">
+              {!points ? (
+                <p className="flex items-center gap-2 px-3 py-5 text-sm/5 text-content-muted-foreground" role="status">
+                  <LoaderCircle aria-hidden="true" className="size-4 animate-spin motion-reduce:animate-none" />
+                  Loading messages…
+                </p>
+              ) : visiblePoints.length === 0 ? (
+                <p className="px-3 py-5 text-sm/5 text-content-muted-foreground">
+                  {points.length === 0 ? 'No user messages are available to fork.' : 'No messages match this search.'}
+                </p>
+              ) : (
+                visiblePoints.map((point) => {
+                  const selected = point.entryId === selectedEntryId
+
+                  return (
+                    <button
+                      key={point.entryId}
+                      type="button"
+                      aria-pressed={selected}
+                      className="w-full rounded-lg border border-content-border bg-content-background px-3 py-2.5 text-left text-sm/5 text-content-foreground outline-none transition-colors hover:bg-content-subtle-background focus-visible:ring-2 focus-visible:ring-focus-ring data-[selected=true]:border-focus-ring data-[selected=true]:bg-content-subtle-background"
+                      data-selected={selected ? 'true' : undefined}
+                      onClick={() => setSelectedEntryId(point.entryId)}
+                    >
+                      <span className="line-clamp-2 whitespace-pre-wrap break-words">{point.text}</span>
+                      <span className="mt-1 block text-xs/4 text-content-muted-foreground">
+                        Message {point.position} of {point.total}
+                      </span>
+                    </button>
+                  )
+                })
+              )}
+            </div>
+          </Field>
+
+          <div className="min-w-0 space-y-5">
+            <Field>
+              <Label>New Session name</Label>
+              <Input value={title} onChange={(event) => setTitle(event.target.value)} />
+            </Field>
+            <div className="rounded-lg border border-content-border bg-content-subtle-background p-3 text-sm/5">
+              <p className="font-medium text-content-foreground">Repository state</p>
+              <p className="mt-1 text-content-muted-foreground">{repositoryState}</p>
+            </div>
+            {error && (
+              <p className="text-sm/5 text-form-error-foreground" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        </div>
+      </DialogBody>
+      <DialogActions>
+        <Button plain disabled={saving} onClick={close}>
+          Cancel
+        </Button>
+        <Button
+          color="accent"
+          disabled={saving || !selectedEntryId || !selectedPointVisible || !title.trim()}
+          onClick={() => void fork()}
+        >
+          {saving ? 'Forking…' : 'Fork Session'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/session-messages.test.tsx
+++ b/src/renderer/components/session-messages.test.tsx
@@ -33,6 +33,30 @@ test('renders duplicate message text in canonical entry order', () => {
   assert.equal(view.getAllByText('Same text', { exact: true }).length, 2)
 })
 
+test('offers to fork from each completed user message by its canonical position', async () => {
+  const requestedPositions: number[] = []
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking={false}
+      onForkFromMessage={(position) => requestedPositions.push(position)}
+      transcript={transcript([
+        { type: 'message', message: { id: 'user-1', role: 'user', text: 'First', state: 'complete', revision: 1 } },
+        {
+          type: 'message',
+          message: { id: 'assistant-1', role: 'assistant', text: 'Response', state: 'complete', revision: 1 },
+        },
+        { type: 'message', message: { id: 'user-2', role: 'user', text: 'Second', state: 'complete', revision: 1 } },
+      ])}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await view.getByRole('button', { name: 'Fork from “Second”' }).click()
+
+  assert.deepEqual(requestedPositions, [2])
+})
+
 test('renders an invoked Skill inline with the user-authored transcript message', () => {
   const view = render(
     <SessionMessages

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -1,4 +1,4 @@
-import { LoaderCircle } from 'lucide-react'
+import { GitFork, LoaderCircle } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui-kit/button'
 import type { SessionId } from '@/src/domain/session'
@@ -14,10 +14,11 @@ type SessionMessagesProperties = Readonly<{
   timelineAnnouncement?: string
   timelineError?: string
   onReloadTimeline?: () => void
+  onForkFromMessage?: (position: number) => void
 }>
 
 type TranscriptEntry =
-  | Readonly<{ type: 'message'; key: string; message: SessionTranscriptMessage }>
+  | Readonly<{ type: 'message'; key: string; message: SessionTranscriptMessage; userPosition?: number }>
   | Readonly<{ type: 'activity'; key: string; activity: AgentActivity }>
 
 const bottomThreshold = 24
@@ -32,20 +33,31 @@ export function SessionMessages({
   timelineAnnouncement,
   timelineError,
   onReloadTimeline,
+  onForkFromMessage,
 }: SessionMessagesProperties) {
   const isLoading = !canonicalTranscript
   const loadError = Boolean(timelineError)
   const reload = onReloadTimeline ?? (() => {})
   const revision = canonicalTranscript?.revision ?? 0
-  const transcript = useMemo<readonly TranscriptEntry[]>(
-    () =>
-      canonicalTranscript?.entries.map((entry) =>
-        entry.type === 'activity'
-          ? { type: 'activity', key: `activity-${entry.activity.id}`, activity: entry.activity }
-          : { type: 'message', key: `message-${entry.message.id}`, message: entry.message }
-      ) ?? [],
-    [canonicalTranscript]
-  )
+  const transcript = useMemo<readonly TranscriptEntry[]>(() => {
+    let userPosition = 0
+
+    return (
+      canonicalTranscript?.entries.map((entry) => {
+        if (entry.type === 'activity') {
+          return { type: 'activity' as const, key: `activity-${entry.activity.id}`, activity: entry.activity }
+        }
+
+        const position = entry.message.role === 'user' ? ++userPosition : undefined
+        return {
+          type: 'message' as const,
+          key: `message-${entry.message.id}`,
+          message: entry.message,
+          userPosition: position,
+        }
+      }) ?? []
+    )
+  }, [canonicalTranscript])
   const runFailureReason = canonicalTranscript?.runFailureReason
   const [pendingExternalUrl, setPendingExternalUrl] = useState<string>()
   const [externalLinkError, setExternalLinkError] = useState(false)
@@ -103,6 +115,8 @@ export function SessionMessages({
                   key={entry.key}
                   message={entry.message}
                   isWorking={isWorking}
+                  userPosition={entry.userPosition}
+                  onForkFromMessage={onForkFromMessage}
                   onOpenExternalLink={requestExternalLink}
                 />
               ) : (
@@ -331,10 +345,14 @@ function useTranscriptScroll({
 function SessionMessageRow({
   message,
   isWorking,
+  userPosition,
+  onForkFromMessage,
   onOpenExternalLink,
 }: Readonly<{
   message: SessionTranscriptMessage
   isWorking: boolean
+  userPosition?: number
+  onForkFromMessage?: (position: number) => void
   onOpenExternalLink: (url: string) => void
 }>) {
   if (message.role === 'user') {
@@ -342,7 +360,7 @@ function SessionMessageRow({
 
     return (
       <article
-        className={`ml-auto w-fit max-w-[80%] rounded-xl border px-3 py-2 text-sm/6 ${
+        className={`group/message relative ml-auto w-fit max-w-[80%] rounded-xl border px-3 py-2 text-sm/6 ${
           steering
             ? `border-content-border bg-content-subtle-background text-content-foreground opacity-80${
                 isWorking ? ' motion-safe:animate-pulse' : ''
@@ -354,6 +372,17 @@ function SessionMessageRow({
         <p className="whitespace-pre-wrap break-words">
           <SkillMentionText text={message.text} skills={message.skills ?? []} />
         </p>
+        {onForkFromMessage && userPosition !== undefined && message.state === 'complete' && !isWorking && (
+          <button
+            type="button"
+            aria-label={`Fork from “${message.text.slice(0, 40) || 'this message'}”`}
+            title="Fork from here"
+            className="absolute -bottom-7 right-0 z-10 rounded-sm p-1.5 text-content-muted-foreground opacity-0 transition-opacity motion-reduce:transition-none hover:bg-session-interaction hover:text-content-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring group-hover/message:opacity-100 group-focus-within/message:opacity-100"
+            onClick={() => onForkFromMessage(userPosition)}
+          >
+            <GitFork aria-hidden="true" className="size-3.5" />
+          </button>
+        )}
       </article>
     )
   }

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -377,7 +377,7 @@ function SessionMessageRow({
             type="button"
             aria-label={`Fork from “${message.text.slice(0, 40) || 'this message'}”`}
             title="Fork from here"
-            className="absolute -bottom-7 right-0 z-10 rounded-sm p-1.5 text-content-muted-foreground opacity-0 transition-opacity motion-reduce:transition-none hover:bg-session-interaction hover:text-content-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring group-hover/message:opacity-100 group-focus-within/message:opacity-100"
+            className="absolute top-1/2 right-full z-10 mr-2 -translate-y-1/2 rounded-sm p-1.5 text-content-muted-foreground opacity-0 transition-opacity motion-reduce:transition-none hover:bg-session-interaction hover:text-content-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring group-hover/message:opacity-100 group-focus-within/message:opacity-100"
             onClick={() => onForkFromMessage(userPosition)}
           >
             <GitFork aria-hidden="true" className="size-3.5" />

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -7,6 +7,7 @@ import type {
   CreateQuickSessionOptions,
   CreateSessionOptions,
   CreateWorkstreamOptions,
+  ForkSessionOptions,
   WorkstreamsSnapshot,
 } from '@/src/domain/workstream'
 import { bundledReleaseNotes } from '@/src/release-notes'
@@ -175,6 +176,9 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     sessions.map((session) => session.id)
   )
   const workstreamLifecycles = new Map(workstreams.map((workstream) => [workstream.id, workstream.lifecycle]))
+  const workstreamWorkingLocations = new Map(
+    workstreams.map((workstream) => [workstream.id, workstream.workingLocation])
+  )
   const recentSessions = sessions.slice(-5).reverse()
   const visibleSessionIds = getVisibleSessionIds(sessionPinning, workstreamSelection.sessionId)
   const visibleSessions = visibleSessionIds.flatMap((ownedSessionId) => {
@@ -336,6 +340,20 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     }
   }
 
+  const forkSession = async (sourceSessionId: SessionId, options: ForkSessionOptions) => {
+    const authorityToken = selectedWorkspaceAuthorityToken()
+    const outcome = await window.piWorkspace.workstreams.forkSession(sourceSessionId, options)
+
+    if (!applyWorkstreamsSnapshot(authorityToken, outcome.snapshot)) return
+
+    setDrafts((currentDrafts) => {
+      const nextDrafts = new Map(currentDrafts)
+      nextDrafts.set(outcome.sessionId, outcome.draft)
+      return nextDrafts
+    })
+    revealCreatedSession(outcome.snapshot, outcome.sessionId)
+  }
+
   const setWorkstreamLifecycle = async (workstreamId: string, lifecycle: 'active' | 'archived') => {
     const authorityToken = selectedWorkspaceAuthorityToken()
     const snapshot = await window.piWorkspace.workstreams.setLifecycle(workstreamId, lifecycle)
@@ -451,6 +469,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
           <SessionArea
             sessions={visibleSessions}
             workstreamLifecycles={workstreamLifecycles}
+            workstreamWorkingLocations={workstreamWorkingLocations}
             activeSessionId={workstreamSelection.sessionId}
             revealRequest={sessionRevealRequest}
             composerFocusRequest={composerFocusRequest}
@@ -472,6 +491,8 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             resumeQueuedFollowUps={resumeQueuedFollowUps}
             sessionConfiguration={window.piWorkspace.sessionConfiguration}
             sessionSkills={window.piWorkspace.sessionSkills}
+            getSessionForkPoints={(sessionId) => window.piWorkspace.workstreams.getSessionForkPoints(sessionId)}
+            forkSession={forkSession}
             onToggleSessionPin={toggleSessionPin}
           />
         ) : selectedWorkstream?.goal ? (

--- a/src/workstreams-ipc.test.ts
+++ b/src/workstreams-ipc.test.ts
@@ -5,6 +5,8 @@ import {
   parseCreateQuickSessionRequest,
   parseCreateSessionRequest,
   parseCreateWorkstreamRequest,
+  parseForkSessionRequest,
+  parseSessionForkPointsRequest,
   parsePreviewWorktreeLocationsRequest,
   parseRenameOwnedSessionRequest,
   parseShowWorkingLocationRequest,
@@ -97,6 +99,23 @@ test('parses a request to show one recorded working location', () => {
     workstreamId: 'workstream-a',
     repositoryId: 'repository-a',
   })
+})
+
+test('parses a request for Session fork points', () => {
+  assert.deepEqual(parseSessionForkPointsRequest({ sessionId: 'session-a' }), {
+    sessionId: sessionId('session-a'),
+  })
+})
+
+test('parses an owned Session fork', () => {
+  assert.deepEqual(parseForkSessionRequest({ sessionId: 'session-a', entryId: 'aaaa0001', title: 'Alternative' }), {
+    sessionId: sessionId('session-a'),
+    options: { entryId: 'aaaa0001', title: 'Alternative' },
+  })
+})
+
+test('rejects a Session fork without a valid entry', () => {
+  assert.equal(parseForkSessionRequest({ sessionId: 'session-a', entryId: '', title: 'Alternative' }), undefined)
 })
 
 test('parses an owned Session rename', () => {

--- a/src/workstreams-ipc.ts
+++ b/src/workstreams-ipc.ts
@@ -4,6 +4,7 @@ import {
   type CreateQuickSessionOptions,
   type CreateSessionOptions,
   type CreateWorkstreamOptions,
+  type ForkSessionOptions,
 } from '@/src/domain/workstream'
 
 export const workstreamsIpcChannels = {
@@ -12,6 +13,8 @@ export const workstreamsIpcChannels = {
   createWorkstream: 'workstreams:create-workstream',
   createQuickSession: 'workstreams:create-quick-session',
   createSession: 'workstreams:create-session',
+  getSessionForkPoints: 'workstreams:get-session-fork-points',
+  forkSession: 'workstreams:fork-session',
   setLifecycle: 'workstreams:set-lifecycle',
   renameSession: 'workstreams:rename-session',
   showWorkingLocation: 'workstreams:show-working-location',
@@ -96,6 +99,28 @@ export function parseCreateSessionRequest(
   }
 
   return { workstreamId, options: title === undefined ? { mode } : { mode, title } }
+}
+
+export function parseSessionForkPointsRequest(value: unknown): Readonly<{ sessionId: SessionId }> | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const id = (value as { sessionId?: unknown }).sessionId
+
+  return isSessionId(id) ? { sessionId: id } : undefined
+}
+
+export function parseForkSessionRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionId; options: ForkSessionOptions }> | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const id = (value as { sessionId?: unknown }).sessionId
+  const entryId = (value as { entryId?: unknown }).entryId
+  const title = (value as { title?: unknown }).title
+
+  return isSessionId(id) && typeof entryId === 'string' && /^[a-f0-9]{8}$/i.test(entryId) && typeof title === 'string'
+    ? { sessionId: id, options: { entryId, title } }
+    : undefined
 }
 
 export function parseWorkstreamLifecycleRequest(

--- a/src/workstreams.ts
+++ b/src/workstreams.ts
@@ -3,10 +3,19 @@ import type {
   CreateQuickSessionOptions,
   CreateSessionOptions,
   CreateWorkstreamOptions,
+  ForkSessionOptions,
+  SessionForkPoint,
   WorkstreamLifecycle,
   WorkstreamsSnapshot,
   WorktreeLocationsPreview,
 } from '@/src/domain/workstream'
+
+export type SessionForkOutcome = Readonly<{
+  status: 'available' | 'pending' | 'quarantined'
+  sessionId: SessionId
+  snapshot: WorkstreamsSnapshot
+  draft: string
+}>
 
 export type WorkstreamCreationOutcome = Readonly<{
   status: 'available' | 'pending' | 'quarantined'
@@ -20,6 +29,8 @@ export interface WorkstreamsBridge {
   createWorkstream(workspaceId: string, options: CreateWorkstreamOptions): Promise<WorkstreamCreationOutcome>
   createQuickSession(workspaceId: string, options: CreateQuickSessionOptions): Promise<WorkstreamCreationOutcome>
   createSession(workstreamId: string, options: CreateSessionOptions): Promise<WorkstreamCreationOutcome>
+  getSessionForkPoints(sessionId: SessionId): Promise<readonly SessionForkPoint[]>
+  forkSession(sessionId: SessionId, options: ForkSessionOptions): Promise<SessionForkOutcome>
   setLifecycle(workstreamId: string, lifecycle: WorkstreamLifecycle): Promise<WorkstreamsSnapshot>
   renameSession(sessionId: SessionId, title: string): Promise<WorkstreamsSnapshot>
   showWorkingLocation(workstreamId: string, repositoryId: string): Promise<void>


### PR DESCRIPTION
## Summary

- add durable Session forking from any canonical user message while leaving the source Session and Repository state unchanged
- preserve Workstream, mode, and working-location semantics, including isolated worktrees and resumable persisted fork intents
- expose forking from both Session actions and individual messages with a responsive history picker, direct confirmation flow, and focused Repository-handling guidance

## Related issue

None

## Validation

- `bun run check` — passed (format, lint, typecheck, 532 tests, and production build)
- `bun run security:scan` — passed with no issues
- manually reviewed the message picker and direct-from-message dialog in the Railyard demo at 1440×757 in light mode

- [x] `bun run check`
- [x] Focused tests or manual validation are described above.
- [x] `bun run security:scan` was run, or this change does not affect dependencies or security-sensitive behavior.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed.
- [x] I have read and will follow the Code of Conduct.

No new dependencies, copied material, generated assets, or license implications.
