### PR TITLE
feat: refine sidebar footer and composer

### DIFF
--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -262,10 +262,10 @@ export function Composer({
   }, [session.id, sessionConfiguration])
 
   return (
-    <div className="composer-tray shrink-0 border-t border-content-border p-3">
+    <div className="composer-tray relative z-10 shrink-0 px-4 pt-3 pb-4">
       <div
         aria-busy={agentRunDisabled ? 'true' : undefined}
-        className="group flex min-h-[52px] flex-col rounded-xl bg-composer-background"
+        className="composer-surface group flex min-h-[52px] flex-col rounded-xl border border-composer-border bg-composer-background"
         onClick={onActivate}
       >
         <ComposerEditor

--- a/src/renderer/components/session-area.test.tsx
+++ b/src/renderer/components/session-area.test.tsx
@@ -229,7 +229,7 @@ test('replaces the Composer with restore guidance for an archived Workstream', (
   assert.doesNotMatch(markup, /aria-label="Send message"/)
 })
 
-test('constrains every visible Session so its transcript scrolls without displacing its Composer', () => {
+test('renders a Composer for every visible Session', () => {
   const markup = renderToStaticMarkup(
     <SessionArea
       sessions={[pinnedSession, activeSession]}
@@ -243,6 +243,5 @@ test('constrains every visible Session so its transcript scrolls without displac
     />
   )
 
-  assert.match(markup, /class="flex min-h-0 min-w-\[400px\] flex-\[1_0_400px\]/)
-  assert.match(markup, /class="composer-tray shrink-0 border-t/)
+  assert.equal(markup.match(/aria-label="Send message"/g)?.length, 2)
 })

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -172,8 +172,8 @@ export function SessionContainer({
         />
       )}
       {composerUnavailable ? (
-        <div className="composer-tray shrink-0 border-t border-content-border p-3">
-          <div className="flex min-h-13 items-center justify-center gap-2 rounded-xl border border-dashed border-composer-border bg-composer-background px-4 text-center text-sm/5 text-composer-muted-foreground">
+        <div className="composer-tray relative z-10 shrink-0 px-4 pt-3 pb-4">
+          <div className="composer-surface flex min-h-13 items-center justify-center gap-2 rounded-xl border border-dashed border-composer-border bg-composer-background px-4 text-center text-sm/5 text-composer-muted-foreground">
             {unavailability ? (
               <>
                 <TriangleAlert aria-hidden="true" className="size-4 shrink-0" />

--- a/src/renderer/components/workspace-navigation.tsx
+++ b/src/renderer/components/workspace-navigation.tsx
@@ -182,29 +182,23 @@ export function WorkspaceNavigation({
         </SidebarHeader>
 
         <SidebarBody>{children}</SidebarBody>
-        <SidebarFooter className="shrink-0">
-          <div className="flex items-stretch rounded-lg border border-sidebar-border">
-            <button
-              type="button"
-              className="flex min-w-0 flex-1 items-center gap-3 rounded-l-lg px-2 py-2 text-left hover:bg-sidebar-interaction focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
-              onClick={onOpenChangelog}
-            >
-              <img alt="" className="size-7 shrink-0 dark:hidden" src="./railyard-symbol-light.svg" />
-              <img alt="" className="hidden size-7 shrink-0 dark:block" src="./railyard-symbol-dark.svg" />
-              <span className="min-w-0">
-                <span className="block truncate text-sm/5 font-medium text-sidebar-foreground">Railyard</span>
-                <span className="block truncate text-xs/5 text-sidebar-muted-foreground">
-                  v{applicationVersion} · Release notes
-                </span>
-              </span>
-            </button>
+        <SidebarFooter className="shrink-0 border-t-0!">
+          <div className="flex items-center justify-between gap-3">
             <Button
               plain
               aria-label="Settings"
-              className="shrink-0 self-stretch rounded-l-none! rounded-r-lg! border-0! border-l! border-sidebar-border! px-3! py-2! text-sidebar-foreground [--btn-icon:var(--theme-sidebar-muted-foreground)] data-hover:bg-sidebar-interaction data-hover:[--btn-icon:var(--theme-sidebar-foreground)]"
+              className="size-9! shrink-0 items-center! p-0! text-sidebar-foreground [--btn-icon:var(--theme-sidebar-muted-foreground)] data-hover:bg-sidebar-interaction data-hover:[--btn-icon:var(--theme-sidebar-foreground)]"
               onClick={() => setSettingsOpen(true)}
             >
               <Settings aria-hidden="true" data-slot="icon" />
+            </Button>
+            <Button
+              plain
+              aria-label={`Release notes for version ${applicationVersion}`}
+              className="min-w-0 px-2! py-1.5! font-mono text-xs/5! font-medium! text-sidebar-muted-foreground data-hover:bg-sidebar-interaction data-hover:text-sidebar-foreground"
+              onClick={onOpenChangelog}
+            >
+              <span className="truncate">v{applicationVersion}</span>
             </Button>
           </div>
         </SidebarFooter>

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -98,7 +98,7 @@
   --theme-activity-border: var(--theme-content-border);
   --theme-composer-action-background: var(--theme-content-foreground);
   --theme-composer-action-foreground: var(--theme-content-background);
-  --theme-composer-background: var(--theme-content-background);
+  --theme-composer-background: var(--theme-control-background);
   --theme-composer-border: var(--theme-content-border);
   --theme-composer-error-foreground: var(--theme-danger-foreground);
   --theme-composer-foreground: var(--theme-content-foreground);
@@ -412,6 +412,22 @@ body,
   max-height: 10.75rem;
 }
 
+.composer-surface {
+  box-shadow:
+    0 0.125rem 0.375rem color-mix(in oklab, var(--theme-overlay-background) 65%, transparent),
+    0 0.75rem 1.75rem color-mix(in oklab, var(--theme-overlay-background) 45%, transparent);
+  transition:
+    border-color 150ms ease-out,
+    box-shadow 150ms ease-out;
+}
+
+.composer-surface:focus-within {
+  border-color: var(--theme-content-hover-border);
+  box-shadow:
+    0 0.125rem 0.5rem color-mix(in oklab, var(--theme-overlay-background) 75%, transparent),
+    0 0.875rem 2rem color-mix(in oklab, var(--theme-overlay-background) 55%, transparent);
+}
+
 .session-messages-reading-column {
   padding: 1rem;
 }
@@ -479,6 +495,7 @@ body,
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .composer-surface,
   .context-usage-fill,
   .context-usage-value {
     transition: none;


### PR DESCRIPTION
## Summary

- simplify the sidebar footer with Settings on the left and a clickable version on the right
- detach the Composer from the Session edges and use the themed control surface for contrast
- add theme-aware elevation and apply the floating treatment to unavailable Composer states

## Testing

- `bun test --max-concurrency=1 --preload ./src/renderer/test-dom.ts` (543 tests)
- `bun run typecheck`
- `bun run lint`
- `bun x prettier --check src/renderer/style.css src/renderer/components/workspace-navigation.tsx src/renderer/components/composer.tsx src/renderer/components/session-container.tsx src/renderer/components/session-area.test.tsx`
- `bun run build`
