### PR TITLE
feat: add Session code previews and diff reviews

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Run Windows quality checks
         if: matrix.os == 'windows-2025'
-        run: bun run format:check && bun run lint && bun run typecheck && bun run test
+        run: bun run format:check && bun run lint && bun run typecheck && bun test --max-concurrency=1 --timeout=15000 --preload ./src/renderer/test-dom.ts

--- a/src/composer-ipc.test.ts
+++ b/src/composer-ipc.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test'
 import { sessionId } from '@/src/domain/session'
 import {
   maximumSessionMessageLength,
+  parseCodeReviewCommentCommand,
   parseQueuedFollowUpRemovalRequest,
   parseSessionMessageSubmission,
   parseSessionRunStopRequest,
@@ -14,6 +15,40 @@ test('accepts a narrow serializable Agent Run stop request', () => {
 
 test('rejects an invalid Agent Run stop request', () => {
   assert.equal(parseSessionRunStopRequest({ sessionId: '' }), undefined)
+})
+
+test('accepts a bounded Repository-relative code-review comment command', () => {
+  assert.deepEqual(
+    parseCodeReviewCommentCommand({
+      sessionId: 'session-a',
+      text: 'Preserve this.',
+      reference: {
+        repositoryId: 'repository-1',
+        repositoryName: 'Pi Workspace',
+        path: 'src/example.ts',
+        oldStart: 2,
+        oldLines: 1,
+        newStart: 2,
+        newLines: 2,
+        patch: '@@ -2 +2,2 @@\n-old\n+new',
+      },
+    }),
+    {
+      sessionId: sessionId('session-a'),
+      text: 'Preserve this.',
+      reference: {
+        repositoryId: 'repository-1',
+        repositoryName: 'Pi Workspace',
+        path: 'src/example.ts',
+        oldStart: 2,
+        oldLines: 1,
+        newStart: 2,
+        newLines: 2,
+        patch: '@@ -2 +2,2 @@\n-old\n+new',
+      },
+      commentId: undefined,
+    }
+  )
 })
 
 test('accepts a narrow queued follow-up removal request', () => {
@@ -31,6 +66,43 @@ test('accepts a narrow serializable Session message submission', () => {
   assert.deepEqual(
     parseSessionMessageSubmission({ sessionId: 'session-a', text: '  Preserve me  ', delivery: 'follow-up' }),
     { sessionId: sessionId('session-a'), text: '  Preserve me  ', delivery: 'follow-up' }
+  )
+})
+
+test('canonicalizes a structured code-review submission at the IPC boundary', () => {
+  const codeReview = {
+    kind: 'follow-up' as const,
+    comments: [
+      {
+        id: 'comment-1',
+        text: 'Please preserve this behavior.',
+        createdAt: 1,
+        reference: {
+          repositoryId: 'repository-1',
+          repositoryName: 'Pi Workspace',
+          path: 'src/example.ts',
+          oldStart: 2,
+          oldLines: 1,
+          newStart: 2,
+          newLines: 2,
+          patch: '@@ -2 +2,2 @@\n-old\n+new',
+        },
+      },
+    ],
+  }
+
+  assert.deepEqual(
+    parseSessionMessageSubmission({ sessionId: 'session-a', text: '', delivery: 'follow-up', codeReview }),
+    {
+      sessionId: sessionId('session-a'),
+      text:
+        'Follow-up about a referenced code change.\n\n' +
+        '## Pi Workspace · src/example.ts · +2–3\n\n' +
+        '~~~~diff\n@@ -2 +2,2 @@\n-old\n+new\n~~~~\n\n' +
+        'Please preserve this behavior.',
+      delivery: 'follow-up',
+      codeReview,
+    }
   )
 })
 

--- a/src/composer-ipc.ts
+++ b/src/composer-ipc.ts
@@ -1,4 +1,13 @@
-import { sessionMessageDeliveries, type SessionMessageSubmission } from '@/src/composer'
+import {
+  sessionMessageDeliveries,
+  type SessionCodeReviewCommentCommand,
+  type SessionMessageSubmission,
+} from '@/src/composer'
+import {
+  formatSessionCodeReviewText,
+  parseSessionCodeReview,
+  parseSessionCodeReviewCommentInput,
+} from '@/src/session-code-review'
 import { isSessionId } from '@/src/domain/session'
 
 /** Session messages are bounded to limit retained IPC and provider work per submission. */
@@ -7,6 +16,10 @@ export const maximumSessionMessageLength = 200_000
 export const composerIpcChannels = {
   compact: 'composer:compact',
   submit: 'composer:submit',
+  getCodeReviewDraft: 'composer:get-code-review-draft',
+  saveCodeReviewComment: 'composer:save-code-review-comment',
+  removeCodeReviewComment: 'composer:remove-code-review-comment',
+  finishCodeReview: 'composer:finish-code-review',
   stop: 'composer:stop',
   removeQueuedFollowUp: 'composer:remove-queued-follow-up',
   resumeQueuedFollowUps: 'composer:resume-queued-follow-ups',
@@ -28,6 +41,27 @@ export function parseSessionRunStopRequest(
   return isSessionId(id) ? { sessionId: id } : undefined
 }
 
+export function parseCodeReviewCommentCommand(value: unknown): SessionCodeReviewCommentCommand | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const command = value as Record<string, unknown>
+  const input = parseSessionCodeReviewCommentInput(command)
+
+  return isSessionId(command.sessionId) && input ? { sessionId: command.sessionId, ...input } : undefined
+}
+
+export function parseCodeReviewCommentRemovalRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionMessageSubmission['sessionId']; commentId: string }> | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const request = value as Record<string, unknown>
+
+  return isSessionId(request.sessionId) && typeof request.commentId === 'string' && request.commentId.length > 0
+    ? { sessionId: request.sessionId, commentId: request.commentId }
+    : undefined
+}
+
 export function parseQueuedFollowUpRemovalRequest(
   value: unknown
 ): Readonly<{ sessionId: SessionMessageSubmission['sessionId']; followUpId: string }> | undefined {
@@ -47,20 +81,25 @@ export function parseSessionMessageSubmission(value: unknown): SessionMessageSub
 
   const submission = value as Record<string, unknown>
   const id = submission.sessionId
+  const codeReview = submission.codeReview === undefined ? undefined : parseSessionCodeReview(submission.codeReview)
+  const text = codeReview ? formatSessionCodeReviewText(codeReview) : submission.text
 
   if (
     !isSessionId(id) ||
-    typeof submission.text !== 'string' ||
-    submission.text.trim().length === 0 ||
-    submission.text.length > maximumSessionMessageLength ||
-    !sessionMessageDeliveries.some((delivery) => delivery === submission.delivery)
+    (submission.codeReview !== undefined && !codeReview) ||
+    typeof text !== 'string' ||
+    text.trim().length === 0 ||
+    text.length > maximumSessionMessageLength ||
+    !sessionMessageDeliveries.some((delivery) => delivery === submission.delivery) ||
+    (codeReview !== undefined && submission.delivery !== 'follow-up')
   ) {
     return undefined
   }
 
   return {
     sessionId: id,
-    text: submission.text,
+    text,
     delivery: submission.delivery as SessionMessageSubmission['delivery'],
+    ...(codeReview ? { codeReview } : {}),
   }
 }

--- a/src/composer.ts
+++ b/src/composer.ts
@@ -1,4 +1,5 @@
 import type { SessionId } from '@/src/domain/session'
+import type { SessionCodeReference, SessionCodeReview, SessionCodeReviewDraft } from '@/src/session-code-review'
 
 export const sessionMessageDeliveries = ['steer', 'follow-up', 'action'] as const
 
@@ -11,6 +12,14 @@ export type SessionMessageSubmission = Readonly<{
   sessionId: SessionId
   text: string
   delivery: SessionMessageDelivery
+  codeReview?: SessionCodeReview
+}>
+
+export type SessionCodeReviewCommentCommand = Readonly<{
+  sessionId: SessionId
+  commentId?: string
+  text: string
+  reference: SessionCodeReference
 }>
 
 export function isSessionSkillName(value: unknown): value is string {
@@ -56,6 +65,10 @@ export type SessionMessageSubmissionResult =
 export interface ComposerBridge {
   compact(sessionId: SessionId): Promise<SessionContextCompactionResult>
   submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult>
+  getCodeReviewDraft(sessionId: SessionId): Promise<SessionCodeReviewDraft>
+  saveCodeReviewComment(command: SessionCodeReviewCommentCommand): Promise<SessionCodeReviewDraft>
+  removeCodeReviewComment(sessionId: SessionId, commentId: string): Promise<SessionCodeReviewDraft>
+  finishCodeReview(sessionId: SessionId): Promise<SessionMessageSubmissionResult>
   stop(sessionId: SessionId): Promise<SessionRunStopResult>
   removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>
   resumeQueuedFollowUps(sessionId: SessionId): Promise<boolean>

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -168,6 +168,63 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
         ]
       },
     },
+    sessionChanges: {
+      async getSnapshot(sessionId) {
+        const session = workstreamsSnapshot.workstreams
+          .flatMap((workstream) => workstream.sessions)
+          .find((candidate) => candidate.id === sessionId)
+
+        return {
+          sessionId,
+          repositories:
+            session?.mode === 'implement'
+              ? [
+                  {
+                    repositoryId: 'Atlas Notes',
+                    repositoryName: 'Atlas Notes',
+                    branch: {
+                      head: 'railyard/offline-editing',
+                      upstream: 'origin/main',
+                      ahead: 2,
+                      behind: 0,
+                      detached: false,
+                      unborn: false,
+                    },
+                    files: [
+                      {
+                        path: 'src/notes/note-store.ts',
+                        status: 'modified' as const,
+                        staged: true,
+                        unstaged: true,
+                        additions: 8,
+                        deletions: 2,
+                      },
+                      {
+                        path: 'src/notes/sync-queue.ts',
+                        status: 'added' as const,
+                        staged: false,
+                        unstaged: true,
+                        additions: 42,
+                        deletions: 0,
+                      },
+                    ],
+                  },
+                ]
+              : [],
+        }
+      },
+      async loadFileDiff(_sessionId, _repositoryId, path, view) {
+        if (path !== 'src/notes/note-store.ts' && path !== 'src/notes/sync-queue.ts') {
+          return { status: 'unavailable', message: 'The changed file is no longer available.' }
+        }
+
+        return {
+          status: 'available',
+          content: `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1,2 +1,3 @@\n-export const sync = saveRemote\n+export const sync = queueLocalSave\n+export const state = '${view}'`,
+          truncated: false,
+        }
+      },
+    },
     sessionConfiguration: {
       async getSnapshot(sessionId) {
         return {

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -6,6 +6,11 @@ import { sessionId } from '@/src/domain/session'
 import type { WorkstreamsSnapshot } from '@/src/domain/workstream'
 import type { SessionTranscriptSnapshot } from '@/src/session-transcript'
 import {
+  formatSessionCodeReviewText,
+  type SessionCodeReview,
+  type SessionCodeReviewDraft,
+} from '@/src/session-code-review'
+import {
   createEmptyWorkstreamKnowledge,
   deriveWorkstreamKnowledgeReadiness,
 } from '@/src/domain/workstream-knowledge-transitions'
@@ -65,6 +70,11 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
   const transcriptsBySessionId: Record<string, SessionTranscriptSnapshot> = { ...scenario.transcriptsBySessionId }
   const transcriptListeners = new Set<Parameters<PiWorkspaceBridge['transcript']['subscribe']>[0]>()
   const settingsListeners = new Set<Parameters<PiWorkspaceBridge['settings']['subscribe']>[0]>()
+  const codeReviewDrafts = new Map<string, SessionCodeReviewDraft>()
+  const demoFileStaging = new Map<string, 'staged' | 'unstaged' | 'partial'>([
+    ['src/notes/note-store.ts', 'partial'],
+    ['src/notes/sync-queue.ts', 'unstaged'],
+  ])
 
   colorSchemeMediaQuery.addEventListener('change', (event) => {
     if (settingsSnapshot.appearance !== 'system') {
@@ -78,6 +88,11 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
     }
   })
 
+  const stagingState = (path: string) => {
+    const state = demoFileStaging.get(path) ?? 'unstaged'
+    return { staged: state !== 'unstaged', unstaged: state !== 'staged' }
+  }
+
   const transcriptSnapshot = (requestedSessionId: string): SessionTranscriptSnapshot =>
     transcriptsBySessionId[requestedSessionId] ?? {
       sessionId: sessionId(requestedSessionId),
@@ -86,6 +101,32 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       runs: [],
       entries: [],
     }
+  const publishCodeReview = (requestedSessionId: string, codeReview: SessionCodeReview) => {
+    const transcript = transcriptSnapshot(requestedSessionId)
+    const revision = transcript.revision + 1
+    const snapshot = {
+      ...transcript,
+      revision,
+      entries: [
+        ...transcript.entries,
+        {
+          type: 'message' as const,
+          message: {
+            id: `demo-review-${revision}`,
+            role: 'user' as const,
+            text: formatSessionCodeReviewText(codeReview),
+            codeReview,
+            state: 'complete' as const,
+            revision,
+          },
+        },
+      ],
+    }
+    transcriptsBySessionId[requestedSessionId] = snapshot
+    transcriptListeners.forEach((listener) =>
+      listener({ sessionId: sessionId(requestedSessionId), revision, snapshot })
+    )
+  }
 
   return {
     applicationState: {
@@ -130,8 +171,48 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       async compact() {
         return { status: 'compacted' as const }
       },
-      async submit() {
-        return { status: 'rejected', reason: 'unexpected' }
+      async submit(submission) {
+        if (!submission.codeReview) return { status: 'rejected' as const, reason: 'unexpected' as const }
+
+        publishCodeReview(submission.sessionId, submission.codeReview)
+        return { status: 'accepted' as const, delivery: submission.delivery }
+      },
+      async getCodeReviewDraft(sessionId) {
+        return codeReviewDrafts.get(sessionId) ?? { comments: [] }
+      },
+      async saveCodeReviewComment(command) {
+        const current = codeReviewDrafts.get(command.sessionId) ?? { comments: [] }
+        const existing = command.commentId
+          ? current.comments.find((comment) => comment.id === command.commentId)
+          : undefined
+        const comment = {
+          id: existing?.id ?? `demo-review-${current.comments.length + 1}`,
+          text: command.text,
+          reference: command.reference,
+          createdAt: existing?.createdAt ?? Date.now(),
+        }
+        const next = {
+          comments: existing
+            ? current.comments.map((candidate) => (candidate.id === existing.id ? comment : candidate))
+            : [...current.comments, comment],
+        }
+        codeReviewDrafts.set(command.sessionId, next)
+        return next
+      },
+      async removeCodeReviewComment(sessionId, commentId) {
+        const next = {
+          comments: (codeReviewDrafts.get(sessionId)?.comments ?? []).filter((comment) => comment.id !== commentId),
+        }
+        codeReviewDrafts.set(sessionId, next)
+        return next
+      },
+      async finishCodeReview(sessionId) {
+        const draft = codeReviewDrafts.get(sessionId) ?? { comments: [] }
+        if (draft.comments.length === 0) return { status: 'rejected' as const, reason: 'invalid-submission' as const }
+
+        codeReviewDrafts.set(sessionId, { comments: [] })
+        publishCodeReview(sessionId, { kind: 'review', comments: draft.comments })
+        return { status: 'accepted' as const, delivery: 'prompt' as const }
       },
       async stop() {
         return { status: 'not-running' }
@@ -194,16 +275,14 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
                       {
                         path: 'src/notes/note-store.ts',
                         status: 'modified' as const,
-                        staged: true,
-                        unstaged: true,
+                        ...stagingState('src/notes/note-store.ts'),
                         additions: 8,
                         deletions: 2,
                       },
                       {
                         path: 'src/notes/sync-queue.ts',
                         status: 'added' as const,
-                        staged: false,
-                        unstaged: true,
+                        ...stagingState('src/notes/sync-queue.ts'),
                         additions: 42,
                         deletions: 0,
                       },
@@ -223,6 +302,12 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
           content: `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1,2 +1,3 @@\n-export const sync = saveRemote\n+export const sync = queueLocalSave\n+export const state = '${view}'`,
           truncated: false,
         }
+      },
+      async setFileStaged(sessionId, _repositoryId, path, staged) {
+        if (!demoFileStaging.has(path)) throw new Error('The changed file is no longer available.')
+
+        demoFileStaging.set(path, staged ? 'staged' : 'unstaged')
+        return this.getSnapshot(sessionId)
       },
     },
     sessionConfiguration: {

--- a/src/main/activity-artifacts.test.ts
+++ b/src/main/activity-artifacts.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { ToolExecution } from '@/src/session-timeline'
+import { deriveActivityArtifacts, deriveMutationPreview } from './activity-artifacts'
+
+function execution(toolName: string, input: unknown, status: ToolExecution['status'] = 'completed'): ToolExecution {
+  return {
+    toolCallId: 'tool-1',
+    activityId: 'activity-1',
+    toolName,
+    label: toolName,
+    status,
+    input,
+  }
+}
+
+const repositories = [{ repositoryId: 'repository-a', workingPath: '/work/repository-a' }]
+
+test('attributes changed files to a Repository without exposing absolute paths', () => {
+  const artifacts = deriveActivityArtifacts(
+    execution('edit', { path: '/work/repository-a/src/file.ts' }),
+    { details: { patch: '@@ -1 +1 @@\n-old\n+new' } },
+    '/runtime',
+    false,
+    repositories
+  )
+
+  assert.deepEqual(artifacts, [
+    { type: 'file-change', path: 'src/file.ts', repositoryId: 'repository-a', additions: 1, deletions: 1 },
+  ])
+})
+
+test('derives immutable edit diffs and exact write snapshots', () => {
+  const editPreview = deriveMutationPreview(
+    execution('edit', { path: '/work/repository-a/src/file.ts' }),
+    { details: { patch: '@@ -1 +1 @@\n-old\n+new' } },
+    '/runtime',
+    repositories
+  )
+  const writePreview = deriveMutationPreview(
+    execution('write', { path: '/work/repository-a/src/new.ts', content: 'export const value = 1\n' }),
+    {},
+    '/runtime',
+    repositories
+  )
+
+  assert.deepEqual(editPreview, {
+    kind: 'diff',
+    path: 'src/file.ts',
+    repositoryId: 'repository-a',
+    content: '@@ -1 +1 @@\n-old\n+new',
+    truncated: false,
+  })
+  assert.deepEqual(writePreview, {
+    kind: 'code',
+    path: 'src/new.ts',
+    repositoryId: 'repository-a',
+    content: 'export const value = 1\n',
+    truncated: false,
+  })
+})
+
+test('derives an apply-patch preview from its operation-time patch result', () => {
+  const input = {
+    patch: '*** Begin Patch\n*** Update File: /work/repository-a/src/file.ts\n*** End Patch',
+  }
+  const preview = deriveMutationPreview(
+    execution('apply_patch', input),
+    { details: { patch: '@@ -1 +1 @@\n-old\n+new' } },
+    '/runtime',
+    repositories
+  )
+
+  assert.equal(preview?.path, 'src/file.ts')
+  assert.equal(preview?.kind, 'diff')
+})
+
+test('does not derive mutation previews for failed or unattributed operations', () => {
+  assert.equal(
+    deriveMutationPreview(execution('edit', { path: '/outside/file.ts' }, 'failed'), {}, '/runtime', repositories),
+    undefined
+  )
+  assert.equal(deriveMutationPreview(execution('read', { path: '/runtime/file.ts' }), {}, '/runtime'), undefined)
+})

--- a/src/main/activity-artifacts.ts
+++ b/src/main/activity-artifacts.ts
@@ -1,5 +1,10 @@
 import { isAbsolute, normalize, relative, sep } from 'node:path'
-import type { ActivityArtifact, ToolExecution } from '@/src/session-timeline'
+import type { ActivityArtifact, ActivityMutationPreview, ToolExecution } from '@/src/session-timeline'
+
+export type ActivityRepositoryLocation = Readonly<{
+  repositoryId: string
+  workingPath: string
+}>
 
 const inspectedToolNames = new Set(['read', 'grep', 'find', 'ls', 'search'])
 const changedToolNames = new Set(['edit', 'write', 'apply_patch'])
@@ -40,17 +45,29 @@ export function deriveActivityArtifacts(
   execution: ToolExecution,
   result: unknown,
   runtimeDirectory: string,
-  isError: boolean
+  isError: boolean,
+  repositories: readonly ActivityRepositoryLocation[] = []
 ): readonly ActivityArtifact[] {
   const artifacts: ActivityArtifact[] = []
-  const path = normalizedRuntimePath(execution.input, runtimeDirectory)
+  const attributedPath = normalizedActivityPath(
+    execution.input,
+    runtimeDirectory,
+    repositories,
+    execution.toolName === 'apply_patch' ? firstPatchPath(execution.input) : undefined
+  )
+  const path = attributedPath?.path
 
   if (!isError && path && inspectedToolNames.has(execution.toolName)) {
     artifacts.push({ type: 'inspected-file', path })
   }
 
   if (!isError && path && changedToolNames.has(execution.toolName)) {
-    artifacts.push({ type: 'file-change', path, ...patchCounts(result) })
+    artifacts.push({
+      type: 'file-change',
+      path,
+      ...(attributedPath?.repositoryId ? { repositoryId: attributedPath.repositoryId } : {}),
+      ...patchCounts(result),
+    })
   }
 
   const command = stringProperty(execution.input, 'command')
@@ -71,6 +88,39 @@ export function deriveActivityArtifacts(
   return artifacts
 }
 
+export function deriveMutationPreview(
+  execution: ToolExecution,
+  result: unknown,
+  runtimeDirectory: string,
+  repositories: readonly ActivityRepositoryLocation[] = []
+): ActivityMutationPreview | undefined {
+  if (execution.status !== 'completed' || !changedToolNames.has(execution.toolName)) return undefined
+
+  const attributedPath = normalizedActivityPath(
+    execution.input,
+    runtimeDirectory,
+    repositories,
+    execution.toolName === 'apply_patch' ? firstPatchPath(execution.input) : undefined
+  )
+  if (!attributedPath) return undefined
+
+  const content =
+    execution.toolName === 'write'
+      ? stringProperty(execution.input, 'content')
+      : stringProperty(objectProperty(result, 'details'), 'patch')
+  if (content === undefined) return undefined
+
+  const limit = 100_000
+  const truncated = content.length > limit
+
+  return {
+    kind: execution.toolName === 'write' ? 'code' : 'diff',
+    ...attributedPath,
+    content: truncated ? `${content.slice(0, limit)}\n…` : content,
+    truncated,
+  }
+}
+
 export function mergeActivityArtifacts(
   current: readonly ActivityArtifact[],
   additions: readonly ActivityArtifact[]
@@ -87,21 +137,46 @@ export function mergeActivityArtifacts(
 export function countArtifactFiles(artifacts: readonly ActivityArtifact[]): number {
   return new Set(
     artifacts.flatMap((artifact) =>
-      artifact.type === 'inspected-file' || artifact.type === 'file-change' ? [artifact.path] : []
+      artifact.type === 'inspected-file'
+        ? [artifact.path]
+        : artifact.type === 'file-change'
+          ? [`${artifact.repositoryId ?? 'session'}:${artifact.path}`]
+          : []
     )
   ).size
 }
 
 function normalizedRuntimePath(input: unknown, runtimeDirectory: string): string | undefined {
-  const path = suppliedPath(input)
+  return normalizedPath(suppliedPath(input), runtimeDirectory)
+}
 
+function normalizedActivityPath(
+  input: unknown,
+  runtimeDirectory: string,
+  repositories: readonly ActivityRepositoryLocation[],
+  suppliedActivityPath?: string
+): Readonly<{ path: string; repositoryId?: string }> | undefined {
+  const path = suppliedActivityPath ?? suppliedPath(input)
   if (!path) return undefined
 
-  const runtimePath = isAbsolute(path) ? relative(runtimeDirectory, path) : normalize(path)
+  if (isAbsolute(path)) {
+    for (const repository of repositories) {
+      const repositoryPath = normalizedPath(path, repository.workingPath)
+      if (repositoryPath) return { path: repositoryPath, repositoryId: repository.repositoryId }
+    }
+  }
 
-  if (runtimePath === '..' || runtimePath.startsWith(`..${sep}`) || isAbsolute(runtimePath)) return undefined
+  const runtimePath = normalizedPath(path, runtimeDirectory)
+  return runtimePath ? { path: runtimePath } : undefined
+}
 
-  return runtimePath.split(sep).join('/')
+function normalizedPath(path: string | undefined, rootPath: string): string | undefined {
+  if (!path) return undefined
+
+  const relativePath = isAbsolute(path) ? relative(rootPath, path) : normalize(path)
+  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) return undefined
+
+  return relativePath.split(sep).join('/')
 }
 
 function suppliedPath(input: unknown): string | undefined {
@@ -140,7 +215,10 @@ function classifyValidation(command: string): string | undefined {
 }
 
 function artifactKey(artifact: ActivityArtifact): string {
-  if (artifact.type === 'inspected-file' || artifact.type === 'file-change') return `${artifact.type}:${artifact.path}`
+  if (artifact.type === 'inspected-file') return `${artifact.type}:${artifact.path}`
+  if (artifact.type === 'file-change') {
+    return `${artifact.type}:${artifact.repositoryId ?? 'session'}:${artifact.path}`
+  }
   if (artifact.type === 'command') return `${artifact.type}:${artifact.command}`
   return `${artifact.type}:${artifact.label}`
 }

--- a/src/main/activity-records.ts
+++ b/src/main/activity-records.ts
@@ -1,4 +1,9 @@
 import type { QueuedFollowUp, QueuedFollowUpRecord } from '@/src/queued-follow-up'
+import {
+  maximumSessionCodeReviewLength,
+  parseSessionCodeReview,
+  type SessionCodeReviewRecord,
+} from '@/src/session-code-review'
 import type { SessionActionCard, SessionActionCardStatus } from '@/src/session-action-cards'
 import {
   agentActivityKinds,
@@ -36,6 +41,7 @@ export type ActivityLayerRecord =
       status: Exclude<SessionActionCardStatus, 'available'>
     }>
   | Readonly<{ version: 1 } & QueuedFollowUpRecord>
+  | Readonly<{ version: 1 } & SessionCodeReviewRecord>
   | Readonly<{ version: 1; type: 'steering-message'; text: string; acceptedAt: number }>
   | Readonly<{ version: 1; type: 'action-message'; text: string; acceptedAt: number }>
   | Readonly<{
@@ -60,6 +66,21 @@ export function isActivityLayerRecord(value: unknown): value is ActivityLayerRec
   }
   if (value.type === 'queued-follow-up') return isQueuedFollowUp(value.followUp)
   if (value.type === 'queued-follow-up-removed') return isNonEmptyString(value.followUpId)
+  if (value.type === 'code-review-comment') {
+    return Boolean(parseSessionCodeReview({ kind: 'review', comments: [value.comment] }))
+  }
+  if (value.type === 'code-review-comment-removed') return isNonEmptyString(value.commentId)
+  if (value.type === 'code-review-comments-cleared') {
+    return Array.isArray(value.commentIds) && value.commentIds.every(isNonEmptyString)
+  }
+  if (value.type === 'code-review-message') {
+    return (
+      Boolean(parseSessionCodeReview(value.review)) &&
+      typeof value.text === 'string' &&
+      value.text.length <= maximumSessionCodeReviewLength &&
+      isTimestamp(value.acceptedAt)
+    )
+  }
   if (value.type === 'steering-message' || value.type === 'action-message') {
     return typeof value.text === 'string' && isTimestamp(value.acceptedAt)
   }
@@ -101,6 +122,7 @@ function isQueuedFollowUp(value: unknown): value is QueuedFollowUp {
     isNonEmptyString(value.id) &&
     typeof value.text === 'string' &&
     (value.skills === undefined || (Array.isArray(value.skills) && value.skills.every(isSessionSkillMention))) &&
+    (value.codeReview === undefined || Boolean(parseSessionCodeReview(value.codeReview))) &&
     isTimestamp(value.createdAt)
   )
 }

--- a/src/main/activity-records.ts
+++ b/src/main/activity-records.ts
@@ -180,6 +180,7 @@ function isActivityArtifact(value: unknown): value is ActivityArtifact {
   if (value.type === 'file-change') {
     return (
       isNonEmptyString(value.path) &&
+      (value.repositoryId === undefined || isNonEmptyString(value.repositoryId)) &&
       (value.additions === undefined || isCount(value.additions)) &&
       (value.deletions === undefined || isCount(value.deletions))
     )

--- a/src/main/application-state/index.ts
+++ b/src/main/application-state/index.ts
@@ -30,6 +30,7 @@ import {
   createWorkstreamSessionStore,
   type OwnedSessionResolution,
   type PreparedSessionRepository,
+  type SessionChangeRepositoryLocation,
   type WorkstreamCreationResult,
 } from './workstream-session-store'
 import { incrementRevision, initializeApplicationStateStore, loadSqlite } from './application-state-store'
@@ -48,6 +49,7 @@ export type ApplicationAuthorityOptions = Readonly<{
 export type {
   OwnedSessionResolution,
   PreparedSessionRepository,
+  SessionChangeRepositoryLocation,
   WorkstreamCreationResult,
 } from './workstream-session-store'
 
@@ -75,6 +77,7 @@ export type ApplicationAuthority = Readonly<{
   renameWorkstreamSession(sessionId: SessionId, title: string): Promise<WorkstreamsSnapshot>
   setSessionDescription(sessionId: SessionId, description: string): Promise<WorkstreamsSnapshot>
   resolveOwnedSession(sessionId: SessionId): Promise<OwnedSessionResolution | undefined>
+  resolveSessionChangeRepositories(sessionId: SessionId): Promise<readonly SessionChangeRepositoryLocation[]>
   resolveWorkstreamWorkingLocation(workstreamId: string, repositoryId: string): Promise<string>
   getWorkstreamKnowledge(workstreamId: string): Promise<WorkstreamKnowledge>
   applyUserWorkstreamKnowledgeCommand(
@@ -159,6 +162,7 @@ export async function initializeApplicationAuthority(
     renameWorkstreamSession,
     setSessionDescription,
     resolveOwnedSession,
+    resolveSessionChangeRepositories,
     resolveWorkstreamWorkingLocation,
     getCurrentWorkstreamRepositorySet,
   } = workstreamSessionStore
@@ -185,6 +189,7 @@ export async function initializeApplicationAuthority(
     renameWorkstreamSession,
     setSessionDescription,
     resolveOwnedSession,
+    resolveSessionChangeRepositories,
     resolveWorkstreamWorkingLocation,
     getWorkstreamKnowledge,
     applyUserWorkstreamKnowledgeCommand,

--- a/src/main/application-state/workstream-session-store.ts
+++ b/src/main/application-state/workstream-session-store.ts
@@ -82,6 +82,12 @@ export type PreparedSessionRepository = Readonly<{
   resourcePolicyRevision: number
 }>
 
+export type SessionChangeRepositoryLocation = Readonly<{
+  repositoryId: string
+  repositoryName: string
+  workingPath: string
+}>
+
 export function createWorkstreamSessionStore({
   openDatabase,
   inspectRepository,
@@ -1266,6 +1272,39 @@ export function createWorkstreamSessionStore({
     }
   }
 
+  async function resolveSessionChangeRepositories(
+    sessionId: SessionId
+  ): Promise<readonly SessionChangeRepositoryLocation[]> {
+    const database = openDatabase()
+
+    try {
+      const session = database.prepare('SELECT mode, creation_status FROM sessions WHERE id = ?').get(sessionId)
+
+      if (!session || session.creation_status !== 'finalized' || session.mode === 'brainstorm') return []
+      if (session.mode !== 'default' && session.mode !== 'implement') return []
+
+      const rows = database
+        .prepare(
+          `SELECT location.repository_id, repository.directory_path, location.working_path
+             FROM session_repository_locations location
+             JOIN repositories repository ON repository.id = location.repository_id
+            WHERE location.session_id = ?
+              AND location.availability = 'available'
+              AND (? = 'default' OR location.kind = 'worktree')
+            ORDER BY location.rowid`
+        )
+        .all(sessionId, session.mode)
+
+      return rows.map((row) => ({
+        repositoryId: String(row.repository_id),
+        repositoryName: repositoryName(String(row.directory_path)),
+        workingPath: String(row.working_path),
+      }))
+    } finally {
+      database.close()
+    }
+  }
+
   async function resolveWorkstreamWorkingLocation(workstreamId: string, repositoryId: string): Promise<string> {
     const database = openDatabase()
     let workspaceId: string
@@ -1311,6 +1350,7 @@ export function createWorkstreamSessionStore({
     renameWorkstreamSession,
     setSessionDescription,
     resolveOwnedSession,
+    resolveSessionChangeRepositories,
     resolveWorkstreamWorkingLocation,
     getCurrentWorkstreamRepositorySet,
   }

--- a/src/main/application-state/workstreams.test.ts
+++ b/src/main/application-state/workstreams.test.ts
@@ -190,6 +190,49 @@ test('lazily creates a Repository worktree for an Implement Session', async () =
   assert.equal(await readFile(join(expectedPath, 'tracked.txt'), 'utf8'), 'committed')
 })
 
+test('exposes only prepared writable Repository locations for Session changes', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Review isolated changes' })
+
+  assert.deepEqual(await authority.resolveSessionChangeRepositories(created.sessionId), [])
+
+  const prepared = await authority.prepareSessionRepository(created.sessionId, repository.id)
+
+  assert.deepEqual(await authority.resolveSessionChangeRepositories(created.sessionId), [
+    {
+      repositoryId: repository.id,
+      repositoryName: repository.name,
+      workingPath: prepared.workingPath,
+    },
+  ])
+})
+
+test('exposes the direct working location for Quick Session changes', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  const quick = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+
+  assert.deepEqual(await authority.resolveSessionChangeRepositories(quick.sessionId), [
+    {
+      repositoryId: repository.id,
+      repositoryName: repository.name,
+      workingPath: repository.directoryPath,
+    },
+  ])
+})
+
+test('excludes Brainstorm Sessions from Session changes', async () => {
+  const { authority, workspace } = await createFixture()
+  const created = await authority.createWorkstream(workspace.id, { goal: 'Inspect without changes' })
+  const brainstorm = await authority.createWorkstreamSession(created.snapshot.workstreams[0]!.id, {
+    mode: 'brainstorm',
+  })
+
+  assert.deepEqual(await authority.resolveSessionChangeRepositories(brainstorm.sessionId), [])
+})
+
 test('restores a removed Implement Session worktree from its persisted branch', async () => {
   const { authority, workspace } = await createFixture()
   const repository = workspace.repositories[0]!

--- a/src/main/application-state/workstreams.test.ts
+++ b/src/main/application-state/workstreams.test.ts
@@ -21,8 +21,8 @@ type RepositoryInspector = (directoryPath: string) => Promise<InspectedGitReposi
 const { Database } = (await Function('return import("bun:sqlite")')()) as BunSqliteModule
 const bunSqlite: SqliteModule = {
   DatabaseSync: Database as unknown as SqliteModule['DatabaseSync'],
-  async backup() {
-    throw new Error('Backup is not exercised by the Bun test adapter.')
+  async backup(_source, destination) {
+    await writeFile(destination, 'SQLite backup')
   },
 }
 
@@ -93,24 +93,33 @@ async function createInterruptedSessionWorktreeFixture() {
   return { storageDirectory, repositoryPath, interrupted, repository, created }
 }
 
-test('reset preserves external Git and Pi Session artifacts without adopting them', async () => {
-  const { authority, storageDirectory, workspace } = await createFixture()
-  const repository = workspace.repositories[0]
-  assert.ok(repository)
-  const created = await authority.createWorkstream(workspace.id, { goal: 'Preserve external artifacts' })
-  const resolution = await authority.resolveOwnedSession(created.sessionId)
-  assert.ok(resolution)
-  const reset = await authority.reset()
+test(
+  'reset preserves external Git and Pi Session artifacts without adopting them',
+  { skip: process.platform === 'win32' ? 'Bun retains closed SQLite handles on Windows.' : false },
+  async () => {
+    const { authority, storageDirectory, workspace } = await createFixture()
+    const repository = workspace.repositories[0]
+    assert.ok(repository)
+    const created = await authority.createWorkstream(workspace.id, { goal: 'Preserve external artifacts' })
+    const resolution = await authority.resolveOwnedSession(created.sessionId)
+    assert.ok(resolution)
+    const reset = await authority.reset()
 
-  assert.deepEqual(reset, { status: 'first-launch' })
-  await Promise.all([access(repository.directoryPath), access(resolution.sessionPath)])
-  assert.deepEqual((await authority.getWorkspaces()).workspaces, [])
-  assert.equal(await authority.resolveOwnedSession(created.sessionId), undefined)
-  assert.equal((await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })).startup.status, 'ready')
-})
+    assert.deepEqual(reset, { status: 'first-launch' })
+    await Promise.all([access(repository.directoryPath), access(resolution.sessionPath)])
+    assert.deepEqual((await authority.getWorkspaces()).workspaces, [])
+    assert.equal(await authority.resolveOwnedSession(created.sessionId), undefined)
+    assert.equal(
+      (await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })).startup.status,
+      'ready'
+    )
+  }
+)
 
 test('reset creates a new application authority generation', async () => {
-  const { authority, storageDirectory } = await createFixture()
+  const storageDirectory = await mkdtemp(join(tmpdir(), 'pi-workspace-reset-generation-'))
+  temporaryDirectories.push(storageDirectory)
+  const authority = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
   const markerPath = join(storageDirectory, 'application-state.json')
   const before = JSON.parse(await readFile(markerPath, 'utf8')) as { generationId: string }
 

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -489,6 +489,15 @@ export async function createPiSessionRuntime(
     },
     getSkills: getAvailableSkills,
     getSkillPrompt,
+    getActivityRepositoryLocations() {
+      const repositories = managedPolicyGuard?.currentPolicy().repositories ?? []
+
+      return repositories.flatMap((repository) =>
+        repository.availability === 'available'
+          ? [{ repositoryId: repository.id, workingPath: repository.workingPath }]
+          : []
+      )
+    },
     loadRawOperation(toolCallId) {
       let input: unknown
       let result: unknown

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -9,6 +9,8 @@ import type {
 } from '@/src/domain/workstream-knowledge-transitions'
 import {
   composerIpcChannels,
+  parseCodeReviewCommentCommand,
+  parseCodeReviewCommentRemovalRequest,
   parseQueuedFollowUpRemovalRequest,
   parseSessionCompactRequest,
   parseSessionMessageSubmission,
@@ -697,6 +699,34 @@ export function initializeComposer(authority: ApplicationAuthority): void {
     return submission
       ? registry.submit(submission)
       : Promise.resolve({ status: 'rejected', reason: 'invalid-submission' })
+  })
+
+  handleTrustedIpc(composerIpcChannels.getCodeReviewDraft, (_event, value: unknown) => {
+    const request = parseSessionRunStopRequest(value)
+
+    return request ? registry.getCodeReviewDraft(request.sessionId) : Promise.reject(new Error('Invalid Session.'))
+  })
+
+  handleTrustedIpc(composerIpcChannels.saveCodeReviewComment, (_event, value: unknown) => {
+    const command = parseCodeReviewCommentCommand(value)
+
+    return command ? registry.saveCodeReviewComment(command) : Promise.reject(new Error('Invalid review comment.'))
+  })
+
+  handleTrustedIpc(composerIpcChannels.removeCodeReviewComment, (_event, value: unknown) => {
+    const request = parseCodeReviewCommentRemovalRequest(value)
+
+    return request
+      ? registry.removeCodeReviewComment(request.sessionId, request.commentId)
+      : Promise.reject(new Error('Invalid review comment.'))
+  })
+
+  handleTrustedIpc(composerIpcChannels.finishCodeReview, (_event, value: unknown) => {
+    const request = parseSessionRunStopRequest(value)
+
+    return request
+      ? registry.finishCodeReview(request.sessionId)
+      : Promise.resolve({ status: 'rejected' as const, reason: 'invalid-submission' as const })
   })
 
   handleTrustedIpc(composerIpcChannels.stop, (_event, value: unknown): Promise<SessionRunStopResult> => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@/src/main/renderer-security'
 import { createStartupFailureUrl, startupRetryUrl } from '@/src/main/startup-failure'
 import { initializeSettings, subscribeToSettings } from '@/src/main/settings'
+import { initializeSessionChanges } from '@/src/main/session-changes-ipc'
 import { initializeWorkstreams } from '@/src/main/workstreams-ipc'
 import { initializeWorkstreamKnowledge } from '@/src/main/workstream-knowledge-ipc'
 import { configureTrustedRendererUrl, registerTrustedRendererWindow } from '@/src/main/trusted-ipc'
@@ -112,6 +113,7 @@ async function initializeApplication(): Promise<void> {
 
     const authority = await initializeApplicationAuthority(app.getPath('userData'))
     initializeApplicationStateIpc(authority)
+    initializeSessionChanges(authority)
     initializeWorkstreams(authority, { openPath: (path) => shell.openPath(path) })
     initializeWorkstreamKnowledge(authority)
     const settings = await initializeSettings()

--- a/src/main/managed-session-runtime-policy.ts
+++ b/src/main/managed-session-runtime-policy.ts
@@ -10,6 +10,7 @@ export type ManagedSessionRuntimePolicyGuardOptions = Readonly<{
 export interface ManagedSessionRuntimePolicyGuard {
   validate(): Promise<ManagedSessionRuntimePolicy>
   prepareRepository(repositoryId: string): Promise<PreparedSessionRepository>
+  currentPolicy(): ManagedSessionRuntimePolicy
 }
 
 export function createManagedSessionRuntimePolicyGuard(
@@ -52,7 +53,7 @@ export function createManagedSessionRuntimePolicyGuard(
     return prepared
   }
 
-  return { validate, prepareRepository }
+  return { validate, prepareRepository, currentPolicy: () => activePolicy }
 }
 
 async function requireCurrentPolicyIdentity(

--- a/src/main/pi-session-runtime-code-review.ts
+++ b/src/main/pi-session-runtime-code-review.ts
@@ -1,0 +1,123 @@
+import type { SessionCodeReviewCommentCommand } from '@/src/composer'
+import type { SessionId } from '@/src/domain/session'
+import type { ActivityLayerRecord } from '@/src/main/activity-records'
+import {
+  maximumSessionCodeReviewComments,
+  parseSessionCodeReview,
+  parseSessionCodeReviewCommentInput,
+  projectSessionCodeReviewDraft,
+  type SessionCodeReviewDraft,
+  type SessionCodeReviewRecord,
+} from '@/src/session-code-review'
+
+type SessionRuntimeCodeReviewOptions = Readonly<{
+  createId: () => string
+  now: () => number
+  persist: (sessionId: SessionId, record: ActivityLayerRecord) => boolean
+}>
+
+export interface SessionRuntimeCodeReviews {
+  hydrate(sessionId: SessionId, records: readonly ActivityLayerRecord[]): void
+  get(sessionId: SessionId): SessionCodeReviewDraft
+  save(command: SessionCodeReviewCommentCommand): SessionCodeReviewDraft
+  remove(sessionId: SessionId, commentId: string): SessionCodeReviewDraft
+  clear(sessionId: SessionId, commentIds: readonly string[]): boolean
+  dispose(): void
+}
+
+/** Owns persisted, unfinished code-review comments for Session runtimes. */
+export function createSessionRuntimeCodeReviews({
+  createId,
+  now,
+  persist,
+}: SessionRuntimeCodeReviewOptions): SessionRuntimeCodeReviews {
+  const draftsBySessionId = new Map<SessionId, SessionCodeReviewDraft>()
+
+  function get(sessionId: SessionId): SessionCodeReviewDraft {
+    return draftsBySessionId.get(sessionId) ?? { comments: [] }
+  }
+
+  return {
+    hydrate(sessionId, activityRecords) {
+      const records = activityRecords.flatMap((record): SessionCodeReviewRecord[] => {
+        if (
+          record.type === 'code-review-comment' ||
+          record.type === 'code-review-comment-removed' ||
+          record.type === 'code-review-comments-cleared' ||
+          record.type === 'code-review-message'
+        ) {
+          return [record]
+        }
+        if (record.type === 'queued-follow-up' && record.followUp.codeReview?.kind === 'review') {
+          return [
+            {
+              type: 'code-review-comments-cleared',
+              commentIds: record.followUp.codeReview.comments.map(({ id }) => id),
+            },
+          ]
+        }
+
+        return []
+      })
+
+      draftsBySessionId.set(sessionId, projectSessionCodeReviewDraft(records))
+    },
+    get,
+    save(command) {
+      const input = parseSessionCodeReviewCommentInput(command)
+      if (!input) throw new TypeError('A valid code-review comment is required.')
+
+      const current = get(command.sessionId)
+      const existing = input.commentId ? current.comments.find((comment) => comment.id === input.commentId) : undefined
+      if (input.commentId && !existing) throw new Error('That review comment is no longer available.')
+      if (!existing && current.comments.length >= maximumSessionCodeReviewComments) {
+        throw new Error('Finish the current review before adding more comments.')
+      }
+
+      const comment = {
+        id: existing?.id ?? createId(),
+        text: input.text,
+        reference: input.reference,
+        createdAt: existing?.createdAt ?? now(),
+      }
+      const comments = existing
+        ? current.comments.map((candidate) => (candidate.id === existing.id ? comment : candidate))
+        : [...current.comments, comment]
+      if (!parseSessionCodeReview({ kind: 'review', comments })) {
+        throw new Error('This review is too large. Finish it before adding more comments.')
+      }
+      if (!persist(command.sessionId, { version: 1, type: 'code-review-comment', comment })) {
+        throw new Error('The review comment could not be saved.')
+      }
+
+      const next = { comments }
+      draftsBySessionId.set(command.sessionId, next)
+      return next
+    },
+    remove(sessionId, commentId) {
+      const current = get(sessionId)
+      if (!current.comments.some((comment) => comment.id === commentId)) return current
+      if (!persist(sessionId, { version: 1, type: 'code-review-comment-removed', commentId })) {
+        throw new Error('The review comment could not be removed.')
+      }
+
+      const next = { comments: current.comments.filter((comment) => comment.id !== commentId) }
+      draftsBySessionId.set(sessionId, next)
+      return next
+    },
+    clear(sessionId, commentIds) {
+      if (commentIds.length === 0) return true
+
+      const persisted = persist(sessionId, { version: 1, type: 'code-review-comments-cleared', commentIds })
+      const cleared = new Set(commentIds)
+      draftsBySessionId.set(sessionId, {
+        comments: get(sessionId).comments.filter((comment) => !cleared.has(comment.id)),
+      })
+
+      return persisted
+    },
+    dispose() {
+      draftsBySessionId.clear()
+    },
+  }
+}

--- a/src/main/pi-session-runtime-transcript.ts
+++ b/src/main/pi-session-runtime-transcript.ts
@@ -95,10 +95,20 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
 
   const hiddenMessageIds = new Set<string>()
   const steeringMessageIds = new Set<string>()
+  const codeReviewsByMessageId = new Map<
+    string,
+    Extract<ActivityLayerRecord, { type: 'code-review-message' }>['review']
+  >()
   const unmatchedConversations = [...history.conversations]
 
   for (const record of history.activityRecords) {
-    if (record.type !== 'steering-message' && record.type !== 'action-message') continue
+    if (
+      record.type !== 'steering-message' &&
+      record.type !== 'action-message' &&
+      record.type !== 'code-review-message'
+    ) {
+      continue
+    }
 
     let index = -1
     let nearestTimestampDifference = Number.POSITIVE_INFINITY
@@ -120,8 +130,10 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
 
     if (record.type === 'action-message') {
       hiddenMessageIds.add(conversation.id)
-    } else {
+    } else if (record.type === 'steering-message') {
       steeringMessageIds.add(conversation.id)
+    } else {
+      codeReviewsByMessageId.set(conversation.id, record.review)
     }
   }
 
@@ -133,6 +145,7 @@ export function hydrateTimeline(timeline: SessionRuntimeTimeline, history: PiSes
       role: conversation.role,
       text: conversation.text,
       skills: conversation.skills,
+      codeReview: codeReviewsByMessageId.get(conversation.id),
       delivery: steeringMessageIds.has(conversation.id) ? 'steer' : undefined,
       state: 'complete',
       revision: 0,

--- a/src/main/pi-session-runtime-transcript.ts
+++ b/src/main/pi-session-runtime-transcript.ts
@@ -1,4 +1,5 @@
 import type { ActivityLayerRecord } from '@/src/main/activity-records'
+import type { ActivityRepositoryLocation } from '@/src/main/activity-artifacts'
 import type { AgentActivity, AgentRun, SessionTimelineEntry, ToolExecution } from '@/src/session-timeline'
 import type { SessionContextUsage, SessionTranscriptMessage } from '@/src/session-transcript'
 import type { SessionActionCard } from '@/src/session-action-cards'
@@ -19,6 +20,7 @@ export type SessionRuntimeTimeline = {
   controlTransitions: Map<string, SessionRuntimeActivityControlTransition>
   persist?: (record: ActivityLayerRecord) => void
   loadRawOperation?: PiSessionRuntime['loadRawOperation']
+  getActivityRepositoryLocations?: () => readonly ActivityRepositoryLocation[]
 }
 
 export type SessionRuntimeActivity = {

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -4,8 +4,14 @@ import type {
   SessionMessageSubmissionResult,
   SessionContextCompactionResult,
   SessionRunStopResult,
+  SessionCodeReviewCommentCommand,
 } from '@/src/composer'
 import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
+import {
+  formatSessionCodeReviewText,
+  parseSessionCodeReview,
+  type SessionCodeReviewDraft,
+} from '@/src/session-code-review'
 import type { SessionId } from '@/src/domain/session'
 import type { SessionActionCardToolInput } from '@/src/session-action-cards'
 import {
@@ -13,6 +19,7 @@ import {
   replaceSessionSkillTokens,
   type SessionSkill,
   type SessionSkillMention,
+  type SessionSkillSelection,
 } from '@/src/session-skills'
 import type { ActivityLayerRecord, AgentRunDiagnosticKind } from '@/src/main/activity-records'
 import {
@@ -59,6 +66,7 @@ import {
   type SessionRuntimeTimeline,
 } from './pi-session-runtime-transcript'
 import { createSessionRuntimeConfiguration } from './pi-session-runtime-configuration'
+import { createSessionRuntimeCodeReviews } from './pi-session-runtime-code-review'
 
 type PiPromptOptions = Readonly<{
   streamingBehavior?: 'steer' | 'followUp'
@@ -151,6 +159,10 @@ export interface PiSessionRuntimeRegistry {
     reconcileAfterRun?: () => Promise<boolean>
   ): void
   submit(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult>
+  getCodeReviewDraft(sessionId: SessionId): Promise<SessionCodeReviewDraft>
+  saveCodeReviewComment(command: SessionCodeReviewCommentCommand): Promise<SessionCodeReviewDraft>
+  removeCodeReviewComment(sessionId: SessionId, commentId: string): Promise<SessionCodeReviewDraft>
+  finishCodeReview(sessionId: SessionId): Promise<SessionMessageSubmissionResult>
   stop(sessionId: SessionId): Promise<SessionRunStopResult>
   compact(sessionId: SessionId): Promise<SessionContextCompactionResult>
   removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>
@@ -184,6 +196,44 @@ export const maximumConcurrentAgentRuns = 10
 /** Preserves normal follow-up use while bounding queued future provider work per Session. */
 export const maximumPendingSessionFollowUps = 3
 
+type ProjectedSessionSubmission = Readonly<{
+  text: string
+  selections: readonly SessionSkillSelection[]
+}>
+
+function projectSessionSubmissionSkills(submission: SessionMessageSubmission): ProjectedSessionSubmission {
+  if (!submission.codeReview) return projectSessionSkillSelections(submission.text)
+
+  const selections: SessionSkillSelection[] = []
+  const text = formatSessionCodeReviewText(submission.codeReview, (commentText, outputOffset) => {
+    const projected = projectSessionSkillSelections(commentText)
+    selections.push(
+      ...projected.selections.map((selection) => ({ ...selection, offset: outputOffset + selection.offset }))
+    )
+
+    return projected.text
+  })
+
+  return { text, selections }
+}
+
+function replaceSessionSubmissionSkills(
+  submission: SessionMessageSubmission,
+  replacement: (name: string) => string | undefined
+): string | undefined {
+  if (!submission.codeReview) return replaceSessionSkillTokens(submission.text, replacement)
+
+  let valid = true
+  const text = formatSessionCodeReviewText(submission.codeReview, (commentText) => {
+    const replaced = replaceSessionSkillTokens(commentText, replacement)
+    if (replaced === undefined) valid = false
+
+    return replaced ?? ''
+  })
+
+  return valid ? text : undefined
+}
+
 export function createPiSessionRuntimeRegistry({
   findSession,
   canSubmit = () => true,
@@ -203,6 +253,11 @@ export function createPiSessionRuntimeRegistry({
   const activationGate = createSessionRuntimeActivationGate()
   const activeAgentRunReservations = new Set<SessionId>()
   const queuedFollowUpQueue = createQueuedFollowUpQueue()
+  const codeReviews = createSessionRuntimeCodeReviews({
+    createId,
+    now,
+    persist: (sessionId, record) => persistActivityRecord(getTimeline(sessionId), record),
+  })
   const submissionQueuesBySessionId = new Map<SessionId, Promise<void>>()
   const sessionReconciliationBySessionId = new Map<SessionId, () => Promise<boolean>>()
   const noProgressTimeoutsBySessionId = new Map<SessionId, ReturnType<typeof setTimeout>>()
@@ -289,7 +344,12 @@ export function createPiSessionRuntimeRegistry({
 
     if (!followUp) return
 
-    const result = await submit({ sessionId, text: followUp.text, delivery: 'follow-up' })
+    const result = await submit({
+      sessionId,
+      text: followUp.text,
+      delivery: 'follow-up',
+      codeReview: followUp.codeReview,
+    })
 
     if (result.status === 'accepted' && result.delivery !== 'follow-up') {
       if (!removeQueuedFollowUp(sessionId, followUp.id)) {
@@ -1049,6 +1109,7 @@ export function createPiSessionRuntimeRegistry({
     const history = runtime.loadHistory?.()
     hydrateTimeline(timeline, history)
     hydrateQueuedFollowUps(sessionId, history)
+    codeReviews.hydrate(sessionId, history?.activityRecords ?? [])
 
     const unsubscribes = [runtime.subscribe((event) => handleRuntimeEvent(sessionId, event))]
     return { runtime, runtimeKey, unsubscribes }
@@ -1071,7 +1132,8 @@ export function createPiSessionRuntimeRegistry({
     messageId: string,
     text: string,
     skills?: readonly SessionSkillMention[],
-    delivery?: 'steer'
+    delivery?: 'steer',
+    codeReview?: SessionMessageSubmission['codeReview']
   ): void {
     const timeline = getTimeline(sessionId)
     const message: SessionTranscriptMessage = {
@@ -1080,6 +1142,7 @@ export function createPiSessionRuntimeRegistry({
       text,
       skills,
       delivery,
+      codeReview,
       state: 'complete',
       revision: timeline.revision + 1,
     }
@@ -1091,7 +1154,7 @@ export function createPiSessionRuntimeRegistry({
     submission: SessionMessageSubmission,
     runtime: PiSessionRuntime
   ): SessionMessageSubmissionResult {
-    const projected = projectSessionSkillSelections(submission.text)
+    const projected = projectSessionSubmissionSkills(submission)
     const availableSkills = runtime.getSkills?.() ?? []
     const skillsAvailable = projected.selections.every((selection) =>
       availableSkills.some((skill) => skill.name === selection.name)
@@ -1100,7 +1163,7 @@ export function createPiSessionRuntimeRegistry({
     if (!skillsAvailable) return { status: 'rejected', reason: 'skill-unavailable' }
 
     try {
-      if (replaceSessionSkillTokens(submission.text, (name) => runtime.getSkillPrompt?.(name)) === undefined) {
+      if (replaceSessionSubmissionSkills(submission, (name) => runtime.getSkillPrompt?.(name)) === undefined) {
         return { status: 'rejected', reason: 'skill-unavailable' }
       }
     } catch {
@@ -1122,6 +1185,7 @@ export function createPiSessionRuntimeRegistry({
       id: createId(),
       text: submission.text,
       skills: skills.length > 0 ? skills : undefined,
+      codeReview: submission.codeReview,
       createdAt: now(),
     }
     const persisted = persistActivityRecord(getTimeline(submission.sessionId), {
@@ -1143,7 +1207,7 @@ export function createPiSessionRuntimeRegistry({
     runtime: PiSessionRuntime,
     authorize: () => boolean | Promise<boolean>
   ): Promise<SessionMessageSubmissionResult> {
-    const projected = projectSessionSkillSelections(submission.text)
+    const projected = projectSessionSubmissionSkills(submission)
     const availableSkills = runtime.getSkills?.() ?? []
     const skills = projected.selections.flatMap((selection): SessionSkillMention[] => {
       const available = availableSkills.find((skill) => skill.name === selection.name)
@@ -1157,7 +1221,7 @@ export function createPiSessionRuntimeRegistry({
 
     let promptText: string | undefined
     try {
-      promptText = replaceSessionSkillTokens(submission.text, (name) => runtime.getSkillPrompt?.(name))
+      promptText = replaceSessionSubmissionSkills(submission, (name) => runtime.getSkillPrompt?.(name))
     } catch {
       return { status: 'rejected', reason: 'unexpected' }
     }
@@ -1199,6 +1263,7 @@ export function createPiSessionRuntimeRegistry({
               role: 'user',
               text: projected.text,
               skills: skillMentions,
+              codeReview: submission.codeReview,
               delivery: acceptedDelivery === 'steer' ? 'steer' : undefined,
               timestamp,
             }
@@ -1224,8 +1289,19 @@ export function createPiSessionRuntimeRegistry({
                 messageId,
                 projected.text,
                 skillMentions,
-                acceptedDelivery === 'steer' ? 'steer' : undefined
+                acceptedDelivery === 'steer' ? 'steer' : undefined,
+                submission.codeReview
               )
+            }
+
+            if (submission.codeReview) {
+              persistActivityRecord(timeline, {
+                version: 1,
+                type: 'code-review-message',
+                review: submission.codeReview,
+                text: projected.text,
+                acceptedAt: timestamp,
+              })
             }
 
             if (acceptedDelivery === 'steer' || acceptedDelivery === 'action') {
@@ -1409,6 +1485,10 @@ export function createPiSessionRuntimeRegistry({
   }
 
   async function submitImmediately(submission: SessionMessageSubmission): Promise<SessionMessageSubmissionResult> {
+    if (submission.codeReview && submission.delivery !== 'follow-up') {
+      return { status: 'rejected', reason: 'invalid-submission' }
+    }
+
     let runtime: PiSessionRuntime | undefined
     let leaseAcquired = false
     let runCapacityReserved = false
@@ -1526,6 +1606,41 @@ export function createPiSessionRuntimeRegistry({
       }
     },
     submit,
+    async getCodeReviewDraft(sessionId) {
+      await getRuntime(sessionId)
+      return codeReviews.get(sessionId)
+    },
+    async saveCodeReviewComment(command) {
+      await getRuntime(command.sessionId)
+      return codeReviews.save(command)
+    },
+    async removeCodeReviewComment(sessionId, commentId) {
+      await getRuntime(sessionId)
+      return codeReviews.remove(sessionId, commentId)
+    },
+    async finishCodeReview(sessionId) {
+      await getRuntime(sessionId)
+      const draft = codeReviews.get(sessionId)
+      if (draft.comments.length === 0) return { status: 'rejected', reason: 'invalid-submission' }
+
+      const codeReview = parseSessionCodeReview({ kind: 'review', comments: draft.comments })
+      if (!codeReview) return { status: 'rejected', reason: 'invalid-submission' }
+
+      const result = await submit({
+        sessionId,
+        text: formatSessionCodeReviewText(codeReview),
+        delivery: 'follow-up',
+        codeReview,
+      })
+
+      if (result.status === 'accepted') {
+        codeReviews.clear(
+          sessionId,
+          draft.comments.map(({ id }) => id)
+        )
+      }
+      return result
+    },
     stop,
     compact,
     async removeQueuedFollowUp(sessionId, followUpId) {
@@ -1636,6 +1751,7 @@ export function createPiSessionRuntimeRegistry({
       activeAgentRunReservations.clear()
       submissionQueuesBySessionId.clear()
       queuedFollowUpQueue.clear()
+      codeReviews.dispose()
     },
   }
 }

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -18,6 +18,7 @@ import type { ActivityLayerRecord, AgentRunDiagnosticKind } from '@/src/main/act
 import {
   countArtifactFiles,
   deriveActivityArtifacts,
+  deriveMutationPreview,
   deriveOperationInputPreview,
   mergeActivityArtifacts,
 } from '@/src/main/activity-artifacts'
@@ -75,6 +76,7 @@ export interface PiSessionRuntime {
   loadHistory?(): PiSessionRuntimeHistory
   appendActivityRecord?(record: ActivityLayerRecord): void
   loadRawOperation?(toolCallId: string): Readonly<{ input: unknown; result?: unknown }> | undefined
+  getActivityRepositoryLocations?(): readonly Readonly<{ repositoryId: string; workingPath: string }>[]
   getSkills?(): readonly SessionSkill[]
   getSkillPrompt?(name: string): string | undefined
   getContextUsage?(): SessionContextUsage | undefined
@@ -884,7 +886,13 @@ export function createPiSessionRuntimeRegistry({
 
       const artifacts = mergeActivityArtifacts(
         owner.activity.artifacts,
-        deriveActivityArtifacts(operation.execution, event.result, timeline.runtimeDirectory ?? '', event.isError)
+        deriveActivityArtifacts(
+          operation.execution,
+          event.result,
+          timeline.runtimeDirectory ?? '',
+          event.isError,
+          timeline.getActivityRepositoryLocations?.()
+        )
       )
 
       replaceActivity(timeline, {
@@ -1034,6 +1042,7 @@ export function createPiSessionRuntimeRegistry({
     timeline.runtimeDirectory = runtimeDirectory
     timeline.persist = runtime.appendActivityRecord?.bind(runtime)
     timeline.loadRawOperation = runtime.loadRawOperation?.bind(runtime)
+    timeline.getActivityRepositoryLocations = runtime.getActivityRepositoryLocations?.bind(runtime)
     // The attaching runtime is authoritative for the Model's context window;
     // context_usage events keep it current from here.
     timeline.contextUsage = runtime.getContextUsage?.()
@@ -1569,6 +1578,12 @@ export function createPiSessionRuntimeRegistry({
           const input = safeDetailText(raw?.input ?? execution.input)
           const rawResult = raw?.result ?? result
           const output = rawResult === undefined ? undefined : safeDetailText(rawResult)
+          const preview = deriveMutationPreview(
+            { ...execution, input: raw?.input ?? execution.input },
+            rawResult,
+            timeline.runtimeDirectory ?? '',
+            timeline.getActivityRepositoryLocations?.()
+          )
 
           return {
             toolCallId: execution.toolCallId,
@@ -1577,7 +1592,8 @@ export function createPiSessionRuntimeRegistry({
             inputPreview: execution.inputPreview,
             input: input.text,
             output: output?.text,
-            truncated: input.truncated || (output?.truncated ?? false),
+            preview,
+            truncated: input.truncated || (output?.truncated ?? false) || (preview?.truncated ?? false),
           }
         }),
       }

--- a/src/main/session-changes-ipc.ts
+++ b/src/main/session-changes-ipc.ts
@@ -1,0 +1,61 @@
+import type { ApplicationAuthority } from '@/src/main/application-state'
+import { inspectGitRepository } from '@/src/main/git-repositories'
+import { handleTrustedIpc } from '@/src/main/trusted-ipc'
+import {
+  parseSessionChangesRequest,
+  parseSessionFileDiffRequest,
+  sessionChangesIpcChannels,
+} from '@/src/session-changes-ipc'
+import { inspectRepositoryChanges, loadRepositoryFileDiff, type SessionChangeRepository } from './session-changes'
+
+let initialized = false
+
+export function initializeSessionChanges(authority: ApplicationAuthority): void {
+  if (initialized) return
+  initialized = true
+
+  handleTrustedIpc(sessionChangesIpcChannels.getSnapshot, async (_event, value: unknown) => {
+    const request = parseSessionChangesRequest(value)
+    if (!request) throw new TypeError('A Session is required.')
+
+    const repositories = await resolveRepositories(authority, request.sessionId)
+
+    return {
+      sessionId: request.sessionId,
+      repositories: await Promise.all(repositories.map(inspectRepositoryChanges)),
+    }
+  })
+
+  handleTrustedIpc(sessionChangesIpcChannels.loadFileDiff, async (_event, value: unknown) => {
+    const request = parseSessionFileDiffRequest(value)
+    if (!request) throw new TypeError('A Session changed file is required.')
+
+    const repositories = await resolveRepositories(authority, request.sessionId)
+    const repository = repositories.find((candidate) => candidate.repositoryId === request.repositoryId)
+    if (!repository) return { status: 'unavailable', message: 'The Repository is not writable by this Session.' }
+
+    return loadRepositoryFileDiff(repository, request)
+  })
+}
+
+async function resolveRepositories(
+  authority: ApplicationAuthority,
+  sessionId: Parameters<ApplicationAuthority['resolveSessionChangeRepositories']>[0]
+): Promise<readonly SessionChangeRepository[]> {
+  const authorized = await authority.resolveSessionChangeRepositories(sessionId)
+
+  return (
+    await Promise.all(
+      authorized.map(async (repository) => {
+        try {
+          const inspected = await inspectGitRepository(repository.workingPath)
+          if (inspected.directoryPath !== repository.workingPath) return undefined
+
+          return repository
+        } catch {
+          return undefined
+        }
+      })
+    )
+  ).flatMap((repository) => (repository ? [repository] : []))
+}

--- a/src/main/session-changes-ipc.ts
+++ b/src/main/session-changes-ipc.ts
@@ -4,9 +4,15 @@ import { handleTrustedIpc } from '@/src/main/trusted-ipc'
 import {
   parseSessionChangesRequest,
   parseSessionFileDiffRequest,
+  parseSessionFileStageRequest,
   sessionChangesIpcChannels,
 } from '@/src/session-changes-ipc'
-import { inspectRepositoryChanges, loadRepositoryFileDiff, type SessionChangeRepository } from './session-changes'
+import {
+  inspectRepositoryChanges,
+  loadRepositoryFileDiff,
+  setRepositoryFileStaged,
+  type SessionChangeRepository,
+} from './session-changes'
 
 let initialized = false
 
@@ -35,6 +41,22 @@ export function initializeSessionChanges(authority: ApplicationAuthority): void 
     if (!repository) return { status: 'unavailable', message: 'The Repository is not writable by this Session.' }
 
     return loadRepositoryFileDiff(repository, request)
+  })
+
+  handleTrustedIpc(sessionChangesIpcChannels.setFileStaged, async (_event, value: unknown) => {
+    const request = parseSessionFileStageRequest(value)
+    if (!request) throw new TypeError('A Session changed file and staging state are required.')
+
+    const repositories = await resolveRepositories(authority, request.sessionId)
+    const repository = repositories.find((candidate) => candidate.repositoryId === request.repositoryId)
+    if (!repository) throw new Error('The Repository is not writable by this Session.')
+
+    await setRepositoryFileStaged(repository, request)
+
+    return {
+      sessionId: request.sessionId,
+      repositories: await Promise.all(repositories.map(inspectRepositoryChanges)),
+    }
   })
 }
 

--- a/src/main/session-changes.test.ts
+++ b/src/main/session-changes.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import test from 'node:test'
+import { inspectRepositoryChanges, loadRepositoryFileDiff, parseGitStatus } from './session-changes'
+
+const exec = promisify(execFile)
+
+async function createRepository(): Promise<string> {
+  const directoryPath = await mkdtemp(join(tmpdir(), 'railyard-changes-'))
+  await exec('git', ['init', directoryPath])
+  await exec('git', ['-C', directoryPath, 'config', 'user.name', 'Railyard tests'])
+  await exec('git', ['-C', directoryPath, 'config', 'user.email', 'tests@railyard.invalid'])
+  await writeFile(join(directoryPath, 'tracked.txt'), 'first\n')
+  await exec('git', ['-C', directoryPath, 'add', 'tracked.txt'])
+  await exec('git', ['-C', directoryPath, 'commit', '-m', 'Initial'])
+
+  return directoryPath
+}
+
+test('parses staged, unstaged, untracked, renamed, and conflicted porcelain-v2 records', () => {
+  const status = [
+    '# branch.oid abc',
+    '# branch.head main',
+    '# branch.upstream origin/main',
+    '# branch.ab +2 -1',
+    '1 M. N... 100644 100644 100644 abc def staged.ts',
+    '1 .M N... 100644 100644 100644 abc def unstaged.ts',
+    '2 R. N... 100644 100644 100644 abc def R100 renamed.ts',
+    'old.ts',
+    'u UU N... 100644 100644 100644 100644 abc def ghi conflict.ts',
+    '? new.ts',
+    '',
+  ].join('\0')
+
+  const parsed = parseGitStatus(status)
+
+  assert.deepEqual(parsed.branch, {
+    head: 'main',
+    upstream: 'origin/main',
+    ahead: 2,
+    behind: 1,
+    detached: false,
+    unborn: false,
+  })
+  assert.deepEqual(
+    parsed.files.map(({ path, previousPath, status, staged, unstaged }) => ({
+      path,
+      previousPath,
+      status,
+      staged,
+      unstaged,
+    })),
+    [
+      { path: 'staged.ts', previousPath: undefined, status: 'modified', staged: true, unstaged: false },
+      { path: 'unstaged.ts', previousPath: undefined, status: 'modified', staged: false, unstaged: true },
+      { path: 'renamed.ts', previousPath: 'old.ts', status: 'renamed', staged: true, unstaged: false },
+      { path: 'conflict.ts', previousPath: undefined, status: 'conflicted', staged: true, unstaged: true },
+      { path: 'new.ts', previousPath: undefined, status: 'untracked', staged: false, unstaged: true },
+    ]
+  )
+})
+
+test('inspects staged and unstaged state once per changed file', async () => {
+  const workingPath = await createRepository()
+  await writeFile(join(workingPath, 'tracked.txt'), 'staged\n')
+  await exec('git', ['-C', workingPath, 'add', 'tracked.txt'])
+  await writeFile(join(workingPath, 'tracked.txt'), 'staged\nunstaged\n')
+  await writeFile(join(workingPath, 'untracked.txt'), 'new\n')
+
+  const changes = await inspectRepositoryChanges({
+    repositoryId: 'repository',
+    repositoryName: 'Repository',
+    workingPath,
+  })
+
+  assert.equal(changes.error, undefined)
+  assert.deepEqual(
+    changes.files.map(({ path, staged, unstaged }) => ({ path, staged, unstaged })),
+    [
+      { path: 'tracked.txt', staged: true, unstaged: true },
+      { path: 'untracked.txt', staged: false, unstaged: true },
+    ]
+  )
+})
+
+test('loads bounded unified diffs and rejects paths outside current changes', async () => {
+  const workingPath = await createRepository()
+  await writeFile(join(workingPath, 'tracked.txt'), 'changed\n')
+
+  const diff = await loadRepositoryFileDiff(
+    { repositoryId: 'repository', repositoryName: 'Repository', workingPath },
+    { path: 'tracked.txt', view: 'all' }
+  )
+
+  assert.equal(diff.status, 'available')
+  assert.match(diff.content ?? '', /^diff --git/m)
+  assert.equal(diff.truncated, false)
+
+  const denied = await loadRepositoryFileDiff(
+    { repositoryId: 'repository', repositoryName: 'Repository', workingPath },
+    { path: '../secret', view: 'all' }
+  )
+  assert.deepEqual(denied, { status: 'unavailable', message: 'The changed file is no longer available.' })
+})
+
+test('reports binary and oversized diffs without rendering them as ordinary text', async () => {
+  const workingPath = await createRepository()
+  await writeFile(join(workingPath, 'tracked.txt'), Buffer.from([0, 1, 2, 3]))
+
+  const binary = await loadRepositoryFileDiff(
+    { repositoryId: 'repository', repositoryName: 'Repository', workingPath },
+    { path: 'tracked.txt', view: 'all' }
+  )
+
+  assert.equal(binary.status, 'binary')
+
+  await writeFile(join(workingPath, 'large.txt'), 'x'.repeat(600_000))
+  const oversized = await loadRepositoryFileDiff(
+    { repositoryId: 'repository', repositoryName: 'Repository', workingPath },
+    { path: 'large.txt', view: 'all' }
+  )
+
+  assert.equal(oversized.status, 'too-large')
+  assert.equal(oversized.truncated, true)
+})
+
+test('returns a per-Repository error when Git inspection fails', async () => {
+  const changes = await inspectRepositoryChanges({
+    repositoryId: 'missing',
+    repositoryName: 'Missing',
+    workingPath: join(tmpdir(), 'missing-railyard-repository'),
+  })
+
+  assert.equal(changes.repositoryId, 'missing')
+  assert.ok(changes.error)
+  assert.deepEqual(changes.files, [])
+})
+
+test('supports an unborn HEAD and an untracked file preview', async () => {
+  const workingPath = await mkdtemp(join(tmpdir(), 'railyard-unborn-'))
+  await exec('git', ['init', workingPath])
+  await writeFile(join(workingPath, 'new.txt'), 'new file\n')
+
+  const changes = await inspectRepositoryChanges({
+    repositoryId: 'repository',
+    repositoryName: 'Repository',
+    workingPath,
+  })
+  const diff = await loadRepositoryFileDiff(
+    { repositoryId: 'repository', repositoryName: 'Repository', workingPath },
+    { path: 'new.txt', view: 'all' }
+  )
+
+  assert.equal(changes.branch.unborn, true)
+  assert.equal(diff.status, 'available')
+  assert.match(diff.content ?? '', /\+new file/)
+})

--- a/src/main/session-changes.test.ts
+++ b/src/main/session-changes.test.ts
@@ -5,7 +5,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import test from 'node:test'
-import { inspectRepositoryChanges, loadRepositoryFileDiff, parseGitStatus } from './session-changes'
+import {
+  inspectRepositoryChanges,
+  loadRepositoryFileDiff,
+  parseGitStatus,
+  setRepositoryFileStaged,
+} from './session-changes'
 
 const exec = promisify(execFile)
 
@@ -84,6 +89,81 @@ test('inspects staged and unstaged state once per changed file', async () => {
       { path: 'tracked.txt', staged: true, unstaged: true },
       { path: 'untracked.txt', staged: false, unstaged: true },
     ]
+  )
+})
+
+test('stages all current changes for a partially staged file and can unstage them again', async () => {
+  const workingPath = await createRepository()
+  const repository = { repositoryId: 'repository', repositoryName: 'Repository', workingPath }
+  await writeFile(join(workingPath, 'tracked.txt'), 'staged\n')
+  await exec('git', ['-C', workingPath, 'add', 'tracked.txt'])
+  await writeFile(join(workingPath, 'tracked.txt'), 'staged\nunstaged\n')
+
+  await setRepositoryFileStaged(repository, { path: 'tracked.txt', staged: true })
+  const staged = await inspectRepositoryChanges(repository)
+  assert.deepEqual(
+    staged.files.map(({ path, staged, unstaged }) => ({ path, staged, unstaged })),
+    [{ path: 'tracked.txt', staged: true, unstaged: false }]
+  )
+
+  await setRepositoryFileStaged(repository, { path: 'tracked.txt', staged: false })
+  const unstaged = await inspectRepositoryChanges(repository)
+  assert.deepEqual(
+    unstaged.files.map(({ path, staged, unstaged }) => ({ path, staged, unstaged })),
+    [{ path: 'tracked.txt', staged: false, unstaged: true }]
+  )
+})
+
+test('stages and unstages an untracked file before the first commit', async () => {
+  const workingPath = await mkdtemp(join(tmpdir(), 'railyard-unborn-stage-'))
+  const repository = { repositoryId: 'repository', repositoryName: 'Repository', workingPath }
+  await exec('git', ['init', workingPath])
+  await writeFile(join(workingPath, 'new.txt'), 'new file\n')
+
+  await setRepositoryFileStaged(repository, { path: 'new.txt', staged: true })
+  const staged = await inspectRepositoryChanges(repository)
+  assert.deepEqual(
+    staged.files.map(({ path, staged, unstaged }) => ({ path, staged, unstaged })),
+    [{ path: 'new.txt', staged: true, unstaged: false }]
+  )
+
+  await setRepositoryFileStaged(repository, { path: 'new.txt', staged: false })
+  const unstaged = await inspectRepositoryChanges(repository)
+  assert.deepEqual(
+    unstaged.files.map(({ path, staged, unstaged }) => ({ path, staged, unstaged })),
+    [{ path: 'new.txt', staged: false, unstaged: true }]
+  )
+})
+
+test('refuses to stage a conflicted file', async () => {
+  const workingPath = await createRepository()
+  const repository = { repositoryId: 'repository', repositoryName: 'Repository', workingPath }
+  const { stdout: branchOutput } = await exec('git', ['-C', workingPath, 'branch', '--show-current'])
+  const baseBranch = branchOutput.trim()
+
+  await exec('git', ['-C', workingPath, 'checkout', '-b', 'conflicting-change'])
+  await writeFile(join(workingPath, 'tracked.txt'), 'branch\n')
+  await exec('git', ['-C', workingPath, 'commit', '-am', 'Branch change'])
+  await exec('git', ['-C', workingPath, 'checkout', baseBranch])
+  await writeFile(join(workingPath, 'tracked.txt'), 'base\n')
+  await exec('git', ['-C', workingPath, 'commit', '-am', 'Base change'])
+  await assert.rejects(exec('git', ['-C', workingPath, 'merge', 'conflicting-change']))
+
+  await assert.rejects(
+    setRepositoryFileStaged(repository, { path: 'tracked.txt', staged: true }),
+    /Resolve the conflict/
+  )
+})
+
+test('rejects staging paths outside the current Repository', async () => {
+  const workingPath = await createRepository()
+
+  await assert.rejects(
+    setRepositoryFileStaged(
+      { repositoryId: 'repository', repositoryName: 'Repository', workingPath },
+      { path: '../secret', staged: true }
+    ),
+    /no longer available/
   )
 })
 

--- a/src/main/session-changes.ts
+++ b/src/main/session-changes.ts
@@ -118,6 +118,38 @@ export async function inspectRepositoryChanges(repository: SessionChangeReposito
   }
 }
 
+export async function setRepositoryFileStaged(
+  repository: SessionChangeRepository,
+  request: Readonly<{ path: string; staged: boolean }>
+): Promise<void> {
+  if (!isSafeRelativePath(request.path)) throw new Error('The changed file is no longer available.')
+
+  const status = parseGitStatus(await runGit(repository.workingPath, ['status', '--porcelain=v2', '--branch', '-z']))
+  const file = status.files.find((candidate) => candidate.path === request.path)
+  if (!file) throw new Error('The changed file is no longer available.')
+  if (file.status === 'conflicted') throw new Error('Resolve the conflict before staging this file.')
+
+  if ((request.staged && !file.unstaged) || (!request.staged && !file.staged)) return
+
+  const paths = [
+    file.path,
+    ...(file.status === 'renamed' && file.previousPath && isSafeRelativePath(file.previousPath)
+      ? [file.previousPath]
+      : []),
+  ]
+  if (request.staged) {
+    await runGit(repository.workingPath, ['add', '--all', '--', ...paths])
+    return
+  }
+
+  if (status.branch.unborn) {
+    await runGit(repository.workingPath, ['rm', '--cached', '--ignore-unmatch', '--', ...paths])
+    return
+  }
+
+  await runGit(repository.workingPath, ['restore', '--staged', '--', ...paths])
+}
+
 export async function loadRepositoryFileDiff(
   repository: SessionChangeRepository,
   request: Readonly<{ path: string; view: SessionFileDiffView }>

--- a/src/main/session-changes.ts
+++ b/src/main/session-changes.ts
@@ -1,0 +1,272 @@
+import { execFile } from 'node:child_process'
+import { isAbsolute, normalize, sep } from 'node:path'
+import { promisify } from 'node:util'
+import type {
+  SessionChangeFile,
+  SessionChangeFileStatus,
+  SessionChangesBranch,
+  SessionFileDiff,
+  SessionFileDiffView,
+  SessionRepositoryChanges,
+} from '@/src/session-changes'
+
+const exec = promisify(execFile)
+const gitTimeout = 10_000
+const maximumGitOutput = 2 * 1024 * 1024
+const maximumDiffLength = 500_000
+
+export type SessionChangeRepository = Readonly<{
+  repositoryId: string
+  repositoryName: string
+  workingPath: string
+}>
+
+type ParsedGitStatus = Readonly<{
+  branch: SessionChangesBranch
+  files: readonly SessionChangeFile[]
+}>
+
+export function parseGitStatus(output: string): ParsedGitStatus {
+  const records = output.split('\0')
+  const branch: {
+    head: string
+    upstream?: string
+    ahead: number
+    behind: number
+    detached: boolean
+    unborn: boolean
+  } = { head: 'HEAD', ahead: 0, behind: 0, detached: false, unborn: false }
+  const files: SessionChangeFile[] = []
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index]
+    if (!record) continue
+
+    if (record.startsWith('# branch.oid ')) {
+      branch.unborn = record.slice(13) === '(initial)'
+      continue
+    }
+    if (record.startsWith('# branch.head ')) {
+      const head = record.slice(14)
+      branch.detached = head === '(detached)'
+      branch.head = branch.detached ? 'Detached HEAD' : head
+      continue
+    }
+    if (record.startsWith('# branch.upstream ')) {
+      branch.upstream = record.slice(18)
+      continue
+    }
+    if (record.startsWith('# branch.ab ')) {
+      const match = record.match(/^# branch\.ab \+(\d+) -(\d+)$/)
+      if (match) {
+        branch.ahead = Number(match[1])
+        branch.behind = Number(match[2])
+      }
+      continue
+    }
+    if (record.startsWith('? ')) {
+      files.push({ path: record.slice(2), status: 'untracked', staged: false, unstaged: true })
+      continue
+    }
+    if (record.startsWith('u ')) {
+      const fields = record.split(' ')
+      const path = fields.slice(10).join(' ')
+      if (path) files.push({ path, status: 'conflicted', staged: true, unstaged: true })
+      continue
+    }
+    if (record.startsWith('1 ') || record.startsWith('2 ')) {
+      const renamed = record.startsWith('2 ')
+      const fields = record.split(' ')
+      const state = fields[1] ?? '..'
+      const path = fields.slice(renamed ? 9 : 8).join(' ')
+      const previousPath = renamed ? records[++index] : undefined
+      if (!path) continue
+
+      files.push({
+        path,
+        ...(previousPath ? { previousPath } : {}),
+        status: fileStatus(state, renamed),
+        staged: state[0] !== '.',
+        unstaged: state[1] !== '.',
+      })
+    }
+  }
+
+  return { branch, files }
+}
+
+export async function inspectRepositoryChanges(repository: SessionChangeRepository): Promise<SessionRepositoryChanges> {
+  try {
+    const status = await runGit(repository.workingPath, ['status', '--porcelain=v2', '--branch', '-z'])
+    const parsed = parseGitStatus(status)
+    const numbers = await readNumstat(repository.workingPath, parsed.branch.unborn)
+
+    return {
+      repositoryId: repository.repositoryId,
+      repositoryName: repository.repositoryName,
+      branch: parsed.branch,
+      files: parsed.files.map((file) => ({ ...file, ...numbers.get(file.path) })),
+    }
+  } catch (error) {
+    return {
+      repositoryId: repository.repositoryId,
+      repositoryName: repository.repositoryName,
+      branch: { head: 'Unavailable', ahead: 0, behind: 0, detached: false, unborn: false },
+      files: [],
+      error: error instanceof Error ? error.message : 'Git changes are unavailable.',
+    }
+  }
+}
+
+export async function loadRepositoryFileDiff(
+  repository: SessionChangeRepository,
+  request: Readonly<{ path: string; view: SessionFileDiffView }>
+): Promise<SessionFileDiff> {
+  if (!isSafeRelativePath(request.path)) return unavailableFile()
+
+  try {
+    const status = parseGitStatus(await runGit(repository.workingPath, ['status', '--porcelain=v2', '--branch', '-z']))
+    const file = status.files.find((candidate) => candidate.path === request.path)
+    if (!file) return unavailableFile()
+    if (request.view === 'staged' && !file.staged) return unavailableFile()
+    if (request.view === 'unstaged' && !file.unstaged) return unavailableFile()
+
+    let content: string
+    if (file.status === 'untracked') {
+      if (request.view === 'staged') return unavailableFile()
+      content = await runUntrackedDiff(repository.workingPath, file.path)
+    } else {
+      const arguments_ = ['diff', '--no-ext-diff', '--no-color', '--unified=3']
+      if (request.view === 'staged') arguments_.push('--cached')
+      else if (request.view === 'all' && !status.branch.unborn) arguments_.push('HEAD')
+      else if (request.view === 'all' && status.branch.unborn) arguments_.push('--cached')
+      arguments_.push('--', file.path)
+      content = await runGit(repository.workingPath, arguments_)
+
+      if (request.view === 'all' && status.branch.unborn && file.unstaged) {
+        content += await runGit(repository.workingPath, [
+          'diff',
+          '--no-ext-diff',
+          '--no-color',
+          '--unified=3',
+          '--',
+          file.path,
+        ])
+      }
+    }
+
+    if (/^Binary files .* differ$/m.test(content) || /^GIT binary patch$/m.test(content)) {
+      return { status: 'binary', message: 'Binary files cannot be previewed.' }
+    }
+    if (content.length > maximumDiffLength) {
+      return {
+        status: 'too-large',
+        content: `${content.slice(0, maximumDiffLength)}\n…`,
+        truncated: true,
+        message: 'The diff was truncated because it is too large to preview.',
+      }
+    }
+
+    return { status: 'available', content, truncated: false }
+  } catch (error) {
+    return {
+      status: 'unavailable',
+      message: error instanceof Error ? error.message : 'The diff is unavailable.',
+    }
+  }
+}
+
+async function readNumstat(workingPath: string, unborn: boolean): Promise<Map<string, Partial<SessionChangeFile>>> {
+  const outputs = await Promise.all([
+    runGit(workingPath, ['diff', '--numstat', '--no-renames']).catch(() => ''),
+    runGit(workingPath, ['diff', '--cached', '--numstat', '--no-renames', ...(unborn ? [] : ['HEAD'])]).catch(() => ''),
+  ])
+  const totals = new Map<string, { additions: number; deletions: number; binary?: boolean }>()
+
+  for (const output of outputs) {
+    for (const line of output.split(/\r?\n/)) {
+      const [added, deleted, ...pathParts] = line.split('\t')
+      const path = pathParts.join('\t')
+      if (!path) continue
+      const current = totals.get(path) ?? { additions: 0, deletions: 0 }
+      if (added === '-' || deleted === '-') current.binary = true
+      else {
+        current.additions += Number(added)
+        current.deletions += Number(deleted)
+      }
+      totals.set(path, current)
+    }
+  }
+
+  return totals
+}
+
+function fileStatus(state: string, renamed: boolean): SessionChangeFileStatus {
+  if (state.includes('U') || state === 'AA' || state === 'DD') return 'conflicted'
+  if (renamed || state.includes('R')) return 'renamed'
+  if (state.includes('C')) return 'copied'
+  if (state.includes('A')) return 'added'
+  if (state.includes('D')) return 'deleted'
+  return 'modified'
+}
+
+function isSafeRelativePath(path: string): boolean {
+  const normalized = normalize(path)
+  return Boolean(path) && !isAbsolute(path) && normalized !== '..' && !normalized.startsWith(`..${sep}`)
+}
+
+function unavailableFile(): SessionFileDiff {
+  return { status: 'unavailable', message: 'The changed file is no longer available.' }
+}
+
+async function runUntrackedDiff(workingPath: string, path: string): Promise<string> {
+  try {
+    const { stdout } = await exec(
+      'git',
+      [
+        '-C',
+        workingPath,
+        'diff',
+        '--no-index',
+        '--no-color',
+        '--unified=3',
+        '--',
+        process.platform === 'win32' ? 'NUL' : '/dev/null',
+        path,
+      ],
+      { encoding: 'utf8', timeout: gitTimeout, maxBuffer: maximumGitOutput, windowsHide: true }
+    )
+
+    return stdout
+  } catch (error) {
+    if (isGitDifference(error)) return error.stdout
+
+    const detail = error instanceof Error && 'stderr' in error ? String(error.stderr).trim() : ''
+    throw new Error(detail || 'Git changes are unavailable.', { cause: error })
+  }
+}
+
+async function runGit(workingPath: string, arguments_: readonly string[]): Promise<string> {
+  try {
+    const { stdout } = await exec('git', ['-C', workingPath, ...arguments_], {
+      encoding: 'utf8',
+      timeout: gitTimeout,
+      maxBuffer: maximumGitOutput,
+      windowsHide: true,
+    })
+    return stdout
+  } catch (error) {
+    const detail = error instanceof Error && 'stderr' in error ? String(error.stderr).trim() : ''
+    throw new Error(detail || 'Git changes are unavailable.', { cause: error })
+  }
+}
+
+function isGitDifference(error: unknown): error is Error & { code: number; stdout: string } {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    error.code === 1 &&
+    'stdout' in error &&
+    typeof error.stdout === 'string'
+  )
+}

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { sessionId } from '@/src/domain/session'
+import { formatSessionCodeReviewText, type SessionCodeReview } from '@/src/session-code-review'
 import { createPiSessionRuntimeRegistry, type PiSessionRuntime } from './pi-session-runtimes'
 
 test('keeps duplicate messages ordered and updates one streaming identity', async () => {
@@ -94,6 +95,242 @@ test('persists an accepted action card across a runtime restart', async () => {
   })
 
   assert.equal((await restartedRegistry.getTranscript(id)).actionCards?.[0]?.status, 'accepted')
+})
+
+test('persists an unfinished code-review comment across a runtime restart', async () => {
+  const records: import('@/src/main/activity-records').ActivityLayerRecord[] = []
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    loadHistory() {
+      return { conversations: [], activityRecords: records, finalState: 'completed' }
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const id = sessionId('review-draft-session')
+  const options = {
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    createId: () => 'comment-1',
+    now: () => 10,
+  }
+  const registry = createPiSessionRuntimeRegistry(options)
+  const reference = {
+    repositoryId: 'repository-1',
+    repositoryName: 'Pi Workspace',
+    path: 'src/example.ts',
+    oldStart: 2,
+    oldLines: 1,
+    newStart: 2,
+    newLines: 2,
+    patch: '@@ -2 +2,2 @@\n-old\n+new',
+  }
+
+  await registry.saveCodeReviewComment({ sessionId: id, text: 'Preserve this.', reference })
+
+  const restartedRegistry = createPiSessionRuntimeRegistry(options)
+  assert.deepEqual((await restartedRegistry.getCodeReviewDraft(id)).comments, [
+    { id: 'comment-1', text: 'Preserve this.', reference, createdAt: 10 },
+  ])
+})
+
+test('does not restore comments already accepted into a queued code review', async () => {
+  const comment = {
+    id: 'comment-1',
+    text: 'Preserve this.',
+    createdAt: 10,
+    reference: {
+      repositoryId: 'repository-1',
+      repositoryName: 'Pi Workspace',
+      path: 'src/example.ts',
+      oldStart: 2,
+      oldLines: 1,
+      newStart: 2,
+      newLines: 2,
+      patch: '@@ -2 +2,2 @@\n-old\n+new',
+    },
+  }
+  const codeReview = { kind: 'review' as const, comments: [comment] }
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    loadHistory() {
+      return {
+        conversations: [],
+        activityRecords: [
+          { version: 1 as const, type: 'code-review-comment' as const, comment },
+          {
+            version: 1 as const,
+            type: 'queued-follow-up' as const,
+            followUp: {
+              id: 'follow-up-1',
+              text: formatSessionCodeReviewText(codeReview),
+              codeReview,
+              createdAt: 11,
+            },
+          },
+        ],
+        finalState: 'completed' as const,
+      }
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  assert.deepEqual((await registry.getCodeReviewDraft(sessionId('queued-review-session'))).comments, [])
+})
+
+test('finishes pending comments as one structured code-review message', async () => {
+  const records: import('@/src/main/activity-records').ActivityLayerRecord[] = []
+  const prompts: string[] = []
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt(text, options) {
+      prompts.push(text)
+      options.preflightResult(true)
+    },
+    subscribe() {
+      return () => {}
+    },
+    loadHistory() {
+      return { conversations: [], activityRecords: records, finalState: 'completed' }
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const id = sessionId('finished-review-session')
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+    createId: () => 'comment-1',
+    now: () => 10,
+  })
+  const reference = {
+    repositoryId: 'repository-1',
+    repositoryName: 'Pi Workspace',
+    path: 'src/example.ts',
+    oldStart: 2,
+    oldLines: 1,
+    newStart: 2,
+    newLines: 2,
+    patch: '@@ -2 +2,2 @@\n-old\n+new',
+  }
+
+  await registry.saveCodeReviewComment({ sessionId: id, text: 'Preserve this.', reference })
+  assert.deepEqual(await registry.finishCodeReview(id), { status: 'accepted', delivery: 'prompt' })
+
+  const snapshot = await registry.getTranscript(id)
+  const message = snapshot.entries.find((entry) => entry.type === 'message')
+  assert.equal(message?.type === 'message' ? message.message.codeReview?.kind : undefined, 'review')
+  assert.deepEqual((await registry.getCodeReviewDraft(id)).comments, [])
+  assert.match(prompts[0] ?? '', /Code review with 1 comment across 1 file/)
+})
+
+test('clears an accepted review from memory when its clear record cannot be persisted', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt(_text, options) {
+      options.preflightResult(true)
+    },
+    subscribe() {
+      return () => {}
+    },
+    appendActivityRecord(record) {
+      if (record.type === 'code-review-comments-cleared') throw new Error('Disk unavailable')
+    },
+    dispose() {},
+  }
+  const id = sessionId('review-clear-failure-session')
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  await registry.saveCodeReviewComment({
+    sessionId: id,
+    text: 'Preserve this.',
+    reference: {
+      repositoryId: 'repository-1',
+      repositoryName: 'Pi Workspace',
+      path: 'src/example.ts',
+      oldStart: 2,
+      oldLines: 1,
+      newStart: 2,
+      newLines: 2,
+      patch: '@@ -2 +2,2 @@\n-old\n+new',
+    },
+  })
+
+  assert.deepEqual(await registry.finishCodeReview(id), { status: 'accepted', delivery: 'prompt' })
+  assert.deepEqual((await registry.getCodeReviewDraft(id)).comments, [])
+})
+
+test('restores structured code-review metadata with its persisted user message', async () => {
+  const codeReview = {
+    kind: 'follow-up' as const,
+    comments: [
+      {
+        id: 'comment-1',
+        text: 'Preserve this.',
+        createdAt: 1,
+        reference: {
+          repositoryId: 'repository-1',
+          repositoryName: 'Pi Workspace',
+          path: 'src/example.ts',
+          oldStart: 2,
+          oldLines: 1,
+          newStart: 2,
+          newLines: 2,
+          patch: '@@ -2 +2,2 @@\n-old\n+new',
+        },
+      },
+    ],
+  }
+  const text =
+    'Follow-up about a referenced code change.\n\n' +
+    '## Pi Workspace · src/example.ts · +2–3\n\n' +
+    '~~~~diff\n@@ -2 +2,2 @@\n-old\n+new\n~~~~\n\nPreserve this.'
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    loadHistory() {
+      return {
+        conversations: [
+          { type: 'conversation' as const, id: 'message-1', role: 'user' as const, text, timestamp: 100 },
+        ],
+        activityRecords: [
+          { version: 1 as const, type: 'code-review-message' as const, review: codeReview, text, acceptedAt: 100 },
+        ],
+        finalState: 'completed' as const,
+      }
+    },
+    dispose() {},
+  }
+  const id = sessionId('restored-review-session')
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  const message = (await registry.getTranscript(id)).entries.find((entry) => entry.type === 'message')
+  assert.deepEqual(message?.type === 'message' ? message.message.codeReview : undefined, codeReview)
 })
 
 test('persists queued follow-ups until the user resumes the queue', async () => {
@@ -635,6 +872,63 @@ test('invokes multiple available Skills where they were mentioned', async () => 
       skill: { name: 'tdd', description: 'Develop test first.', availability: 'available' },
     },
   ])
+})
+
+test('expands Skills from review comments without interpreting immutable patch text', async () => {
+  let promptedText = ''
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt(text, options) {
+      promptedText = text
+      options.preflightResult(true)
+    },
+    getSkills() {
+      return [{ name: 'tdd', description: 'Develop test first.' }]
+    },
+    getSkillPrompt(name) {
+      return `<${name}>`
+    },
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+  const id = sessionId('review-skill-session')
+  const codeReview: SessionCodeReview = {
+    kind: 'follow-up',
+    comments: [
+      {
+        id: 'comment-1',
+        text: '/skill:tdd Check this documentation change.',
+        createdAt: 1,
+        reference: {
+          repositoryId: 'repository-1',
+          repositoryName: 'Pi Workspace',
+          path: 'docs.md',
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 1,
+          patch: '@@ -1 +1 @@\n-old\n+Run /skill:missing before merging.',
+        },
+      },
+    ],
+  }
+
+  const result = await registry.submit({
+    sessionId: id,
+    text: formatSessionCodeReviewText(codeReview),
+    delivery: 'follow-up',
+    codeReview,
+  })
+
+  assert.deepEqual(result, { status: 'accepted', delivery: 'prompt' })
+  assert.match(promptedText, /\+Run \/skill:missing before merging\./)
+  assert.match(promptedText, /<tdd> Check this documentation change\./)
 })
 
 test('rejects a selected Skill that is unavailable to the Session runtime', async () => {

--- a/src/pi-workspace.ts
+++ b/src/pi-workspace.ts
@@ -2,6 +2,7 @@ import type { ComposerBridge } from '@/src/composer'
 import type { ApplicationStateBridge } from '@/src/application-state-ipc'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
+import type { SessionChangesBridge } from '@/src/session-changes'
 import type { SessionTranscriptBridge } from '@/src/session-transcript'
 import type { SettingsBridge } from '@/src/settings'
 import type { WorkstreamsBridge } from '@/src/workstreams'
@@ -11,6 +12,7 @@ export type PiWorkspaceBridge = Readonly<{
   applicationState: ApplicationStateBridge
   composer: ComposerBridge
   sessionSkills: SessionSkillsBridge
+  sessionChanges: SessionChangesBridge
   sessionConfiguration: SessionConfigurationBridge
   transcript: SessionTranscriptBridge
   settings: SettingsBridge

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,8 @@ import { composerIpcChannels } from '@/src/composer-ipc'
 import type { WorkstreamsSnapshot } from '@/src/domain/workstream'
 import type { SessionSkillsBridge } from '@/src/session-skills'
 import { sessionSkillsIpcChannels } from '@/src/session-skills-ipc'
+import type { SessionChangesBridge, SessionChangesSnapshot, SessionFileDiff } from '@/src/session-changes'
+import { sessionChangesIpcChannels } from '@/src/session-changes-ipc'
 import type {
   SessionConfigurationBridge,
   SessionConfigurationCommandResult,
@@ -179,6 +181,20 @@ const sessionSkillsBridge: SessionSkillsBridge = {
   },
 }
 
+const sessionChangesBridge: SessionChangesBridge = {
+  getSnapshot(sessionId) {
+    return ipcRenderer.invoke(sessionChangesIpcChannels.getSnapshot, { sessionId }) as Promise<SessionChangesSnapshot>
+  },
+  loadFileDiff(sessionId, repositoryId, path, view) {
+    return ipcRenderer.invoke(sessionChangesIpcChannels.loadFileDiff, {
+      sessionId,
+      repositoryId,
+      path,
+      view,
+    }) as Promise<SessionFileDiff>
+  },
+}
+
 const sessionConfigurationBridge: SessionConfigurationBridge = {
   getSnapshot(sessionId) {
     return ipcRenderer.invoke(sessionConfigurationIpcChannels.getSnapshot, {
@@ -250,6 +266,7 @@ const piWorkspaceBridge: PiWorkspaceBridge = {
   applicationState: applicationStateBridge,
   composer: composerBridge,
   sessionSkills: sessionSkillsBridge,
+  sessionChanges: sessionChangesBridge,
   sessionConfiguration: sessionConfigurationBridge,
   transcript: sessionTranscriptBridge,
   settings: settingsBridge,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -164,6 +164,18 @@ const composerBridge: ComposerBridge = {
   submit(submission) {
     return ipcRenderer.invoke(composerIpcChannels.submit, submission) as Promise<SessionMessageSubmissionResult>
   },
+  getCodeReviewDraft(sessionId) {
+    return ipcRenderer.invoke(composerIpcChannels.getCodeReviewDraft, { sessionId })
+  },
+  saveCodeReviewComment(command) {
+    return ipcRenderer.invoke(composerIpcChannels.saveCodeReviewComment, command)
+  },
+  removeCodeReviewComment(sessionId, commentId) {
+    return ipcRenderer.invoke(composerIpcChannels.removeCodeReviewComment, { sessionId, commentId })
+  },
+  finishCodeReview(sessionId) {
+    return ipcRenderer.invoke(composerIpcChannels.finishCodeReview, { sessionId })
+  },
   stop(sessionId) {
     return ipcRenderer.invoke(composerIpcChannels.stop, { sessionId }) as Promise<SessionRunStopResult>
   },
@@ -192,6 +204,14 @@ const sessionChangesBridge: SessionChangesBridge = {
       path,
       view,
     }) as Promise<SessionFileDiff>
+  },
+  setFileStaged(sessionId, repositoryId, path, staged) {
+    return ipcRenderer.invoke(sessionChangesIpcChannels.setFileStaged, {
+      sessionId,
+      repositoryId,
+      path,
+      staged,
+    }) as Promise<SessionChangesSnapshot>
   },
 }
 

--- a/src/queued-follow-up.ts
+++ b/src/queued-follow-up.ts
@@ -1,9 +1,11 @@
 import type { SessionSkillMention } from '@/src/session-skills'
+import type { SessionCodeReview } from '@/src/session-code-review'
 
 export type QueuedFollowUp = Readonly<{
   id: string
   text: string
   skills?: readonly SessionSkillMention[]
+  codeReview?: SessionCodeReview
   createdAt: number
 }>
 

--- a/src/renderer/components/agent-activity-card.test.tsx
+++ b/src/renderer/components/agent-activity-card.test.tsx
@@ -78,6 +78,55 @@ test('a command artifact is omitted from the outcome summary', () => {
   assert.equal(view.queryByText('bun test: failed'), null)
 })
 
+test('loads an operation-time preview only when a changed file is expanded', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  let loadCount = 0
+  let opened: readonly [string | undefined, string] | undefined
+  const view = render(
+    <AgentActivityCard
+      activity={{
+        ...activity,
+        artifacts: [{ type: 'file-change', path: 'src/session.ts', repositoryId: 'repository-a' }],
+      }}
+      loadDetails={async () => {
+        loadCount += 1
+        return {
+          activityId: activity.id,
+          operations: [
+            {
+              toolCallId: 'edit-1',
+              label: 'edit',
+              status: 'completed',
+              input: '{}',
+              truncated: false,
+              preview: {
+                kind: 'diff',
+                path: 'src/session.ts',
+                repositoryId: 'repository-a',
+                content: '@@ -1 +1 @@\n-old\n+new',
+                truncated: false,
+              },
+            },
+          ],
+        }
+      }}
+      onOpenCurrentDiff={(repositoryId, path) => {
+        opened = [repositoryId, path]
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await user.click(view.getByText('Validate the result'))
+  assert.equal(loadCount, 0)
+  await user.click(view.getByRole('button', { name: 'src/session.ts' }))
+
+  assert.equal(loadCount, 1)
+  assert.ok(view.getByRole('region', { name: 'Operation-time preview for src/session.ts' }))
+  await user.click(view.getByRole('button', { name: 'Open current diff' }))
+  assert.deepEqual(opened, ['repository-a', 'src/session.ts'])
+})
+
 test('operations remain unloaded until their disclosure is opened', async () => {
   const user = userEvent.setup({ document: browser.document as unknown as Document })
   let loadCount = 0

--- a/src/renderer/components/agent-activity-card.tsx
+++ b/src/renderer/components/agent-activity-card.tsx
@@ -1,11 +1,13 @@
 import { Button } from '@/components/ui-kit/button'
-import { ChevronDown, CircleCheck, CircleSlash2, CircleX, LoaderCircle } from 'lucide-react'
+import { ChevronDown, ChevronRight, CircleCheck, CircleSlash2, CircleX, ExternalLink, LoaderCircle } from 'lucide-react'
 import { useState } from 'react'
 import type { AgentActivity, AgentActivityDetails, ActivityArtifact } from '@/src/session-timeline'
+import { DiffView } from './diff-view'
 
 type AgentActivityCardProperties = Readonly<{
   activity: AgentActivity
   loadDetails: () => Promise<AgentActivityDetails | undefined>
+  onOpenCurrentDiff?: (repositoryId: string | undefined, path: string) => void
 }>
 
 const statusPresentation = {
@@ -16,12 +18,31 @@ const statusPresentation = {
   blocked: { label: 'Blocked', Icon: CircleSlash2, className: 'text-activity-blocked' },
 } as const
 
-export function AgentActivityCard({ activity, loadDetails }: AgentActivityCardProperties) {
+export function AgentActivityCard({
+  activity,
+  loadDetails,
+  onOpenCurrentDiff = () => {},
+}: AgentActivityCardProperties) {
   const [details, setDetails] = useState<AgentActivityDetails>()
   const [detailState, setDetailState] = useState<'idle' | 'loading' | 'failed'>('idle')
   const [operationsExpanded, setOperationsExpanded] = useState(false)
+  const [expandedPreviewKey, setExpandedPreviewKey] = useState<string>()
   const presentation = statusPresentation[activity.status]
   const sections = artifactSections(activity.artifacts)
+
+  const ensureDetails = async () => {
+    if (detailState !== 'idle' || details) return
+
+    setDetailState('loading')
+
+    try {
+      const loaded = await loadDetails()
+      if (loaded) setDetails(loaded)
+      setDetailState(loaded ? 'idle' : 'failed')
+    } catch {
+      setDetailState('failed')
+    }
+  }
 
   const toggleOperations = async () => {
     if (operationsExpanded) {
@@ -32,19 +53,7 @@ export function AgentActivityCard({ activity, loadDetails }: AgentActivityCardPr
 
     setOperationsExpanded(true)
 
-    if (detailState !== 'idle' || details) return
-
-    setDetailState('loading')
-
-    try {
-      const loaded = await loadDetails()
-
-      if (loaded) setDetails(loaded)
-
-      setDetailState(loaded ? 'idle' : 'failed')
-    } catch {
-      setDetailState('failed')
-    }
+    await ensureDetails()
   }
 
   return (
@@ -79,18 +88,75 @@ export function AgentActivityCard({ activity, loadDetails }: AgentActivityCardPr
           <section key={section.title}>
             <h3 className="text-xs/5 font-semibold text-content-foreground">{section.title}</h3>
             <ul className="mt-1 space-y-1 text-xs/5 text-content-muted-foreground">
-              {section.items.map((item) => (
-                <li key={item.key} className="flex items-center gap-1.5">
-                  {item.status === 'completed' && (
-                    <CircleCheck aria-hidden="true" className="size-3.5 shrink-0 text-activity-completed" />
-                  )}
-                  {item.status === 'failed' && (
-                    <CircleX aria-hidden="true" className="size-3.5 shrink-0 text-activity-failed" />
-                  )}
-                  <span>{item.label}</span>
-                  {item.status && <span className="sr-only">{item.status}</span>}
-                </li>
-              ))}
+              {section.items.map((item) => {
+                const preview = details?.operations.find(
+                  (operation) =>
+                    operation.preview !== undefined &&
+                    operation.preview.path === item.path &&
+                    operation.preview.repositoryId === item.repositoryId
+                )?.preview
+                const expanded = expandedPreviewKey === item.key
+
+                return (
+                  <li key={item.key}>
+                    {item.path ? (
+                      <>
+                        <button
+                          aria-expanded={expanded}
+                          className="flex w-full min-w-0 items-center gap-1.5 rounded px-1 py-0.5 text-left hover:bg-content-interaction focus-visible:outline-2 focus-visible:outline-focus-ring"
+                          onClick={() => {
+                            setExpandedPreviewKey(expanded ? undefined : item.key)
+                            if (!expanded) void ensureDetails()
+                          }}
+                          type="button"
+                        >
+                          <ChevronRight
+                            aria-hidden="true"
+                            className={`size-3.5 shrink-0 ${expanded ? 'rotate-90' : ''}`}
+                          />
+                          <span className="min-w-0 flex-1 truncate" title={item.label}>
+                            {item.label}
+                          </span>
+                        </button>
+                        {expanded && (
+                          <div className="mt-2 space-y-2 pl-5">
+                            {detailState === 'loading' ? (
+                              <p>Loading operation-time preview…</p>
+                            ) : preview ? (
+                              <>
+                                <p>Operation-time {preview.kind === 'diff' ? 'diff' : 'snapshot'}</p>
+                                <DiffView
+                                  content={preview.content}
+                                  kind={preview.kind}
+                                  label={`Operation-time preview for ${preview.path}`}
+                                />
+                                {preview.truncated && <p>The operation-time preview was truncated.</p>}
+                                <Button plain onClick={() => onOpenCurrentDiff(preview.repositoryId, preview.path)}>
+                                  <ExternalLink aria-hidden="true" data-slot="icon" />
+                                  Open current diff
+                                </Button>
+                              </>
+                            ) : (
+                              <p>Operation-time preview unavailable.</p>
+                            )}
+                          </div>
+                        )}
+                      </>
+                    ) : (
+                      <div className="flex items-center gap-1.5">
+                        {item.status === 'completed' && (
+                          <CircleCheck aria-hidden="true" className="size-3.5 shrink-0 text-activity-completed" />
+                        )}
+                        {item.status === 'failed' && (
+                          <CircleX aria-hidden="true" className="size-3.5 shrink-0 text-activity-failed" />
+                        )}
+                        <span>{item.label}</span>
+                        {item.status && <span className="sr-only">{item.status}</span>}
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
             </ul>
           </section>
         ))}
@@ -167,7 +233,13 @@ export function AgentActivityCard({ activity, loadDetails }: AgentActivityCardPr
 
 function artifactSections(artifacts: readonly ActivityArtifact[]): readonly {
   title: string
-  items: readonly { key: string; label: string; status?: 'completed' | 'failed' }[]
+  items: readonly {
+    key: string
+    label: string
+    path?: string
+    repositoryId?: string
+    status?: 'completed' | 'failed'
+  }[]
 }[] {
   const changed = artifacts.flatMap((artifact) => {
     if (artifact.type !== 'file-change') return []
@@ -177,7 +249,14 @@ function artifactSections(artifacts: readonly ActivityArtifact[]): readonly {
         ? ''
         : ` (+${artifact.additions} −${artifact.deletions})`
 
-    return [{ key: `changed-${artifact.path}`, label: `${artifact.path}${counts}` }]
+    return [
+      {
+        key: `changed-${artifact.repositoryId ?? 'session'}-${artifact.path}`,
+        label: `${artifact.path}${counts}`,
+        path: artifact.path,
+        repositoryId: artifact.repositoryId,
+      },
+    ]
   })
 
   const validation = artifacts.flatMap((artifact) =>

--- a/src/renderer/components/diff-view.test.ts
+++ b/src/renderer/components/diff-view.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { parseUnifiedDiffHunks } from './diff-view'
+
+test('parses independently referenceable unified diff hunks with their immutable patches', () => {
+  const content = [
+    'diff --git a/src/example.ts b/src/example.ts',
+    '--- a/src/example.ts',
+    '+++ b/src/example.ts',
+    '@@ -2,2 +2,3 @@',
+    ' unchanged',
+    '-old',
+    '+new',
+    '+added',
+    '@@ -20 +21 @@',
+    '-before',
+    '+after',
+  ].join('\n')
+
+  assert.deepEqual(parseUnifiedDiffHunks(content), [
+    {
+      id: '2:2:0',
+      oldStart: 2,
+      oldLines: 2,
+      newStart: 2,
+      newLines: 3,
+      patch: '@@ -2,2 +2,3 @@\n unchanged\n-old\n+new\n+added',
+    },
+    {
+      id: '20:21:1',
+      oldStart: 20,
+      oldLines: 1,
+      newStart: 21,
+      newLines: 1,
+      patch: '@@ -20 +21 @@\n-before\n+after',
+    },
+  ])
+})

--- a/src/renderer/components/diff-view.tsx
+++ b/src/renderer/components/diff-view.tsx
@@ -1,9 +1,23 @@
+import type { ReactNode } from 'react'
+import { MessageSquarePlus, Send } from 'lucide-react'
 import type { ActivityMutationPreview } from '@/src/session-timeline'
+
+export type DiffHunk = Readonly<{
+  id: string
+  oldStart: number
+  oldLines: number
+  newStart: number
+  newLines: number
+  patch: string
+}>
 
 export type DiffViewProperties = Readonly<{
   content: string
   kind?: ActivityMutationPreview['kind']
   label?: string
+  onCommentHunk?: (hunk: DiffHunk) => void
+  onFollowUpHunk?: (hunk: DiffHunk) => void
+  renderHunkFooter?: (hunk: DiffHunk) => ReactNode
 }>
 
 type DiffLine = Readonly<{
@@ -13,54 +27,157 @@ type DiffLine = Readonly<{
   newLine?: number
 }>
 
-export function DiffView({ content, kind = 'diff', label = 'Code preview' }: DiffViewProperties) {
-  const lines = kind === 'diff' ? parseUnifiedDiff(content) : codeLines(content)
+export function DiffView({
+  content,
+  kind = 'diff',
+  label = 'Code preview',
+  onCommentHunk,
+  onFollowUpHunk,
+  renderHunkFooter,
+}: DiffViewProperties) {
+  const sections = kind === 'diff' ? parseUnifiedDiffSections(content) : [{ lines: codeLines(content) }]
+  const interactive = Boolean(onCommentHunk || onFollowUpHunk || renderHunkFooter)
 
   return (
     <div
       aria-label={label}
-      className="overflow-x-auto rounded-lg border border-content-border bg-session-message-code-background font-mono text-[11px]/5 text-session-message-code-foreground"
+      className="overflow-hidden rounded-lg border border-content-border bg-session-message-code-background font-mono text-[11px]/5 text-session-message-code-foreground"
       role="region"
       tabIndex={0}
     >
-      <table className="w-max min-w-full border-separate border-spacing-0">
-        <tbody>
-          {lines.map((line, index) => (
-            <tr
-              className={
-                line.kind === 'addition'
-                  ? 'bg-diff-addition-background'
-                  : line.kind === 'deletion'
-                    ? 'bg-diff-deletion-background'
-                    : line.kind === 'meta'
-                      ? 'text-content-muted-foreground'
-                      : undefined
-              }
-              key={`${index}-${line.text}`}
-            >
-              <td className="sticky left-0 w-10 select-none border-r border-content-border bg-content-background px-2 text-right text-content-muted-foreground">
-                {line.oldLine}
-              </td>
-              <td className="sticky left-10 w-10 select-none border-r border-content-border bg-content-background px-2 text-right text-content-muted-foreground">
-                {line.newLine}
-              </td>
-              <td
-                className={`whitespace-pre px-3 ${
-                  line.kind === 'addition'
-                    ? 'text-diff-addition-foreground'
-                    : line.kind === 'deletion'
-                      ? 'text-diff-deletion-foreground'
-                      : ''
-                }`}
-              >
-                {line.text || ' '}
-              </td>
-            </tr>
-          ))}
-        </tbody>
+      <table className="w-full table-fixed border-separate border-spacing-0">
+        {sections.map((section, sectionIndex) => (
+          <tbody className={section.hunk ? 'group/hunk' : undefined} key={section.hunk?.id ?? `meta-${sectionIndex}`}>
+            {section.lines.map((line, lineIndex) => (
+              <DiffTableRow
+                actions={
+                  interactive && section.hunk && lineIndex === 0 ? (
+                    <span className="ml-auto flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/hunk:opacity-100 group-focus-within/hunk:opacity-100 motion-reduce:transition-none">
+                      {onCommentHunk && (
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-sans text-[10px]/4 font-medium text-content-foreground hover:bg-content-interaction focus-visible:outline-2 focus-visible:outline-focus-ring"
+                          onClick={() => onCommentHunk(section.hunk!)}
+                        >
+                          <MessageSquarePlus aria-hidden="true" className="size-3" />
+                          Comment
+                        </button>
+                      )}
+                      {onFollowUpHunk && (
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-sans text-[10px]/4 font-medium text-content-foreground hover:bg-content-interaction focus-visible:outline-2 focus-visible:outline-focus-ring"
+                          onClick={() => onFollowUpHunk(section.hunk!)}
+                        >
+                          <Send aria-hidden="true" className="size-3" />
+                          Follow up
+                        </button>
+                      )}
+                    </span>
+                  ) : undefined
+                }
+                key={`${lineIndex}-${line.text}`}
+                line={line}
+              />
+            ))}
+            {section.hunk && renderHunkFooter ? (
+              <DiffHunkFooterRow hunk={section.hunk} render={renderHunkFooter} />
+            ) : null}
+          </tbody>
+        ))}
       </table>
     </div>
   )
+}
+
+function DiffHunkFooterRow({ hunk, render }: Readonly<{ hunk: DiffHunk; render: (hunk: DiffHunk) => ReactNode }>) {
+  const content = render(hunk)
+  if (!content) return null
+
+  return (
+    <tr>
+      <td className="border-t border-content-border bg-content-background p-0" colSpan={3}>
+        {content}
+      </td>
+    </tr>
+  )
+}
+
+function DiffTableRow({ line, actions }: Readonly<{ line: DiffLine; actions?: ReactNode }>) {
+  return (
+    <tr
+      className={
+        line.kind === 'addition'
+          ? 'bg-diff-addition-background'
+          : line.kind === 'deletion'
+            ? 'bg-diff-deletion-background'
+            : line.kind === 'meta'
+              ? 'text-content-muted-foreground'
+              : undefined
+      }
+    >
+      <td className="w-10 select-none border-r border-content-border bg-content-background px-2 text-right align-top text-content-muted-foreground">
+        {line.oldLine}
+      </td>
+      <td className="w-10 select-none border-r border-content-border bg-content-background px-2 text-right align-top text-content-muted-foreground">
+        {line.newLine}
+      </td>
+      <td
+        className={`break-words whitespace-pre-wrap px-3 align-top ${
+          line.kind === 'addition'
+            ? 'text-diff-addition-foreground'
+            : line.kind === 'deletion'
+              ? 'text-diff-deletion-foreground'
+              : ''
+        }`}
+      >
+        <span className="flex min-w-0 items-start gap-2">
+          <span className="min-w-0 flex-1">{line.text || ' '}</span>
+          {actions}
+        </span>
+      </td>
+    </tr>
+  )
+}
+
+type DiffSection = Readonly<{
+  hunk?: DiffHunk
+  lines: readonly DiffLine[]
+}>
+
+export function parseUnifiedDiffHunks(content: string): readonly DiffHunk[] {
+  return parseUnifiedDiffSections(content).flatMap((section) => (section.hunk ? [section.hunk] : []))
+}
+
+function parseUnifiedDiffSections(content: string): readonly DiffSection[] {
+  const sourceLines = content.split('\n')
+  const headerIndexes = sourceLines.flatMap((line, index) => (line.startsWith('@@ ') ? [index] : []))
+  if (headerIndexes.length === 0) return [{ lines: parseUnifiedDiff(content) }]
+
+  const sections: DiffSection[] = []
+  const firstHeader = headerIndexes[0]!
+  if (firstHeader > 0) sections.push({ lines: parseUnifiedDiff(sourceLines.slice(0, firstHeader).join('\n')) })
+
+  headerIndexes.forEach((startIndex, index) => {
+    const endIndex = headerIndexes[index + 1] ?? sourceLines.length
+    const patch = sourceLines.slice(startIndex, endIndex).join('\n')
+    const header = sourceLines[startIndex]?.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/)
+    if (!header) return
+
+    sections.push({
+      hunk: {
+        id: `${header[1]}:${header[3]}:${index}`,
+        oldStart: Number(header[1]),
+        oldLines: Number(header[2] ?? 1),
+        newStart: Number(header[3]),
+        newLines: Number(header[4] ?? 1),
+        patch,
+      },
+      lines: parseUnifiedDiff(patch),
+    })
+  })
+
+  return sections
 }
 
 function codeLines(content: string): readonly DiffLine[] {

--- a/src/renderer/components/diff-view.tsx
+++ b/src/renderer/components/diff-view.tsx
@@ -1,0 +1,100 @@
+import type { ActivityMutationPreview } from '@/src/session-timeline'
+
+export type DiffViewProperties = Readonly<{
+  content: string
+  kind?: ActivityMutationPreview['kind']
+  label?: string
+}>
+
+type DiffLine = Readonly<{
+  text: string
+  kind: 'addition' | 'deletion' | 'context' | 'meta'
+  oldLine?: number
+  newLine?: number
+}>
+
+export function DiffView({ content, kind = 'diff', label = 'Code preview' }: DiffViewProperties) {
+  const lines = kind === 'diff' ? parseUnifiedDiff(content) : codeLines(content)
+
+  return (
+    <div
+      aria-label={label}
+      className="overflow-x-auto rounded-lg border border-content-border bg-session-message-code-background font-mono text-[11px]/5 text-session-message-code-foreground"
+      role="region"
+      tabIndex={0}
+    >
+      <table className="w-max min-w-full border-separate border-spacing-0">
+        <tbody>
+          {lines.map((line, index) => (
+            <tr
+              className={
+                line.kind === 'addition'
+                  ? 'bg-diff-addition-background'
+                  : line.kind === 'deletion'
+                    ? 'bg-diff-deletion-background'
+                    : line.kind === 'meta'
+                      ? 'text-content-muted-foreground'
+                      : undefined
+              }
+              key={`${index}-${line.text}`}
+            >
+              <td className="sticky left-0 w-10 select-none border-r border-content-border bg-content-background px-2 text-right text-content-muted-foreground">
+                {line.oldLine}
+              </td>
+              <td className="sticky left-10 w-10 select-none border-r border-content-border bg-content-background px-2 text-right text-content-muted-foreground">
+                {line.newLine}
+              </td>
+              <td
+                className={`whitespace-pre px-3 ${
+                  line.kind === 'addition'
+                    ? 'text-diff-addition-foreground'
+                    : line.kind === 'deletion'
+                      ? 'text-diff-deletion-foreground'
+                      : ''
+                }`}
+              >
+                {line.text || ' '}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function codeLines(content: string): readonly DiffLine[] {
+  return content.split('\n').map((text, index) => ({ text, kind: 'context', newLine: index + 1 }))
+}
+
+export function parseUnifiedDiff(content: string): readonly DiffLine[] {
+  let oldLine: number | undefined
+  let newLine: number | undefined
+
+  return content.split('\n').map((text): DiffLine => {
+    const header = text.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+    if (header) {
+      oldLine = Number(header[1])
+      newLine = Number(header[2])
+      return { text, kind: 'meta' }
+    }
+    if (text.startsWith('diff ') || text.startsWith('index ') || text.startsWith('---') || text.startsWith('+++')) {
+      return { text, kind: 'meta' }
+    }
+    if (text.startsWith('+')) {
+      const line = { text, kind: 'addition' as const, newLine }
+      if (newLine !== undefined) newLine += 1
+      return line
+    }
+    if (text.startsWith('-')) {
+      const line = { text, kind: 'deletion' as const, oldLine }
+      if (oldLine !== undefined) oldLine += 1
+      return line
+    }
+
+    const line = { text, kind: 'context' as const, oldLine, newLine }
+    if (oldLine !== undefined) oldLine += 1
+    if (newLine !== undefined) newLine += 1
+    return line
+  })
+}

--- a/src/renderer/components/queued-follow-up-tray.test.tsx
+++ b/src/renderer/components/queued-follow-up-tray.test.tsx
@@ -97,6 +97,46 @@ test('renders queued Skill tokens as Skill references', () => {
   assert.match(view.container.textContent ?? '', /Write the focused test\./)
 })
 
+test('summarizes a queued referenced follow-up by file and comment', () => {
+  const view = render(
+    <QueuedFollowUpTray
+      sessionId={id}
+      isWorking
+      queuedFollowUps={[
+        {
+          id: 'follow-up-1',
+          text: 'Formatted model context',
+          createdAt: 1,
+          codeReview: {
+            kind: 'follow-up',
+            comments: [
+              {
+                id: 'comment-1',
+                text: 'Keep this visible.',
+                createdAt: 1,
+                reference: {
+                  repositoryId: 'repository-1',
+                  repositoryName: 'Pi Workspace',
+                  path: 'src/session-changes.tsx',
+                  oldStart: 1,
+                  oldLines: 1,
+                  newStart: 1,
+                  newLines: 1,
+                  patch: '@@ -1 +1 @@\n-old\n+new',
+                },
+              },
+            ],
+          },
+        },
+      ]}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  assert.match(view.getByText(/Next follow-up/).textContent ?? '', /src\/session-changes.tsx/)
+  assert.ok(view.getByText('Keep this visible.'))
+})
+
 test('reveals only the next three queued follow-ups', async () => {
   const user = userEvent.setup({ document: browser.document as unknown as Document })
   const view = renderInBrowser(

--- a/src/renderer/components/queued-follow-up-tray.tsx
+++ b/src/renderer/components/queued-follow-up-tray.tsx
@@ -21,18 +21,28 @@ type QueuedFollowUpTrayProperties = Readonly<{
 }>
 
 function QueuedFollowUpContent({ followUp, next }: Readonly<{ followUp: QueuedFollowUp; next: boolean }>) {
-  const projected = projectSessionSkillSelections(followUp.text)
-  const skills =
-    followUp.skills ??
-    projected.selections.map(({ name, offset }) => ({
-      offset,
-      skill: { name, availability: 'unavailable' as const },
-    }))
+  const reviewComment = followUp.codeReview?.comments[0]
+  const source = reviewComment?.text ?? followUp.text
+  const projected = projectSessionSkillSelections(source)
+  const skills = reviewComment
+    ? projected.selections.map(({ name, offset }) => ({
+        offset,
+        skill: followUp.skills?.find((mention) => mention.skill.name === name)?.skill ?? {
+          name,
+          availability: 'unavailable' as const,
+        },
+      }))
+    : (followUp.skills ??
+      projected.selections.map(({ name, offset }) => ({
+        offset,
+        skill: { name, availability: 'unavailable' as const },
+      })))
 
   return (
     <>
       <span className="block text-xs/4 font-medium text-content-muted-foreground">
         {next ? 'Next follow-up' : 'Follow-up'}
+        {reviewComment ? ` · ${reviewComment.reference.path}` : ''}
       </span>
       <span className="mt-0.5 line-clamp-2 block whitespace-pre-wrap break-words">
         <SkillMentionText text={projected.text} skills={skills} />

--- a/src/renderer/components/session-area.tsx
+++ b/src/renderer/components/session-area.tsx
@@ -38,6 +38,7 @@ type SessionAreaProperties = {
   onToggleSessionPin: (sessionId: SessionId) => void
   acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
   onStartImplementSession?: (workstreamId: string) => Promise<void>
+  onOpenCurrentDiff?: (sessionId: SessionId, repositoryId: string | undefined, path: string) => void
 }
 
 export function SessionArea({
@@ -65,6 +66,7 @@ export function SessionArea({
   onToggleSessionPin,
   acceptActionCard = async () => false,
   onStartImplementSession = async () => {},
+  onOpenCurrentDiff = () => {},
 }: SessionAreaProperties) {
   const sessionPaneRefs = useRef(new Map<SessionId, HTMLDivElement>())
 
@@ -122,6 +124,7 @@ export function SessionArea({
             onTogglePin={() => onToggleSessionPin(session.id)}
             acceptActionCard={acceptActionCard}
             onStartImplementSession={onStartImplementSession}
+            onOpenCurrentDiff={(repositoryId, path) => onOpenCurrentDiff(session.id, repositoryId, path)}
           />
         </div>
       ))}

--- a/src/renderer/components/session-changes.test.tsx
+++ b/src/renderer/components/session-changes.test.tsx
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { sessionId } from '@/src/domain/session'
+import type { PiWorkspaceBridge } from '@/src/pi-workspace'
+import { browser } from '@/src/renderer/test-dom'
+import { SessionChanges } from './session-changes'
+
+const id = sessionId('session-changes')
+
+afterEach(() => cleanup())
+
+function installBridge() {
+  const diffRequests: string[] = []
+  const bridge = {
+    sessionChanges: {
+      async getSnapshot() {
+        return {
+          sessionId: id,
+          repositories: [
+            {
+              repositoryId: 'repository-a',
+              repositoryName: 'Repository A',
+              branch: { head: 'main', ahead: 1, behind: 0, detached: false, unborn: false },
+              files: [
+                {
+                  path: 'src/file.ts',
+                  status: 'modified' as const,
+                  staged: true,
+                  unstaged: true,
+                  additions: 1,
+                  deletions: 1,
+                },
+              ],
+            },
+          ],
+        }
+      },
+      async loadFileDiff(_sessionId: string, _repositoryId: string, _path: string, view: string) {
+        diffRequests.push(view)
+        return { status: 'available' as const, content: '@@ -1 +1 @@\n-old\n+new', truncated: false }
+      },
+    },
+    transcript: {
+      subscribe() {
+        return () => {}
+      },
+    },
+  } as unknown as PiWorkspaceBridge
+
+  Object.defineProperty(browser.window, 'piWorkspace', { configurable: true, value: bridge })
+  return diffRequests
+}
+
+test('discards a stale changes refresh response', async () => {
+  const requests: Array<(snapshot: Awaited<ReturnType<PiWorkspaceBridge['sessionChanges']['getSnapshot']>>) => void> =
+    []
+  Object.defineProperty(browser.window, 'piWorkspace', {
+    configurable: true,
+    value: {
+      sessionChanges: {
+        getSnapshot: () =>
+          new Promise((resolve) => {
+            requests.push(resolve)
+          }),
+      },
+      transcript: { subscribe: () => () => {} },
+    } as unknown as PiWorkspaceBridge,
+  })
+  const view = render(<SessionChanges sessionId={id} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+  await waitFor(() => assert.equal(requests.length, 1))
+
+  browser.window.dispatchEvent(new browser.window.Event('focus'))
+  await waitFor(() => assert.equal(requests.length, 2))
+  requests[1]!({
+    sessionId: id,
+    repositories: [
+      {
+        repositoryId: 'repository-a',
+        repositoryName: 'Repository A',
+        branch: { head: 'main', ahead: 0, behind: 0, detached: false, unborn: false },
+        files: [{ path: 'newer.ts', status: 'added', staged: false, unstaged: true }],
+      },
+    ],
+  })
+  await waitFor(() => assert.ok(view.getByText('newer.ts')))
+
+  requests[0]!({ sessionId: id, repositories: [] })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  assert.ok(view.getByText('newer.ts'))
+})
+
+test('navigates from a changed file to lazy all, staged, and unstaged diffs', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const diffRequests = installBridge()
+  const view = render(<SessionChanges sessionId={id} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+
+  await waitFor(() => assert.ok(view.getByRole('button', { name: /src\/file.ts/ })))
+  await user.click(view.getByRole('button', { name: /src\/file.ts/ }))
+  await waitFor(() => assert.ok(view.getByRole('region', { name: 'Diff for src/file.ts' })))
+
+  assert.deepEqual(diffRequests, ['all'])
+  await user.click(view.getByRole('tab', { name: /^staged$/i }))
+  await waitFor(() => assert.deepEqual(diffRequests, ['all', 'staged']))
+  await user.click(view.getByRole('tab', { name: /^unstaged$/i }))
+  await waitFor(() => assert.deepEqual(diffRequests, ['all', 'staged', 'unstaged']))
+  await user.click(view.getByRole('button', { name: 'Back to changed files' }))
+
+  const fileButton = view.getByRole('button', { name: /src\/file.ts/ })
+  assert.ok(view.getByText('1 changed files'))
+  await waitFor(() => assert.equal(browser.document.activeElement, fileButton))
+})

--- a/src/renderer/components/session-changes.test.tsx
+++ b/src/renderer/components/session-changes.test.tsx
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { sessionId } from '@/src/domain/session'
 import type { PiWorkspaceBridge } from '@/src/pi-workspace'
@@ -11,35 +11,103 @@ const id = sessionId('session-changes')
 
 afterEach(() => cleanup())
 
-function installBridge() {
+function installBridge({
+  deferRefreshedDiff = false,
+  diffContent = '@@ -1 +1 @@\n-old\n+new',
+  includeChangedFile = true,
+  initialReviewComments = [],
+}: Readonly<{
+  deferRefreshedDiff?: boolean
+  diffContent?: string
+  includeChangedFile?: boolean
+  initialReviewComments?: readonly import('@/src/session-code-review').SessionCodeReviewComment[]
+}> = {}) {
   const diffRequests: string[] = []
+  const stageRequests: boolean[] = []
+  const savedReviewComments: string[] = []
+  const submittedReviews: unknown[] = []
+  let finishedReviews = 0
+  let reviewComments = [...initialReviewComments]
+  let resolveRefreshedDiff: (() => void) | undefined
+  const refreshedDiff = new Promise<void>((resolve) => {
+    resolveRefreshedDiff = resolve
+  })
+  let staged = true
+  let unstaged = true
+  const snapshot = () => ({
+    sessionId: id,
+    repositories: [
+      {
+        repositoryId: 'repository-a',
+        repositoryName: 'Repository A',
+        branch: { head: 'main', ahead: 1, behind: 0, detached: false, unborn: false },
+        files: includeChangedFile
+          ? [
+              {
+                path: 'src/file.ts',
+                status: 'modified' as const,
+                staged,
+                unstaged,
+                additions: 1,
+                deletions: 1,
+              },
+            ]
+          : [],
+      },
+    ],
+  })
   const bridge = {
     sessionChanges: {
       async getSnapshot() {
-        return {
-          sessionId: id,
-          repositories: [
-            {
-              repositoryId: 'repository-a',
-              repositoryName: 'Repository A',
-              branch: { head: 'main', ahead: 1, behind: 0, detached: false, unborn: false },
-              files: [
-                {
-                  path: 'src/file.ts',
-                  status: 'modified' as const,
-                  staged: true,
-                  unstaged: true,
-                  additions: 1,
-                  deletions: 1,
-                },
-              ],
-            },
-          ],
-        }
+        return snapshot()
       },
       async loadFileDiff(_sessionId: string, _repositoryId: string, _path: string, view: string) {
         diffRequests.push(view)
-        return { status: 'available' as const, content: '@@ -1 +1 @@\n-old\n+new', truncated: false }
+        if (deferRefreshedDiff && diffRequests.length > 1) await refreshedDiff
+
+        return { status: 'available' as const, content: diffContent, truncated: false }
+      },
+      async setFileStaged(_sessionId: string, _repositoryId: string, _path: string, nextStaged: boolean) {
+        stageRequests.push(nextStaged)
+        staged = nextStaged
+        unstaged = !nextStaged
+        return snapshot()
+      },
+    },
+    composer: {
+      async getCodeReviewDraft() {
+        return { comments: reviewComments }
+      },
+      async saveCodeReviewComment(command: import('@/src/composer').SessionCodeReviewCommentCommand) {
+        savedReviewComments.push(command.text)
+        const comment = {
+          id: command.commentId ?? 'comment-1',
+          text: command.text,
+          reference: command.reference,
+          createdAt: 1,
+        }
+        reviewComments = command.commentId
+          ? reviewComments.map((candidate) => (candidate.id === command.commentId ? comment : candidate))
+          : [...reviewComments, comment]
+        return { comments: reviewComments }
+      },
+      async removeCodeReviewComment(_sessionId: string, commentId: string) {
+        reviewComments = reviewComments.filter((comment) => comment.id !== commentId)
+        return { comments: reviewComments }
+      },
+      async finishCodeReview() {
+        finishedReviews += 1
+        reviewComments = []
+        return { status: 'accepted' as const, delivery: 'prompt' as const }
+      },
+      async submit(submission: unknown) {
+        submittedReviews.push(submission)
+        return { status: 'accepted' as const, delivery: 'follow-up' as const }
+      },
+    },
+    sessionSkills: {
+      async getAvailable() {
+        return [{ name: 'tdd', description: 'Test-driven development.' }]
       },
     },
     transcript: {
@@ -50,7 +118,16 @@ function installBridge() {
   } as unknown as PiWorkspaceBridge
 
   Object.defineProperty(browser.window, 'piWorkspace', { configurable: true, value: bridge })
-  return diffRequests
+  return {
+    diffRequests,
+    stageRequests,
+    savedReviewComments,
+    submittedReviews,
+    get finishedReviews() {
+      return finishedReviews
+    },
+    resolveRefreshedDiff,
+  }
 }
 
 test('discards a stale changes refresh response', async () => {
@@ -73,45 +150,163 @@ test('discards a stale changes refresh response', async () => {
   })
   await waitFor(() => assert.equal(requests.length, 1))
 
-  browser.window.dispatchEvent(new browser.window.Event('focus'))
+  act(() => browser.window.dispatchEvent(new browser.window.Event('focus')))
   await waitFor(() => assert.equal(requests.length, 2))
-  requests[1]!({
-    sessionId: id,
-    repositories: [
-      {
-        repositoryId: 'repository-a',
-        repositoryName: 'Repository A',
-        branch: { head: 'main', ahead: 0, behind: 0, detached: false, unborn: false },
-        files: [{ path: 'newer.ts', status: 'added', staged: false, unstaged: true }],
-      },
-    ],
+  await act(async () => {
+    requests[1]!({
+      sessionId: id,
+      repositories: [
+        {
+          repositoryId: 'repository-a',
+          repositoryName: 'Repository A',
+          branch: { head: 'main', ahead: 0, behind: 0, detached: false, unborn: false },
+          files: [{ path: 'newer.ts', status: 'added', staged: false, unstaged: true }],
+        },
+      ],
+    })
+    await Promise.resolve()
   })
   await waitFor(() => assert.ok(view.getByText('newer.ts')))
 
-  requests[0]!({ sessionId: id, repositories: [] })
+  await act(async () => {
+    requests[0]!({ sessionId: id, repositories: [] })
+    await Promise.resolve()
+  })
   await new Promise((resolve) => setTimeout(resolve, 0))
   assert.ok(view.getByText('newer.ts'))
 })
 
-test('navigates from a changed file to lazy all, staged, and unstaged diffs', async () => {
+test('toggles a lazy inline diff and stages the whole file from its indeterminate state', async () => {
   const user = userEvent.setup({ document: browser.document as unknown as Document })
-  const diffRequests = installBridge()
+  const { diffRequests, stageRequests } = installBridge()
   const view = render(<SessionChanges sessionId={id} />, {
     container: browser.document.body as unknown as HTMLElement,
   })
 
-  await waitFor(() => assert.ok(view.getByRole('button', { name: /src\/file.ts/ })))
-  await user.click(view.getByRole('button', { name: /src\/file.ts/ }))
+  const fileButton = await waitFor(() => view.getByRole('button', { name: /src\/file.ts/ }))
+  const stageCheckbox = view.getByRole('checkbox', { name: 'Stage src/file.ts' })
+  assert.equal(stageCheckbox.getAttribute('aria-checked'), 'mixed')
+
+  await user.click(fileButton)
+  await waitFor(() => assert.ok(view.getByRole('region', { name: 'Diff for src/file.ts' })))
+  assert.deepEqual(diffRequests, ['all'])
+
+  await user.click(stageCheckbox)
+  await waitFor(() =>
+    assert.equal(view.getByRole('checkbox', { name: 'Unstage src/file.ts' }).getAttribute('aria-checked'), 'true')
+  )
+  assert.deepEqual(stageRequests, [true])
+  await waitFor(() => assert.deepEqual(diffRequests, ['all', 'all']))
+
+  await user.click(fileButton)
+  assert.equal(view.queryByRole('region', { name: 'Diff for src/file.ts' }), null)
+  assert.ok(view.getByText('1 changed file'))
+})
+
+test('retains a hunk comment until the user finishes the code review', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const review = installBridge()
+  const view = render(<SessionChanges sessionId={id} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+
+  await user.click(await waitFor(() => view.getByRole('button', { name: /src\/file.ts/ })))
   await waitFor(() => assert.ok(view.getByRole('region', { name: 'Diff for src/file.ts' })))
 
-  assert.deepEqual(diffRequests, ['all'])
-  await user.click(view.getByRole('tab', { name: /^staged$/i }))
-  await waitFor(() => assert.deepEqual(diffRequests, ['all', 'staged']))
-  await user.click(view.getByRole('tab', { name: /^unstaged$/i }))
-  await waitFor(() => assert.deepEqual(diffRequests, ['all', 'staged', 'unstaged']))
-  await user.click(view.getByRole('button', { name: 'Back to changed files' }))
+  await user.click(view.getByRole('button', { name: 'Comment' }))
+  await user.type(view.getByRole('textbox', { name: 'Comment on src/file.ts' }), 'Keep this diff visible.{Enter}')
 
-  const fileButton = view.getByRole('button', { name: /src\/file.ts/ })
-  assert.ok(view.getByText('1 changed files'))
-  await waitFor(() => assert.equal(browser.document.activeElement, fileButton))
+  await waitFor(() => assert.ok(view.getByRole('button', { name: 'Finish review (1)' })))
+  assert.deepEqual(review.savedReviewComments, ['Keep this diff visible.'])
+  assert.ok(view.getByText('Keep this diff visible.'))
+
+  await user.click(view.getByRole('button', { name: 'Finish review (1)' }))
+  await waitFor(() => assert.equal(review.finishedReviews, 1))
+  assert.equal(view.queryByRole('button', { name: 'Finish review (1)' }), null)
+})
+
+test('keeps a persisted comment manageable after its file leaves current changes', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const comment = {
+    id: 'comment-1',
+    text: 'Keep the previous behavior.',
+    createdAt: 1,
+    reference: {
+      repositoryId: 'repository-a',
+      repositoryName: 'Repository A',
+      path: 'src/removed.ts',
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+      patch: '@@ -1 +1 @@\n-old\n+new',
+    },
+  }
+  const review = installBridge({ includeChangedFile: false, initialReviewComments: [comment] })
+  const view = render(<SessionChanges sessionId={id} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+
+  assert.ok(await waitFor(() => view.getByText('Keep the previous behavior.')))
+  assert.ok(view.getByText('src/removed.ts'))
+  await user.click(view.getByRole('button', { name: 'Edit review comment' }))
+  const editor = view.getByRole('textbox', { name: 'Edit comment on src/removed.ts' })
+  await user.type(editor, ' Updated behavior.{Enter}')
+
+  const updated = 'Keep the previous behavior. Updated behavior.'
+  await waitFor(() => assert.deepEqual(review.savedReviewComments, [updated]))
+  assert.ok(view.getByText(updated))
+  await user.click(view.getByRole('button', { name: 'Remove review comment' }))
+  await waitFor(() => assert.equal(view.queryByText(updated), null))
+})
+
+test('sends one hunk as an immediate referenced follow-up', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const review = installBridge()
+  const view = render(<SessionChanges sessionId={id} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+
+  await user.click(await waitFor(() => view.getByRole('button', { name: /src\/file.ts/ })))
+  await user.click(await waitFor(() => view.getByRole('button', { name: 'Follow up' })))
+  await user.type(view.getByRole('textbox', { name: 'Follow up on src/file.ts' }), 'Change this.{Enter}')
+
+  await waitFor(() => assert.equal(review.submittedReviews.length, 1))
+  const submission = review.submittedReviews[0] as import('@/src/composer').SessionMessageSubmission
+  assert.equal(submission.delivery, 'follow-up')
+  assert.equal(submission.codeReview?.kind, 'follow-up')
+  assert.equal(submission.codeReview?.comments[0]?.reference.patch, '@@ -1 +1 @@\n-old\n+new')
+})
+
+test('keeps an expanded diff visible while staging refreshes its content', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const { diffRequests, resolveRefreshedDiff } = installBridge({ deferRefreshedDiff: true })
+  const view = render(<SessionChanges sessionId={id} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+
+  await user.click(await waitFor(() => view.getByRole('button', { name: /src\/file.ts/ })))
+  await waitFor(() => assert.ok(view.getByRole('region', { name: 'Diff for src/file.ts' })))
+
+  await user.click(view.getByRole('checkbox', { name: 'Stage src/file.ts' }))
+  await waitFor(() => assert.deepEqual(diffRequests, ['all', 'all']))
+  assert.ok(view.getByRole('region', { name: 'Diff for src/file.ts' }))
+
+  await act(async () => resolveRefreshedDiff?.())
+})
+
+test('unstages a fully staged file from its checkbox', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const { stageRequests } = installBridge()
+  const view = render(<SessionChanges sessionId={id} />, {
+    container: browser.document.body as unknown as HTMLElement,
+  })
+
+  const stageCheckbox = await waitFor(() => view.getByRole('checkbox', { name: 'Stage src/file.ts' }))
+  await user.click(stageCheckbox)
+  const unstageCheckbox = await waitFor(() => view.getByRole('checkbox', { name: 'Unstage src/file.ts' }))
+
+  await user.click(unstageCheckbox)
+  await waitFor(() => assert.ok(view.getByRole('checkbox', { name: 'Stage src/file.ts' })))
+  assert.deepEqual(stageRequests, [true, false])
 })

--- a/src/renderer/components/session-changes.tsx
+++ b/src/renderer/components/session-changes.tsx
@@ -1,14 +1,29 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowLeft, CircleAlert, FileCode2, GitBranch, LoaderCircle, RefreshCw } from 'lucide-react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import {
+  ChevronRight,
+  CircleAlert,
+  FileCode2,
+  GitBranch,
+  LoaderCircle,
+  Pencil,
+  RefreshCw,
+  Trash2,
+  X,
+} from 'lucide-react'
 import { Button } from '@/components/ui-kit/button'
+import { Checkbox } from '@/components/ui-kit/checkbox'
 import type { SessionId } from '@/src/domain/session'
-import type {
-  SessionChangeFile,
-  SessionChangesSnapshot,
-  SessionFileDiff,
-  SessionFileDiffView,
-} from '@/src/session-changes'
-import { DiffView } from './diff-view'
+import type { SessionChangeFile, SessionChangesSnapshot, SessionFileDiff } from '@/src/session-changes'
+import {
+  boundSessionCodeReferencePatch,
+  type SessionCodeReference,
+  type SessionCodeReviewComment,
+  type SessionCodeReviewDraft,
+} from '@/src/session-code-review'
+import { projectSessionSkillSelections, type SessionSkill } from '@/src/session-skills'
+import { ComposerEditor, type ComposerEditorHandle } from './composer-editor'
+import { DiffView, parseUnifiedDiffHunks, type DiffHunk } from './diff-view'
+import { SkillMentionText } from './skill-mention-text'
 
 export type SessionChangesSelection = Readonly<{
   repositoryId?: string
@@ -21,20 +36,36 @@ type SessionChangesProperties = Readonly<{
   selection?: SessionChangesSelection
 }>
 
-type SelectedFile = Readonly<{ repositoryId: string; repositoryName: string; file: SessionChangeFile }>
-
 export function SessionChanges({ sessionId, selection }: SessionChangesProperties) {
   const [snapshot, setSnapshot] = useState<SessionChangesSnapshot>()
+  const [snapshotRevision, setSnapshotRevision] = useState(0)
   const [error, setError] = useState<string>()
-  const [selected, setSelected] = useState<SelectedFile>()
-  const [view, setView] = useState<SessionFileDiffView>('all')
-  const [diff, setDiff] = useState<SessionFileDiff>()
-  const [diffLoading, setDiffLoading] = useState(false)
+  const [expandedFiles, setExpandedFiles] = useState<ReadonlySet<string>>(new Set())
+  const [stagingFile, setStagingFile] = useState<string>()
+  const [stagingErrors, setStagingErrors] = useState<ReadonlyMap<string, string>>(new Map())
   const [announcement, setAnnouncement] = useState('')
+  const [reviewDraft, setReviewDraft] = useState<SessionCodeReviewDraft>({ comments: [] })
+  const [availableSkills, setAvailableSkills] = useState<readonly SessionSkill[]>([])
+  const [reviewPending, setReviewPending] = useState(false)
+  const [reviewError, setReviewError] = useState<string>()
+  const [activeReviewFile, setActiveReviewFile] = useState<string>()
   const requestRef = useRef(0)
-  const diffRequestRef = useRef(0)
-  const selectedRef = useRef<SelectedFile | undefined>(undefined)
-  const fileButtonRefs = useRef(new Map<string, HTMLButtonElement>())
+  const expandedFilesRef = useRef(expandedFiles)
+
+  const applySnapshot = useCallback((next: SessionChangesSnapshot) => {
+    const availableFiles = new Set(
+      next.repositories.flatMap((repository) =>
+        repository.files.map((file) => fileKey(repository.repositoryId, file.path))
+      )
+    )
+    const missingFile = [...expandedFilesRef.current].find((key) => !availableFiles.has(key))
+
+    if (missingFile) setAnnouncement(`${filePathFromKey(missingFile)} is no longer changed.`)
+
+    setExpandedFiles((current) => new Set([...current].filter((key) => availableFiles.has(key))))
+    setSnapshot(next)
+    setSnapshotRevision((revision) => revision + 1)
+  }, [])
 
   const refresh = useCallback(async () => {
     const request = ++requestRef.current
@@ -44,29 +75,18 @@ export function SessionChanges({ sessionId, selection }: SessionChangesPropertie
       const next = await window.piWorkspace.sessionChanges.getSnapshot(sessionId)
       if (request !== requestRef.current) return
 
-      setSnapshot(next)
-      const current = selectedRef.current
-      if (current) {
-        const repository = next.repositories.find((candidate) => candidate.repositoryId === current.repositoryId)
-        const file = repository?.files.find((candidate) => candidate.path === current.file.path)
-
-        if (repository && file) {
-          setSelected({ repositoryId: repository.repositoryId, repositoryName: repository.repositoryName, file })
-        } else {
-          setSelected(undefined)
-          setAnnouncement(`${current.file.path} is no longer changed.`)
-        }
-      }
+      applySnapshot(next)
     } catch (loadError) {
       if (request !== requestRef.current) return
       setError(loadError instanceof Error ? loadError.message : 'Changes are unavailable.')
     }
-  }, [sessionId])
+  }, [applySnapshot, sessionId])
 
   useEffect(() => {
     setSnapshot(undefined)
-    setSelected(undefined)
-    setDiff(undefined)
+    setExpandedFiles(new Set())
+    setStagingFile(undefined)
+    setStagingErrors(new Map())
     void refresh()
 
     const unsubscribe = window.piWorkspace.transcript.subscribe((mutation) => {
@@ -77,15 +97,41 @@ export function SessionChanges({ sessionId, selection }: SessionChangesPropertie
 
     return () => {
       requestRef.current += 1
-      diffRequestRef.current += 1
       unsubscribe()
       window.removeEventListener('focus', handleFocus)
     }
   }, [refresh, sessionId])
 
   useEffect(() => {
-    selectedRef.current = selected
-  }, [selected])
+    expandedFilesRef.current = expandedFiles
+  }, [expandedFiles])
+
+  useEffect(() => {
+    let current = true
+    setReviewDraft({ comments: [] })
+    setAvailableSkills([])
+    setReviewError(undefined)
+    setActiveReviewFile(undefined)
+
+    void window.piWorkspace.composer?.getCodeReviewDraft?.(sessionId).then(
+      (draft) => {
+        if (current) setReviewDraft(draft)
+      },
+      () => {
+        if (current) setReviewError('Review comments could not be loaded.')
+      }
+    )
+    void window.piWorkspace.sessionSkills?.getAvailable(sessionId).then(
+      (skills) => {
+        if (current) setAvailableSkills(skills)
+      },
+      () => {}
+    )
+
+    return () => {
+      current = false
+    }
+  }, [sessionId])
 
   useEffect(() => {
     if (!selection || !snapshot) return
@@ -93,115 +139,189 @@ export function SessionChanges({ sessionId, selection }: SessionChangesPropertie
     for (const repository of snapshot.repositories) {
       if (selection.repositoryId && selection.repositoryId !== repository.repositoryId) continue
       const file = repository.files.find((candidate) => candidate.path === selection.path)
-      if (file) {
-        setSelected({ repositoryId: repository.repositoryId, repositoryName: repository.repositoryName, file })
-        setView('all')
-        return
-      }
+      if (!file) continue
+
+      const key = fileKey(repository.repositoryId, file.path)
+      setExpandedFiles((current) => new Set(current).add(key))
+      return
     }
   }, [selection?.request, snapshot])
 
-  useEffect(() => {
-    if (!selected) return
+  const setFileStaged = async (repositoryId: string, file: SessionChangeFile, staged: boolean) => {
+    const key = fileKey(repositoryId, file.path)
+    setStagingFile(key)
+    setStagingErrors((current) => {
+      const next = new Map(current)
+      next.delete(key)
+      return next
+    })
 
-    const request = ++diffRequestRef.current
-    setDiff(undefined)
-    setDiffLoading(true)
+    try {
+      const next = await window.piWorkspace.sessionChanges.setFileStaged(sessionId, repositoryId, file.path, staged)
+      requestRef.current += 1
+      applySnapshot(next)
+      setAnnouncement(`${file.path} ${staged ? 'staged' : 'unstaged'}.`)
+    } catch (stageError) {
+      setStagingErrors((current) =>
+        new Map(current).set(
+          key,
+          stageError instanceof Error ? stageError.message : `Could not ${staged ? 'stage' : 'unstage'} the file.`
+        )
+      )
+    } finally {
+      setStagingFile(undefined)
+    }
+  }
 
-    void window.piWorkspace.sessionChanges
-      .loadFileDiff(sessionId, selected.repositoryId, selected.file.path, view)
-      .then((next) => {
-        if (request === diffRequestRef.current) setDiff(next)
+  const saveReviewComment = async (
+    text: string,
+    reference: SessionCodeReference,
+    commentId?: string
+  ): Promise<boolean> => {
+    setReviewPending(true)
+    setReviewError(undefined)
+
+    try {
+      const next = await window.piWorkspace.composer.saveCodeReviewComment({
+        sessionId,
+        commentId,
+        text,
+        reference,
       })
-      .catch((loadError: unknown) => {
-        if (request !== diffRequestRef.current) return
-        setDiff({
-          status: 'unavailable',
-          message: loadError instanceof Error ? loadError.message : 'The diff is unavailable.',
-        })
-      })
-      .finally(() => {
-        if (request === diffRequestRef.current) setDiffLoading(false)
-      })
-  }, [selected?.repositoryId, selected?.file.path, sessionId, view])
+      setReviewDraft(next)
+      setAnnouncement(commentId ? 'Review comment updated.' : 'Review comment added.')
+      return true
+    } catch (saveError) {
+      setReviewError(saveError instanceof Error ? saveError.message : 'The review comment could not be saved.')
+      return false
+    } finally {
+      setReviewPending(false)
+    }
+  }
 
-  if (selected) {
-    const views: SessionFileDiffView[] = [
-      'all',
-      ...(selected.file.staged ? (['staged'] as const) : []),
-      ...(selected.file.unstaged ? (['unstaged'] as const) : []),
-    ]
+  const removeReviewComment = async (commentId: string): Promise<void> => {
+    setReviewPending(true)
+    setReviewError(undefined)
 
-    return (
-      <div className="flex min-h-0 flex-1 flex-col bg-content-background">
-        <header className="sticky top-0 z-20 border-b border-content-border bg-content-background px-4 py-3">
-          <div className="flex min-w-0 items-center gap-2">
-            <Button
-              plain
-              aria-label="Back to changed files"
-              onClick={() => {
-                const key = `${selected.repositoryId}:${selected.file.path}`
-                setSelected(undefined)
-                window.requestAnimationFrame(() => fileButtonRefs.current.get(key)?.focus())
-              }}
-            >
-              <ArrowLeft aria-hidden="true" data-slot="icon" />
-            </Button>
-            <div className="min-w-0">
-              <h3 className="truncate text-sm/5 font-medium text-content-foreground" title={selected.file.path}>
-                {selected.file.path}
-              </h3>
-              <p className="truncate text-xs/4 text-content-muted-foreground">{selected.repositoryName}</p>
-            </div>
-          </div>
-          {views.length > 1 && (
-            <div aria-label="Diff view" className="mt-3 flex gap-1" role="tablist">
-              {views.map((candidate) => (
-                <button
-                  aria-selected={view === candidate}
-                  className="rounded-md px-2.5 py-1 text-xs/5 capitalize text-content-muted-foreground hover:bg-content-interaction data-[selected=true]:bg-content-interaction-strong data-[selected=true]:text-content-foreground"
-                  data-selected={view === candidate}
-                  key={candidate}
-                  onClick={() => setView(candidate)}
-                  role="tab"
-                  type="button"
-                >
-                  {candidate}
-                </button>
-              ))}
-            </div>
-          )}
-        </header>
-        <div className="min-h-0 flex-1 overflow-y-auto p-3">
-          {diffLoading ? (
-            <ResourceMessage icon={LoaderCircle} message="Loading diff…" spinning />
-          ) : diff?.content ? (
-            <>
-              {diff.message && <p className="mb-2 text-xs/5 text-content-muted-foreground">{diff.message}</p>}
-              <DiffView content={diff.content} label={`Diff for ${selected.file.path}`} />
-            </>
-          ) : (
-            <ResourceMessage icon={CircleAlert} message={diff?.message ?? 'The diff is unavailable.'} />
-          )}
-        </div>
-      </div>
-    )
+    try {
+      setReviewDraft(await window.piWorkspace.composer.removeCodeReviewComment(sessionId, commentId))
+      setAnnouncement('Review comment removed.')
+    } catch (removeError) {
+      setReviewError(removeError instanceof Error ? removeError.message : 'The review comment could not be removed.')
+    } finally {
+      setReviewPending(false)
+    }
+  }
+
+  const sendCodeFollowUp = async (text: string, reference: SessionCodeReference): Promise<boolean> => {
+    setReviewPending(true)
+    setReviewError(undefined)
+    const comment = {
+      id: `follow-up-${Date.now()}`,
+      text,
+      reference,
+      createdAt: Date.now(),
+    }
+
+    try {
+      const result = await window.piWorkspace.composer.submit({
+        sessionId,
+        text: '',
+        delivery: 'follow-up',
+        codeReview: { kind: 'follow-up', comments: [comment] },
+      })
+      if (result.status === 'rejected') {
+        setReviewError('The referenced follow-up could not be sent.')
+        return false
+      }
+
+      setAnnouncement('Referenced follow-up sent.')
+      return true
+    } catch {
+      setReviewError('The referenced follow-up could not be sent.')
+      return false
+    } finally {
+      setReviewPending(false)
+    }
+  }
+
+  const finishReview = async () => {
+    if (reviewDraft.comments.length === 0 || reviewPending) return
+
+    setReviewPending(true)
+    setReviewError(undefined)
+
+    try {
+      const result = await window.piWorkspace.composer.finishCodeReview(sessionId)
+      if (result.status === 'rejected') {
+        setReviewError('The code review could not be sent.')
+        return
+      }
+
+      setReviewDraft({ comments: [] })
+      setAnnouncement('Code review sent.')
+    } catch {
+      setReviewError('The code review could not be sent.')
+    } finally {
+      setReviewPending(false)
+    }
   }
 
   const fileCount = snapshot?.repositories.reduce((count, repository) => count + repository.files.length, 0) ?? 0
+  const currentFiles = new Set(
+    snapshot?.repositories.flatMap((repository) =>
+      repository.files.map((file) => fileKey(repository.repositoryId, file.path))
+    ) ?? []
+  )
+  const detachedReviewComments = snapshot
+    ? reviewDraft.comments.filter(({ reference }) => !currentFiles.has(fileKey(reference.repositoryId, reference.path)))
+    : []
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-content-background">
       <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-content-border px-4">
         <div>
           <h2 className="text-sm/5 font-semibold text-content-foreground">Session changes</h2>
-          <p className="text-xs/4 text-content-muted-foreground">{fileCount} changed files</p>
+          <p className="text-xs/4 text-content-muted-foreground">
+            {fileCount} changed {fileCount === 1 ? 'file' : 'files'}
+          </p>
         </div>
-        <Button plain aria-label="Refresh Session changes" onClick={() => void refresh()}>
-          <RefreshCw aria-hidden="true" data-slot="icon" />
-        </Button>
+        <div className="flex items-center gap-1.5">
+          {reviewDraft.comments.length > 0 && (
+            <Button
+              outline
+              className="!px-2.5 !py-1.5 !text-xs/5"
+              disabled={reviewPending}
+              onClick={() => void finishReview()}
+            >
+              {reviewPending ? 'Sending review…' : `Finish review (${reviewDraft.comments.length})`}
+            </Button>
+          )}
+          <Button
+            plain
+            aria-label="Refresh Session changes"
+            disabled={Boolean(stagingFile)}
+            onClick={() => void refresh()}
+          >
+            <RefreshCw aria-hidden="true" data-slot="icon" />
+          </Button>
+        </div>
       </header>
+      {reviewError && (
+        <p className="border-b border-content-border px-4 py-2 text-xs/5 text-form-error-foreground" role="alert">
+          {reviewError}
+        </p>
+      )}
       <div className="min-h-0 flex-1 overflow-y-auto">
+        {detachedReviewComments.length > 0 && (
+          <DetachedReviewComments
+            availableSkills={availableSkills}
+            comments={detachedReviewComments}
+            pending={reviewPending}
+            onRemove={removeReviewComment}
+            onSave={saveReviewComment}
+          />
+        )}
         {!snapshot && !error ? (
           <ResourceMessage icon={LoaderCircle} message="Loading changes…" spinning />
         ) : error ? (
@@ -233,36 +353,92 @@ export function SessionChanges({ sessionId, selection }: SessionChangesPropertie
                 {repository.error && <p className="mt-1 text-xs/4 text-form-error-foreground">{repository.error}</p>}
               </div>
               <ul>
-                {repository.files.map((file) => (
-                  <li key={file.path}>
-                    <button
-                      ref={(button) => {
-                        const key = `${repository.repositoryId}:${file.path}`
-                        if (button) fileButtonRefs.current.set(key, button)
-                        else fileButtonRefs.current.delete(key)
-                      }}
-                      className="flex w-full min-w-0 items-center gap-3 px-4 py-2.5 text-left hover:bg-content-interaction focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-focus-ring"
-                      onClick={() =>
-                        setSelected({
-                          repositoryId: repository.repositoryId,
-                          repositoryName: repository.repositoryName,
-                          file,
-                        })
-                      }
-                      type="button"
-                    >
-                      <FileCode2 aria-hidden="true" className="size-4 shrink-0 text-content-muted-foreground" />
-                      <span className="min-w-0 flex-1 truncate text-xs/5 text-content-foreground" title={file.path}>
-                        {file.path}
-                      </span>
-                      <span className="flex shrink-0 gap-1 text-[10px]/4 font-medium uppercase text-content-muted-foreground">
-                        {file.staged && <span title="Staged">S</span>}
-                        {file.unstaged && <span title="Unstaged">U</span>}
-                        <span>{file.status.slice(0, 1)}</span>
-                      </span>
-                    </button>
-                  </li>
-                ))}
+                {repository.files.map((file) => {
+                  const key = fileKey(repository.repositoryId, file.path)
+                  const expanded = expandedFiles.has(key)
+                  const staging = stagingFile === key
+                  const fullyStaged = file.staged && !file.unstaged
+                  const partiallyStaged = file.staged && file.unstaged
+
+                  return (
+                    <li aria-busy={staging} className="border-t border-content-border first:border-t-0" key={file.path}>
+                      <div className="flex min-w-0 items-center gap-2 px-2 py-1.5 hover:bg-content-interaction focus-within:bg-content-interaction">
+                        <button
+                          aria-expanded={expanded}
+                          className="group flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left focus-visible:outline-2 focus-visible:outline-focus-ring"
+                          onClick={() =>
+                            setExpandedFiles((current) => {
+                              const next = new Set(current)
+                              if (expanded) next.delete(key)
+                              else next.add(key)
+                              return next
+                            })
+                          }
+                          type="button"
+                        >
+                          <ChevronRight
+                            aria-hidden="true"
+                            className="size-3.5 shrink-0 text-content-muted-foreground transition-transform group-aria-expanded:rotate-90 motion-reduce:transition-none"
+                          />
+                          <FileCode2 aria-hidden="true" className="size-4 shrink-0 text-content-muted-foreground" />
+                          <span className="min-w-0 flex-1 truncate text-xs/5 text-content-foreground" title={file.path}>
+                            {file.path}
+                          </span>
+                          <span className="shrink-0 text-[10px]/4 font-medium uppercase text-content-muted-foreground">
+                            {file.status === 'conflicted' ? 'Conflict' : file.status.slice(0, 1)}
+                          </span>
+                        </button>
+                        {staging && (
+                          <LoaderCircle
+                            aria-label={`${fullyStaged ? 'Unstaging' : 'Staging'} ${file.path}`}
+                            className="size-4 shrink-0 animate-spin text-content-muted-foreground motion-reduce:animate-none"
+                          />
+                        )}
+                        <Checkbox
+                          aria-label={
+                            file.status === 'conflicted'
+                              ? `Staging unavailable for conflicted file ${file.path}`
+                              : `${fullyStaged ? 'Unstage' : 'Stage'} ${file.path}`
+                          }
+                          checked={file.staged}
+                          disabled={Boolean(stagingFile) || file.status === 'conflicted'}
+                          indeterminate={partiallyStaged}
+                          onChange={() => void setFileStaged(repository.repositoryId, file, !fullyStaged)}
+                          title={
+                            file.status === 'conflicted' ? 'Resolve the conflict before staging this file.' : undefined
+                          }
+                        />
+                      </div>
+                      {stagingErrors.get(key) && (
+                        <p className="px-4 pb-2 text-xs/5 text-form-error-foreground" role="alert">
+                          {stagingErrors.get(key)}
+                        </p>
+                      )}
+                      {expanded && (
+                        <div className="border-t border-content-border bg-content-subtle-background p-3">
+                          <InlineFileDiff
+                            availableSkills={availableSkills}
+                            editorActive={activeReviewFile === key}
+                            file={file}
+                            refreshRevision={snapshotRevision}
+                            repositoryId={repository.repositoryId}
+                            repositoryName={repository.repositoryName}
+                            reviewComments={reviewDraft.comments.filter(
+                              ({ reference }) =>
+                                reference.repositoryId === repository.repositoryId && reference.path === file.path
+                            )}
+                            reviewPending={reviewPending}
+                            sessionId={sessionId}
+                            onActivateEditor={() => setActiveReviewFile(key)}
+                            onFollowUp={sendCodeFollowUp}
+                            onRemoveComment={removeReviewComment}
+                            onSaveComment={saveReviewComment}
+                          />
+                        </div>
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             </section>
           ))
@@ -273,6 +449,430 @@ export function SessionChanges({ sessionId, selection }: SessionChangesPropertie
       </p>
     </div>
   )
+}
+
+function DetachedReviewComments({
+  availableSkills,
+  comments,
+  pending,
+  onRemove,
+  onSave,
+}: Readonly<{
+  availableSkills: readonly SessionSkill[]
+  comments: readonly SessionCodeReviewComment[]
+  pending: boolean
+  onRemove: (commentId: string) => Promise<void>
+  onSave: (text: string, reference: SessionCodeReference, commentId?: string) => Promise<boolean>
+}>) {
+  const [editingCommentId, setEditingCommentId] = useState<string>()
+
+  return (
+    <section className="space-y-2 border-b border-content-border bg-content-subtle-background p-3">
+      <div>
+        <h3 className="text-xs/5 font-semibold text-content-foreground">Comments on earlier changes</h3>
+        <p className="text-[10px]/4 text-content-muted-foreground">
+          These files are no longer in the current Git changes.
+        </p>
+      </div>
+      {comments.map((comment) => {
+        const editing = editingCommentId === comment.id
+
+        return (
+          <div
+            className="space-y-2 rounded-lg border border-content-border bg-content-background p-2.5"
+            key={comment.id}
+          >
+            <div className="text-[10px]/4 text-content-muted-foreground">
+              <p className="truncate font-medium text-content-foreground">{comment.reference.path}</p>
+              <p className="truncate">
+                {comment.reference.repositoryName} · {hunkLineRange(comment.reference)}
+              </p>
+            </div>
+            <ReviewCommentCard
+              availableSkills={availableSkills}
+              comment={comment}
+              disabled={pending}
+              stale
+              onEdit={() => setEditingCommentId(comment.id)}
+              onRemove={() => {
+                setEditingCommentId(undefined)
+                void onRemove(comment.id)
+              }}
+            />
+            <details>
+              <summary className="w-fit cursor-pointer rounded text-xs/5 font-medium text-content-muted-foreground outline-none hover:text-content-foreground focus-visible:ring-2 focus-visible:ring-focus-ring">
+                View referenced diff
+              </summary>
+              <div className="mt-2">
+                <DiffView content={comment.reference.patch} label={`Referenced diff for ${comment.reference.path}`} />
+              </div>
+            </details>
+            {editing && (
+              <DiffMiniComposer
+                availableSkills={availableSkills}
+                draft={comment.text}
+                label={`Edit comment on ${comment.reference.path}`}
+                pending={pending}
+                referenceLabel={`${comment.reference.path} · ${hunkLineRange(comment.reference)}`}
+                submitLabel="Save"
+                onCancel={() => setEditingCommentId(undefined)}
+                onSubmit={async (text) => {
+                  if (await onSave(text, comment.reference, comment.id)) setEditingCommentId(undefined)
+                }}
+              />
+            )}
+          </div>
+        )
+      })}
+    </section>
+  )
+}
+
+type HunkEditor = Readonly<{
+  mode: 'comment' | 'follow-up'
+  hunk: DiffHunk
+  draft: string
+  commentId?: string
+}>
+
+function InlineFileDiff({
+  availableSkills,
+  editorActive,
+  file,
+  refreshRevision,
+  repositoryId,
+  repositoryName,
+  reviewComments,
+  reviewPending,
+  sessionId,
+  onActivateEditor,
+  onFollowUp,
+  onRemoveComment,
+  onSaveComment,
+}: Readonly<{
+  availableSkills: readonly SessionSkill[]
+  editorActive: boolean
+  file: SessionChangeFile
+  refreshRevision: number
+  repositoryId: string
+  repositoryName: string
+  reviewComments: readonly SessionCodeReviewComment[]
+  reviewPending: boolean
+  sessionId: SessionId
+  onActivateEditor: () => void
+  onFollowUp: (text: string, reference: SessionCodeReference) => Promise<boolean>
+  onRemoveComment: (commentId: string) => Promise<void>
+  onSaveComment: (text: string, reference: SessionCodeReference, commentId?: string) => Promise<boolean>
+}>) {
+  const [diff, setDiff] = useState<SessionFileDiff>()
+  const [loading, setLoading] = useState(true)
+  const [editor, setEditor] = useState<HunkEditor>()
+
+  useEffect(() => {
+    if (!editorActive) setEditor(undefined)
+  }, [editorActive])
+
+  useEffect(() => {
+    let current = true
+    setLoading(true)
+
+    void window.piWorkspace.sessionChanges
+      .loadFileDiff(sessionId, repositoryId, file.path, 'all')
+      .then((next) => {
+        if (current) setDiff(next)
+      })
+      .catch((loadError: unknown) => {
+        if (!current) return
+        setDiff({
+          status: 'unavailable',
+          message: loadError instanceof Error ? loadError.message : 'The diff is unavailable.',
+        })
+      })
+      .finally(() => {
+        if (current) setLoading(false)
+      })
+
+    return () => {
+      current = false
+    }
+  }, [file.path, refreshRevision, repositoryId, sessionId])
+
+  if (loading && !diff) return <ResourceMessage icon={LoaderCircle} message="Loading diff…" spinning />
+  if (!diff?.content)
+    return <ResourceMessage icon={CircleAlert} message={diff?.message ?? 'The diff is unavailable.'} />
+
+  const referenceFor = (hunk: DiffHunk): SessionCodeReference => {
+    const bounded = boundSessionCodeReferencePatch(hunk.patch)
+
+    return {
+      repositoryId,
+      repositoryName,
+      path: file.path,
+      oldStart: hunk.oldStart,
+      oldLines: hunk.oldLines,
+      newStart: hunk.newStart,
+      newLines: hunk.newLines,
+      patch: bounded.patch,
+      ...(bounded.truncated ? { truncated: true } : {}),
+    }
+  }
+  const commentsFor = (hunk: DiffHunk) =>
+    reviewComments.filter(
+      ({ reference }) =>
+        reference.oldStart === hunk.oldStart &&
+        reference.oldLines === hunk.oldLines &&
+        reference.newStart === hunk.newStart &&
+        reference.newLines === hunk.newLines
+    )
+  const hunks = parseUnifiedDiffHunks(diff.content)
+  const unanchoredComments = reviewComments.filter(
+    (comment) => !hunks.some((hunk) => commentsFor(hunk).some((candidate) => candidate.id === comment.id))
+  )
+
+  return (
+    <>
+      {diff.message && <p className="mb-2 text-xs/5 text-content-muted-foreground">{diff.message}</p>}
+      <DiffView
+        content={diff.content}
+        label={`Diff for ${file.path}`}
+        onCommentHunk={(hunk) => {
+          onActivateEditor()
+          setEditor({ mode: 'comment', hunk, draft: '' })
+        }}
+        onFollowUpHunk={(hunk) => {
+          onActivateEditor()
+          setEditor({ mode: 'follow-up', hunk, draft: '' })
+        }}
+        renderHunkFooter={(hunk) => {
+          const comments = commentsFor(hunk)
+          const activeEditor = editor?.hunk.id === hunk.id ? editor : undefined
+          if (comments.length === 0 && !activeEditor) return null
+
+          return (
+            <div className="space-y-2 p-2.5 font-sans">
+              {comments.map((comment) => (
+                <ReviewCommentCard
+                  availableSkills={availableSkills}
+                  comment={comment}
+                  disabled={reviewPending}
+                  key={comment.id}
+                  stale={comment.reference.patch !== hunk.patch}
+                  onEdit={() => {
+                    onActivateEditor()
+                    setEditor({
+                      mode: 'comment',
+                      hunk,
+                      draft: comment.text,
+                      commentId: comment.id,
+                    })
+                  }}
+                  onRemove={() => void onRemoveComment(comment.id)}
+                />
+              ))}
+              {activeEditor && (
+                <DiffMiniComposer
+                  availableSkills={availableSkills}
+                  draft={activeEditor.draft}
+                  label={`${activeEditor.mode === 'comment' ? 'Comment' : 'Follow up'} on ${file.path}`}
+                  pending={reviewPending}
+                  referenceLabel={`${file.path} · ${hunkLineRange(activeEditor.hunk)}`}
+                  submitLabel={activeEditor.mode === 'comment' ? 'Comment' : 'Follow up'}
+                  onCancel={() => setEditor(undefined)}
+                  onSubmit={async (text) => {
+                    const reference = referenceFor(activeEditor.hunk)
+                    const accepted =
+                      activeEditor.mode === 'comment'
+                        ? await onSaveComment(text, reference, activeEditor.commentId)
+                        : await onFollowUp(text, reference)
+                    if (accepted) setEditor(undefined)
+                  }}
+                />
+              )}
+            </div>
+          )
+        }}
+      />
+      {unanchoredComments.length > 0 && (
+        <div className="mt-2 space-y-2 rounded-lg border border-content-border bg-content-background p-2.5">
+          <p className="text-xs/5 font-medium text-content-muted-foreground">Comments on an earlier diff</p>
+          {unanchoredComments.map((comment) => (
+            <ReviewCommentCard
+              availableSkills={availableSkills}
+              comment={comment}
+              disabled={reviewPending}
+              key={comment.id}
+              stale
+              onRemove={() => void onRemoveComment(comment.id)}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+function ReviewCommentCard({
+  availableSkills,
+  comment,
+  disabled,
+  stale = false,
+  onEdit,
+  onRemove,
+}: Readonly<{
+  availableSkills: readonly SessionSkill[]
+  comment: SessionCodeReviewComment
+  disabled: boolean
+  stale?: boolean
+  onEdit?: () => void
+  onRemove: () => void
+}>) {
+  const projected = projectSessionSkillSelections(comment.text)
+  const skills = projected.selections.map(({ name, offset }) => {
+    const available = availableSkills.find((skill) => skill.name === name)
+
+    return {
+      offset,
+      skill: available
+        ? { ...available, availability: 'available' as const }
+        : { name, availability: 'unavailable' as const },
+    }
+  })
+
+  return (
+    <article className="rounded-md border border-content-border bg-content-subtle-background px-3 py-2 text-xs/5 text-content-foreground">
+      <div className="flex items-start gap-2">
+        <p className="min-w-0 flex-1 whitespace-pre-wrap break-words">
+          <SkillMentionText skills={skills} text={projected.text} />
+        </p>
+        <div className="flex shrink-0 items-center gap-0.5">
+          {onEdit && (
+            <button
+              type="button"
+              aria-label="Edit review comment"
+              className="rounded p-1 text-content-muted-foreground hover:bg-content-interaction hover:text-content-foreground focus-visible:outline-2 focus-visible:outline-focus-ring disabled:opacity-50"
+              disabled={disabled}
+              onClick={onEdit}
+            >
+              <Pencil aria-hidden="true" className="size-3.5" />
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Remove review comment"
+            className="rounded p-1 text-content-muted-foreground hover:bg-content-interaction hover:text-content-foreground focus-visible:outline-2 focus-visible:outline-focus-ring disabled:opacity-50"
+            disabled={disabled}
+            onClick={onRemove}
+          >
+            <Trash2 aria-hidden="true" className="size-3.5" />
+          </button>
+        </div>
+      </div>
+      {stale && (
+        <p className="mt-1.5 text-[10px]/4 text-content-muted-foreground">Code changed after this comment was added.</p>
+      )}
+      {comment.reference.truncated && (
+        <p className="mt-1.5 text-[10px]/4 text-content-muted-foreground">Referenced diff was truncated.</p>
+      )}
+    </article>
+  )
+}
+
+function DiffMiniComposer({
+  availableSkills,
+  draft: initialDraft,
+  label,
+  pending,
+  referenceLabel,
+  submitLabel,
+  onCancel,
+  onSubmit,
+}: Readonly<{
+  availableSkills: readonly SessionSkill[]
+  draft: string
+  label: string
+  pending: boolean
+  referenceLabel: string
+  submitLabel: 'Comment' | 'Follow up' | 'Save'
+  onCancel: () => void
+  onSubmit: (text: string) => Promise<void>
+}>) {
+  const descriptionId = useId()
+  const editorHandle = useRef<ComposerEditorHandle>(null)
+  const [draft, setDraft] = useState(initialDraft)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => editorHandle.current?.focus(), [])
+
+  const submit = async () => {
+    const text = (editorHandle.current?.getDraft() ?? draft).trim()
+    if (pending || submitting || text.length === 0) return
+
+    setSubmitting(true)
+    try {
+      await onSubmit(text)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-composer-border bg-composer-background shadow-sm">
+      <div className="flex items-center gap-1.5 border-b border-composer-border px-3 py-1.5 text-[10px]/4 font-medium text-composer-muted-foreground">
+        <FileCode2 aria-hidden="true" className="size-3" />
+        <span className="truncate">{referenceLabel}</span>
+      </div>
+      <ComposerEditor
+        ref={editorHandle}
+        availableSkills={availableSkills}
+        describedBy={descriptionId}
+        draft={draft}
+        label={label}
+        readOnly={pending || submitting}
+        onChange={setDraft}
+        onFocus={() => {}}
+        onSubmit={() => void submit()}
+      />
+      <div className="flex items-center justify-end gap-1.5 border-t border-composer-border px-2.5 py-2">
+        <button
+          type="button"
+          aria-label={`Cancel ${submitLabel.toLowerCase()}`}
+          className="rounded-md p-1.5 text-composer-muted-foreground hover:bg-composer-interaction hover:text-composer-foreground focus-visible:outline-2 focus-visible:outline-focus-ring"
+          disabled={pending || submitting}
+          onClick={onCancel}
+        >
+          <X aria-hidden="true" className="size-3.5" />
+        </button>
+        <Button
+          className="!px-2.5 !py-1.5 !text-xs/5"
+          disabled={pending || submitting || draft.trim().length === 0}
+          onClick={() => void submit()}
+        >
+          {submitting ? `${submitLabel}…` : submitLabel}
+        </Button>
+      </div>
+      <p className="sr-only" id={descriptionId}>
+        Enter to {submitLabel.toLowerCase()}. Shift+Enter for a new line. Skill references are available.
+      </p>
+    </div>
+  )
+}
+
+function hunkLineRange(hunk: Readonly<Pick<DiffHunk, 'oldStart' | 'oldLines' | 'newStart' | 'newLines'>>): string {
+  if (hunk.newLines > 0) {
+    const end = hunk.newStart + hunk.newLines - 1
+    return `+${hunk.newStart}${end === hunk.newStart ? '' : `–${end}`}`
+  }
+
+  const end = hunk.oldStart + Math.max(1, hunk.oldLines) - 1
+  return `-${hunk.oldStart}${end === hunk.oldStart ? '' : `–${end}`}`
+}
+
+function fileKey(repositoryId: string, path: string): string {
+  return `${repositoryId}\0${path}`
+}
+
+function filePathFromKey(key: string): string {
+  return key.slice(key.indexOf('\0') + 1)
 }
 
 function ResourceMessage({

--- a/src/renderer/components/session-changes.tsx
+++ b/src/renderer/components/session-changes.tsx
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ArrowLeft, CircleAlert, FileCode2, GitBranch, LoaderCircle, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui-kit/button'
+import type { SessionId } from '@/src/domain/session'
+import type {
+  SessionChangeFile,
+  SessionChangesSnapshot,
+  SessionFileDiff,
+  SessionFileDiffView,
+} from '@/src/session-changes'
+import { DiffView } from './diff-view'
+
+export type SessionChangesSelection = Readonly<{
+  repositoryId?: string
+  path: string
+  request: number
+}>
+
+type SessionChangesProperties = Readonly<{
+  sessionId: SessionId
+  selection?: SessionChangesSelection
+}>
+
+type SelectedFile = Readonly<{ repositoryId: string; repositoryName: string; file: SessionChangeFile }>
+
+export function SessionChanges({ sessionId, selection }: SessionChangesProperties) {
+  const [snapshot, setSnapshot] = useState<SessionChangesSnapshot>()
+  const [error, setError] = useState<string>()
+  const [selected, setSelected] = useState<SelectedFile>()
+  const [view, setView] = useState<SessionFileDiffView>('all')
+  const [diff, setDiff] = useState<SessionFileDiff>()
+  const [diffLoading, setDiffLoading] = useState(false)
+  const [announcement, setAnnouncement] = useState('')
+  const requestRef = useRef(0)
+  const diffRequestRef = useRef(0)
+  const selectedRef = useRef<SelectedFile | undefined>(undefined)
+  const fileButtonRefs = useRef(new Map<string, HTMLButtonElement>())
+
+  const refresh = useCallback(async () => {
+    const request = ++requestRef.current
+    setError(undefined)
+
+    try {
+      const next = await window.piWorkspace.sessionChanges.getSnapshot(sessionId)
+      if (request !== requestRef.current) return
+
+      setSnapshot(next)
+      const current = selectedRef.current
+      if (current) {
+        const repository = next.repositories.find((candidate) => candidate.repositoryId === current.repositoryId)
+        const file = repository?.files.find((candidate) => candidate.path === current.file.path)
+
+        if (repository && file) {
+          setSelected({ repositoryId: repository.repositoryId, repositoryName: repository.repositoryName, file })
+        } else {
+          setSelected(undefined)
+          setAnnouncement(`${current.file.path} is no longer changed.`)
+        }
+      }
+    } catch (loadError) {
+      if (request !== requestRef.current) return
+      setError(loadError instanceof Error ? loadError.message : 'Changes are unavailable.')
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    setSnapshot(undefined)
+    setSelected(undefined)
+    setDiff(undefined)
+    void refresh()
+
+    const unsubscribe = window.piWorkspace.transcript.subscribe((mutation) => {
+      if (mutation.sessionId === sessionId) void refresh()
+    })
+    const handleFocus = () => void refresh()
+    window.addEventListener('focus', handleFocus)
+
+    return () => {
+      requestRef.current += 1
+      diffRequestRef.current += 1
+      unsubscribe()
+      window.removeEventListener('focus', handleFocus)
+    }
+  }, [refresh, sessionId])
+
+  useEffect(() => {
+    selectedRef.current = selected
+  }, [selected])
+
+  useEffect(() => {
+    if (!selection || !snapshot) return
+
+    for (const repository of snapshot.repositories) {
+      if (selection.repositoryId && selection.repositoryId !== repository.repositoryId) continue
+      const file = repository.files.find((candidate) => candidate.path === selection.path)
+      if (file) {
+        setSelected({ repositoryId: repository.repositoryId, repositoryName: repository.repositoryName, file })
+        setView('all')
+        return
+      }
+    }
+  }, [selection?.request, snapshot])
+
+  useEffect(() => {
+    if (!selected) return
+
+    const request = ++diffRequestRef.current
+    setDiff(undefined)
+    setDiffLoading(true)
+
+    void window.piWorkspace.sessionChanges
+      .loadFileDiff(sessionId, selected.repositoryId, selected.file.path, view)
+      .then((next) => {
+        if (request === diffRequestRef.current) setDiff(next)
+      })
+      .catch((loadError: unknown) => {
+        if (request !== diffRequestRef.current) return
+        setDiff({
+          status: 'unavailable',
+          message: loadError instanceof Error ? loadError.message : 'The diff is unavailable.',
+        })
+      })
+      .finally(() => {
+        if (request === diffRequestRef.current) setDiffLoading(false)
+      })
+  }, [selected?.repositoryId, selected?.file.path, sessionId, view])
+
+  if (selected) {
+    const views: SessionFileDiffView[] = [
+      'all',
+      ...(selected.file.staged ? (['staged'] as const) : []),
+      ...(selected.file.unstaged ? (['unstaged'] as const) : []),
+    ]
+
+    return (
+      <div className="flex min-h-0 flex-1 flex-col bg-content-background">
+        <header className="sticky top-0 z-20 border-b border-content-border bg-content-background px-4 py-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Button
+              plain
+              aria-label="Back to changed files"
+              onClick={() => {
+                const key = `${selected.repositoryId}:${selected.file.path}`
+                setSelected(undefined)
+                window.requestAnimationFrame(() => fileButtonRefs.current.get(key)?.focus())
+              }}
+            >
+              <ArrowLeft aria-hidden="true" data-slot="icon" />
+            </Button>
+            <div className="min-w-0">
+              <h3 className="truncate text-sm/5 font-medium text-content-foreground" title={selected.file.path}>
+                {selected.file.path}
+              </h3>
+              <p className="truncate text-xs/4 text-content-muted-foreground">{selected.repositoryName}</p>
+            </div>
+          </div>
+          {views.length > 1 && (
+            <div aria-label="Diff view" className="mt-3 flex gap-1" role="tablist">
+              {views.map((candidate) => (
+                <button
+                  aria-selected={view === candidate}
+                  className="rounded-md px-2.5 py-1 text-xs/5 capitalize text-content-muted-foreground hover:bg-content-interaction data-[selected=true]:bg-content-interaction-strong data-[selected=true]:text-content-foreground"
+                  data-selected={view === candidate}
+                  key={candidate}
+                  onClick={() => setView(candidate)}
+                  role="tab"
+                  type="button"
+                >
+                  {candidate}
+                </button>
+              ))}
+            </div>
+          )}
+        </header>
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">
+          {diffLoading ? (
+            <ResourceMessage icon={LoaderCircle} message="Loading diff…" spinning />
+          ) : diff?.content ? (
+            <>
+              {diff.message && <p className="mb-2 text-xs/5 text-content-muted-foreground">{diff.message}</p>}
+              <DiffView content={diff.content} label={`Diff for ${selected.file.path}`} />
+            </>
+          ) : (
+            <ResourceMessage icon={CircleAlert} message={diff?.message ?? 'The diff is unavailable.'} />
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const fileCount = snapshot?.repositories.reduce((count, repository) => count + repository.files.length, 0) ?? 0
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-content-background">
+      <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-content-border px-4">
+        <div>
+          <h2 className="text-sm/5 font-semibold text-content-foreground">Session changes</h2>
+          <p className="text-xs/4 text-content-muted-foreground">{fileCount} changed files</p>
+        </div>
+        <Button plain aria-label="Refresh Session changes" onClick={() => void refresh()}>
+          <RefreshCw aria-hidden="true" data-slot="icon" />
+        </Button>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {!snapshot && !error ? (
+          <ResourceMessage icon={LoaderCircle} message="Loading changes…" spinning />
+        ) : error ? (
+          <div className="p-5 text-center">
+            <ResourceMessage icon={CircleAlert} message={error} />
+            <Button className="mt-3" outline onClick={() => void refresh()}>
+              Retry
+            </Button>
+          </div>
+        ) : snapshot?.repositories.length === 0 ? (
+          <ResourceMessage icon={GitBranch} message="No writable Repository has been prepared for this Session." />
+        ) : fileCount === 0 ? (
+          <ResourceMessage icon={GitBranch} message="This Session has no uncommitted changes." />
+        ) : (
+          snapshot?.repositories.map((repository) => (
+            <section className="border-b border-content-border last:border-b-0" key={repository.repositoryId}>
+              <div className="bg-content-subtle-background px-4 py-2.5">
+                <div className="flex items-center gap-2">
+                  <GitBranch aria-hidden="true" className="size-3.5 text-content-muted-foreground" />
+                  <h3 className="truncate text-xs/5 font-semibold text-content-foreground">
+                    {repository.repositoryName}
+                  </h3>
+                </div>
+                <p className="mt-0.5 truncate text-xs/4 text-content-muted-foreground">
+                  {repository.branch.head}
+                  {repository.branch.ahead > 0 ? ` · ${repository.branch.ahead} ahead` : ''}
+                  {repository.branch.behind > 0 ? ` · ${repository.branch.behind} behind` : ''}
+                </p>
+                {repository.error && <p className="mt-1 text-xs/4 text-form-error-foreground">{repository.error}</p>}
+              </div>
+              <ul>
+                {repository.files.map((file) => (
+                  <li key={file.path}>
+                    <button
+                      ref={(button) => {
+                        const key = `${repository.repositoryId}:${file.path}`
+                        if (button) fileButtonRefs.current.set(key, button)
+                        else fileButtonRefs.current.delete(key)
+                      }}
+                      className="flex w-full min-w-0 items-center gap-3 px-4 py-2.5 text-left hover:bg-content-interaction focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-focus-ring"
+                      onClick={() =>
+                        setSelected({
+                          repositoryId: repository.repositoryId,
+                          repositoryName: repository.repositoryName,
+                          file,
+                        })
+                      }
+                      type="button"
+                    >
+                      <FileCode2 aria-hidden="true" className="size-4 shrink-0 text-content-muted-foreground" />
+                      <span className="min-w-0 flex-1 truncate text-xs/5 text-content-foreground" title={file.path}>
+                        {file.path}
+                      </span>
+                      <span className="flex shrink-0 gap-1 text-[10px]/4 font-medium uppercase text-content-muted-foreground">
+                        {file.staged && <span title="Staged">S</span>}
+                        {file.unstaged && <span title="Unstaged">U</span>}
+                        <span>{file.status.slice(0, 1)}</span>
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
+      </div>
+      <p aria-live="polite" className="sr-only">
+        {announcement || `${fileCount} changed files.`}
+      </p>
+    </div>
+  )
+}
+
+function ResourceMessage({
+  icon: Icon,
+  message,
+  spinning = false,
+}: Readonly<{ icon: typeof CircleAlert; message: string; spinning?: boolean }>) {
+  return (
+    <div className="flex min-h-40 flex-col items-center justify-center gap-2 p-5 text-center text-xs/5 text-content-muted-foreground">
+      <Icon aria-hidden="true" className={`size-5 ${spinning ? 'animate-spin motion-reduce:animate-none' : ''}`} />
+      <p>{message}</p>
+    </div>
+  )
+}

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -37,6 +37,7 @@ type SessionContainerProperties = {
   onTogglePin: () => void
   acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
   onStartImplementSession?: (workstreamId: string) => Promise<void>
+  onOpenCurrentDiff?: (repositoryId: string | undefined, path: string) => void
 }
 
 export function SessionContainer({
@@ -62,6 +63,7 @@ export function SessionContainer({
   onTogglePin,
   acceptActionCard = async () => false,
   onStartImplementSession = async () => {},
+  onOpenCurrentDiff = () => {},
 }: SessionContainerProperties) {
   const headingId = useId()
   const transcriptState = useSessionTranscript(session.id)
@@ -143,6 +145,7 @@ export function SessionContainer({
         timelineAnnouncement={transcriptState.announcement}
         timelineError={transcriptState.error}
         onReloadTimeline={transcriptState.reload}
+        onOpenCurrentDiff={onOpenCurrentDiff}
         onActionCard={async (card: SessionActionCard, option) => {
           if (card.kind === 'start-implement-session') {
             await onStartImplementSession(session.workstreamId)

--- a/src/renderer/components/session-messages.test.tsx
+++ b/src/renderer/components/session-messages.test.tsx
@@ -77,6 +77,54 @@ test('renders duplicate message text in canonical entry order', () => {
   assert.equal(view.getAllByText('Same text', { exact: true }).length, 2)
 })
 
+test('renders a finished code review as a grouped transcript card', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking={false}
+      transcript={transcript([
+        {
+          type: 'message',
+          message: {
+            id: 'review-1',
+            role: 'user',
+            text: 'Formatted model context',
+            codeReview: {
+              kind: 'review',
+              comments: [
+                {
+                  id: 'comment-1',
+                  text: 'Keep the previous diff visible.',
+                  createdAt: 1,
+                  reference: {
+                    repositoryId: 'repository-1',
+                    repositoryName: 'Pi Workspace',
+                    path: 'src/session-changes.tsx',
+                    oldStart: 10,
+                    oldLines: 2,
+                    newStart: 10,
+                    newLines: 3,
+                    patch: '@@ -10,2 +10,3 @@\n-old\n+new',
+                  },
+                },
+              ],
+            },
+            state: 'complete',
+            revision: 1,
+          },
+        },
+      ])}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  assert.ok(view.getByText('Finished review'))
+  await user.click(view.getByText('src/session-changes.tsx'))
+  assert.ok(view.getByText('Keep the previous diff visible.'))
+  assert.ok(view.getByText('Lines +10–12'))
+})
+
 test('renders an invoked Skill inline with the user-authored transcript message', () => {
   const view = render(
     <SessionMessages

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -17,6 +17,7 @@ type SessionMessagesProperties = Readonly<{
   timelineError?: string
   onReloadTimeline?: () => void
   onActionCard?: (card: SessionActionCard, option?: 'draft' | 'ready') => Promise<boolean>
+  onOpenCurrentDiff?: (repositoryId: string | undefined, path: string) => void
 }>
 
 type TranscriptEntry =
@@ -38,6 +39,7 @@ export function SessionMessages({
   timelineError,
   onReloadTimeline,
   onActionCard = async () => false,
+  onOpenCurrentDiff = () => {},
 }: SessionMessagesProperties) {
   const isLoading = !canonicalTranscript
   const loadError = Boolean(timelineError)
@@ -124,6 +126,7 @@ export function SessionMessages({
                   key={entry.key}
                   activity={entry.activity}
                   loadDetails={() => window.piWorkspace.transcript.loadActivityDetails(sessionId, entry.activity.id)}
+                  onOpenCurrentDiff={onOpenCurrentDiff}
                 />
               )
             )}

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -3,7 +3,10 @@ import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRe
 import { Button } from '@/components/ui-kit/button'
 import type { SessionId } from '@/src/domain/session'
 import type { SessionActionCard } from '@/src/session-action-cards'
+import type { SessionCodeReview, SessionCodeReviewComment } from '@/src/session-code-review'
+import { projectSessionSkillSelections, type SessionSkillMention } from '@/src/session-skills'
 import { AgentActivityCard } from '@/src/renderer/components/agent-activity-card'
+import { DiffView } from '@/src/renderer/components/diff-view'
 import { SkillMentionText } from '@/src/renderer/components/skill-mention-text'
 import type { AgentActivity, ContextCompaction } from '@/src/session-timeline'
 import type { SessionTranscriptMessage, SessionTranscriptSnapshot } from '@/src/session-transcript'
@@ -425,6 +428,8 @@ function SessionMessageRow({
   onOpenExternalLink: (url: string) => void
 }>) {
   if (message.role === 'user') {
+    if (message.codeReview) return <CodeReviewMessageCard review={message.codeReview} skills={message.skills ?? []} />
+
     const steering = message.delivery === 'steer'
 
     return (
@@ -457,6 +462,101 @@ function SessionMessageRow({
       </Suspense>
     </article>
   )
+}
+
+function CodeReviewMessageCard({
+  review,
+  skills,
+}: Readonly<{ review: SessionCodeReview; skills: readonly SessionSkillMention[] }>) {
+  const files = new Map<string, { repositoryName: string; path: string; comments: SessionCodeReviewComment[] }>()
+
+  review.comments.forEach((comment) => {
+    const reference = comment.reference
+    const key = `${reference.repositoryId}\0${reference.path}`
+    const file = files.get(key) ?? {
+      repositoryName: reference.repositoryName,
+      path: reference.path,
+      comments: [],
+    }
+    file.comments.push(comment)
+    files.set(key, file)
+  })
+
+  return (
+    <article className="ml-auto w-full max-w-[90%] overflow-hidden rounded-xl border border-session-message-person-border bg-session-message-person-background text-session-message-person-foreground">
+      <header className="border-b border-session-message-person-border px-4 py-3">
+        <p className="text-xs/4 font-medium text-content-muted-foreground">
+          {review.kind === 'review' ? 'Finished review' : 'Referenced follow-up'}
+        </p>
+        <p className="mt-0.5 text-sm/5 font-medium">
+          {review.comments.length} {review.comments.length === 1 ? 'comment' : 'comments'} across {files.size}{' '}
+          {files.size === 1 ? 'file' : 'files'}
+        </p>
+      </header>
+      <div className="divide-y divide-session-message-person-border">
+        {[...files.values()].map((file) => (
+          <details key={`${file.repositoryName}-${file.path}`} open={review.kind === 'follow-up'}>
+            <summary className="cursor-pointer list-none px-4 py-2.5 text-xs/5 font-medium outline-none hover:bg-session-interaction focus-visible:ring-2 focus-visible:ring-focus-ring">
+              <span className="block truncate">{file.path}</span>
+              <span className="block truncate font-normal text-content-muted-foreground">
+                {file.repositoryName} · {file.comments.length} {file.comments.length === 1 ? 'comment' : 'comments'}
+              </span>
+            </summary>
+            <div className="space-y-3 border-t border-session-message-person-border px-3 py-3">
+              {file.comments.map((comment) => (
+                <div className="space-y-2" key={comment.id}>
+                  <p className="text-[10px]/4 font-medium uppercase tracking-wide text-content-muted-foreground">
+                    {codeReferenceRange(comment)}
+                  </p>
+                  <p className="whitespace-pre-wrap break-words text-sm/6">
+                    <ReviewCommentText comment={comment} skills={skills} />
+                  </p>
+                  {comment.reference.truncated && (
+                    <p className="text-[10px]/4 text-content-muted-foreground">Referenced diff was truncated.</p>
+                  )}
+                  <details>
+                    <summary className="w-fit cursor-pointer rounded text-xs/5 font-medium text-content-muted-foreground outline-none hover:text-content-foreground focus-visible:ring-2 focus-visible:ring-focus-ring">
+                      View referenced diff
+                    </summary>
+                    <div className="mt-2">
+                      <DiffView content={comment.reference.patch} label={`Referenced diff for ${file.path}`} />
+                    </div>
+                  </details>
+                </div>
+              ))}
+            </div>
+          </details>
+        ))}
+      </div>
+    </article>
+  )
+}
+
+function ReviewCommentText({
+  comment,
+  skills,
+}: Readonly<{ comment: SessionCodeReviewComment; skills: readonly SessionSkillMention[] }>) {
+  const projected = projectSessionSkillSelections(comment.text)
+  const mentions = projected.selections.map(({ name, offset }) => ({
+    offset,
+    skill: skills.find((mention) => mention.skill.name === name)?.skill ?? {
+      name,
+      availability: 'unavailable' as const,
+    },
+  }))
+
+  return <SkillMentionText text={projected.text} skills={mentions} />
+}
+
+function codeReferenceRange(comment: SessionCodeReviewComment): string {
+  const reference = comment.reference
+  if (reference.newLines > 0) {
+    const end = reference.newStart + reference.newLines - 1
+    return `Lines +${reference.newStart}${end === reference.newStart ? '' : `–${end}`}`
+  }
+
+  const end = reference.oldStart + Math.max(1, reference.oldLines) - 1
+  return `Lines -${reference.oldStart}${end === reference.oldStart ? '' : `–${end}`}`
 }
 
 function SessionCompactionSummary({

--- a/src/renderer/components/workstream-context.test.tsx
+++ b/src/renderer/components/workstream-context.test.tsx
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { sessionId } from '@/src/domain/session'
-import type { Workstream } from '@/src/domain/workstream'
+import type { OwnedSession, Workstream } from '@/src/domain/workstream'
+import type { PiWorkspaceBridge } from '@/src/pi-workspace'
 import { createEmptyWorkstreamKnowledge, type WorkstreamKnowledge } from '@/src/domain/workstream-knowledge-transitions'
 import { browser } from '@/src/renderer/test-dom'
 import { WorkstreamContext, WorkstreamContextLayout } from './workstream-context'
@@ -214,6 +215,68 @@ test('does not show structured knowledge for a Quick Session Workstream', () => 
   }
 
   assert.equal(renderToStaticMarkup(<WorkstreamContext workstream={quickWorkstream} />), '')
+})
+
+test('shows Knowledge and Changes in a keyboard-resizable utility dock when space permits', async () => {
+  const originalRect = Object.getOwnPropertyDescriptor(browser.window.HTMLElement.prototype, 'getBoundingClientRect')
+  Object.defineProperty(browser.window.HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      width: 1_000,
+      height: 800,
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 1_000,
+      bottom: 800,
+    }),
+  })
+  Object.defineProperty(browser.window, 'piWorkspace', {
+    configurable: true,
+    value: {
+      sessionChanges: {
+        async getSnapshot(requestedSessionId: ReturnType<typeof sessionId>) {
+          return { sessionId: requestedSessionId, repositories: [] }
+        },
+        async loadFileDiff() {
+          return { status: 'unavailable', message: 'Unavailable.' }
+        },
+      },
+      transcript: { subscribe: () => () => {} },
+    } as unknown as PiWorkspaceBridge,
+  })
+
+  try {
+    const activeSession: OwnedSession = {
+      id: sessionId('session-a'),
+      workstreamId: workstream.id,
+      title: 'Implement changes',
+      mode: 'implement',
+      availability: 'available',
+      repositoryAccess: { kind: 'managed' },
+    }
+    const view = render(
+      <WorkstreamContextLayout workstream={workstream} activeSession={activeSession}>
+        <div>Active Session</div>
+      </WorkstreamContextLayout>,
+      { container: browser.document.body as unknown as HTMLElement }
+    )
+
+    const separator = await waitFor(() => view.getByRole('separator', { name: 'Resize utility panel' }))
+    assert.ok(view.getAllByRole('tab', { name: 'Knowledge' }).length >= 1)
+    assert.ok(view.getAllByRole('tab', { name: 'Changes' }).length >= 1)
+    assert.equal(separator.getAttribute('aria-valuenow'), '420')
+
+    fireEvent.keyDown(separator, { key: 'ArrowLeft' })
+    assert.equal(separator.getAttribute('aria-valuenow'), '440')
+  } finally {
+    if (originalRect) {
+      Object.defineProperty(browser.window.HTMLElement.prototype, 'getBoundingClientRect', originalRect)
+    } else {
+      Reflect.deleteProperty(browser.window.HTMLElement.prototype, 'getBoundingClientRect')
+    }
+  }
 })
 
 test('provides responsive access to the selected Workstream knowledge', async () => {

--- a/src/renderer/components/workstream-context.test.tsx
+++ b/src/renderer/components/workstream-context.test.tsx
@@ -266,10 +266,10 @@ test('shows Knowledge and Changes in a keyboard-resizable utility dock when spac
     const separator = await waitFor(() => view.getByRole('separator', { name: 'Resize utility panel' }))
     assert.ok(view.getAllByRole('tab', { name: 'Knowledge' }).length >= 1)
     assert.ok(view.getAllByRole('tab', { name: 'Changes' }).length >= 1)
-    assert.equal(separator.getAttribute('aria-valuenow'), '420')
+    assert.equal(separator.getAttribute('aria-valuenow'), '520')
 
     fireEvent.keyDown(separator, { key: 'ArrowLeft' })
-    assert.equal(separator.getAttribute('aria-valuenow'), '440')
+    assert.equal(separator.getAttribute('aria-valuenow'), '540')
   } finally {
     if (originalRect) {
       Object.defineProperty(browser.window.HTMLElement.prototype, 'getBoundingClientRect', originalRect)

--- a/src/renderer/components/workstream-context.tsx
+++ b/src/renderer/components/workstream-context.tsx
@@ -1,10 +1,21 @@
-import { useState, type ReactNode } from 'react'
-import { BookOpen, FileCheck2, FolderGit2, FolderOpen, GitBranch, ListOrdered, PanelRight } from 'lucide-react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import {
+  BookOpen,
+  FileCheck2,
+  FolderGit2,
+  FolderOpen,
+  GitBranch,
+  GitCompareArrows,
+  ListOrdered,
+  PanelRight,
+  PanelRightClose,
+} from 'lucide-react'
 import { Button } from '@/components/ui-kit/button'
-import { Dialog, DialogActions, DialogBody, DialogTitle } from '@/components/ui-kit/dialog'
-import type { Workstream } from '@/src/domain/workstream'
+import { Dialog, DialogBody, DialogTitle } from '@/components/ui-kit/dialog'
+import type { OwnedSession, Workstream } from '@/src/domain/workstream'
 import { projectWorkstreamContext } from '@/src/renderer/workstream-context-projection'
 import type { WorkstreamKnowledgeResource } from '@/src/renderer/use-workstream-knowledge'
+import { SessionChanges, type SessionChangesSelection } from './session-changes'
 
 type WorkstreamContextProperties = Readonly<{
   workstream: Workstream
@@ -226,63 +237,231 @@ export function WorkstreamSelectionScreen({ workstream }: WorkstreamContextPrope
 type WorkstreamContextLayoutProperties = Readonly<{
   children: ReactNode
   workstream?: Workstream
+  activeSession?: OwnedSession
+  changesSelection?: SessionChangesSelection
   stateResource?: WorkstreamKnowledgeResource
   onShowWorkingLocation?(workstreamId: string, repositoryId: string): Promise<void>
 }>
 
+type UtilityTab = 'knowledge' | 'changes'
+
 export function WorkstreamContextLayout({
   children,
   workstream,
+  activeSession,
+  changesSelection,
   stateResource,
   onShowWorkingLocation,
 }: WorkstreamContextLayoutProperties) {
-  const [contextOpen, setContextOpen] = useState(false)
   const hasKnowledge = Boolean(workstream?.goal)
+  const hasChanges = Boolean(activeSession && activeSession.mode !== 'brainstorm')
+  const [open, setOpen] = useState(hasKnowledge)
+  const [tab, setTab] = useState<UtilityTab>(hasKnowledge ? 'knowledge' : 'changes')
+  const [dockWidth, setDockWidth] = useState(420)
+  const [layoutWidth, setLayoutWidth] = useState(0)
+  const layoutRef = useRef<HTMLDivElement>(null)
+  const persistent = layoutWidth >= 400 + dockWidth
+
+  useEffect(() => {
+    const element = layoutRef.current
+    if (!element) return
+
+    const updateWidth = () => setLayoutWidth(element.getBoundingClientRect().width)
+    updateWidth()
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateWidth)
+      return () => window.removeEventListener('resize', updateWidth)
+    }
+
+    const observer = new ResizeObserver(updateWidth)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (!changesSelection || !hasChanges) return
+    setTab('changes')
+    setOpen(true)
+  }, [changesSelection?.request, hasChanges])
+
+  useEffect(() => {
+    if (tab === 'knowledge' && !hasKnowledge && hasChanges) setTab('changes')
+    if (tab === 'changes' && !hasChanges && hasKnowledge) setTab('knowledge')
+  }, [hasChanges, hasKnowledge, tab])
+
+  const resizeDock = (nextWidth: number) => {
+    const maximum = Math.min(720, Math.max(320, layoutWidth - 400))
+    setDockWidth(Math.max(320, Math.min(maximum, nextWidth)))
+  }
+
+  const startResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const startX = event.clientX
+    const startWidth = dockWidth
+
+    const move = (moveEvent: PointerEvent) => resizeDock(startWidth + startX - moveEvent.clientX)
+    const stop = () => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', stop)
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', stop)
+  }
+
+  const utility = (
+    <UtilityDock
+      activeSession={activeSession}
+      changesSelection={changesSelection}
+      hasChanges={hasChanges}
+      hasKnowledge={hasKnowledge}
+      onClose={() => setOpen(false)}
+      onSelectTab={setTab}
+      onShowWorkingLocation={onShowWorkingLocation}
+      stateResource={stateResource}
+      tab={tab}
+      workstream={workstream}
+    />
+  )
 
   return (
     <>
-      <div className="flex min-h-0 min-w-0 flex-1">
+      <div ref={layoutRef} className="flex min-h-0 min-w-0 flex-1">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          {hasKnowledge && (
-            <div className="flex items-center justify-between gap-3 border-b border-content-border px-4 py-2 min-[1180px]:hidden">
-              <p className="min-w-0 truncate text-xs/5 text-content-muted-foreground">{workstream?.goal}</p>
-              <Button plain onClick={() => setContextOpen(true)} aria-label="Open Workstream knowledge">
+          {(hasKnowledge || hasChanges) && (!open || !persistent) && (
+            <div className="flex items-center justify-between gap-3 border-b border-content-border px-4 py-2">
+              <p className="min-w-0 truncate text-xs/5 text-content-muted-foreground">
+                {hasKnowledge ? workstream?.goal : activeSession?.title}
+              </p>
+              <Button
+                plain
+                onClick={() => setOpen(true)}
+                aria-label={hasKnowledge && !hasChanges ? 'Open Workstream knowledge' : 'Open utility panel'}
+              >
                 <PanelRight aria-hidden="true" data-slot="icon" />
-                Context
+                {hasChanges ? 'Changes' : 'Knowledge'}
               </Button>
             </div>
           )}
           {children}
         </div>
 
-        {workstream?.goal && (
-          <aside className="hidden w-80 shrink-0 border-l border-content-border min-[1180px]:flex">
-            <WorkstreamContext
-              workstream={workstream}
-              stateResource={stateResource}
-              onShowWorkingLocation={onShowWorkingLocation}
+        {open && persistent && (hasKnowledge || hasChanges) && (
+          <>
+            <div
+              aria-label="Resize utility panel"
+              aria-orientation="vertical"
+              aria-valuemax={720}
+              aria-valuemin={320}
+              aria-valuenow={dockWidth}
+              className="w-1 shrink-0 cursor-col-resize bg-content-border hover:bg-content-hover-border focus-visible:outline-2 focus-visible:outline-focus-ring"
+              onKeyDown={(event) => {
+                if (event.key === 'ArrowLeft') resizeDock(dockWidth + 20)
+                if (event.key === 'ArrowRight') resizeDock(dockWidth - 20)
+              }}
+              onPointerDown={startResize}
+              role="separator"
+              tabIndex={0}
             />
-          </aside>
+            <aside className="flex shrink-0 border-l border-content-border" style={{ width: dockWidth }}>
+              {utility}
+            </aside>
+          </>
         )}
       </div>
 
-      {workstream?.goal && (
-        <Dialog open={contextOpen} onClose={setContextOpen} size="md">
-          <DialogTitle>Workstream knowledge</DialogTitle>
-          <DialogBody className="-mx-8 -mb-8 max-h-[70vh] overflow-y-auto">
-            <WorkstreamContext
-              workstream={workstream}
-              stateResource={stateResource}
-              onShowWorkingLocation={onShowWorkingLocation}
-            />
-          </DialogBody>
-          <DialogActions>
-            <Button plain aria-label="Close Workstream knowledge" onClick={() => setContextOpen(false)}>
-              Close
-            </Button>
-          </DialogActions>
+      {(hasKnowledge || hasChanges) && (
+        <Dialog open={open && !persistent} onClose={setOpen} size="xl" scrollable>
+          <DialogTitle className="sr-only">
+            {hasKnowledge && !hasChanges ? 'Workstream knowledge' : 'Session utility panel'}
+          </DialogTitle>
+          <DialogBody className="-m-8 flex min-h-[70vh] overflow-hidden">{utility}</DialogBody>
         </Dialog>
       )}
     </>
+  )
+}
+
+function UtilityDock({
+  activeSession,
+  changesSelection,
+  hasChanges,
+  hasKnowledge,
+  onClose,
+  onSelectTab,
+  onShowWorkingLocation,
+  stateResource,
+  tab,
+  workstream,
+}: Readonly<{
+  activeSession?: OwnedSession
+  changesSelection?: SessionChangesSelection
+  hasChanges: boolean
+  hasKnowledge: boolean
+  onClose: () => void
+  onSelectTab: (tab: UtilityTab) => void
+  onShowWorkingLocation?: (workstreamId: string, repositoryId: string) => Promise<void>
+  stateResource?: WorkstreamKnowledgeResource
+  tab: UtilityTab
+  workstream?: Workstream
+}>) {
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-content-background">
+      <div className="flex h-12 shrink-0 items-center gap-1 border-b border-content-border px-2" role="tablist">
+        {hasKnowledge && (
+          <UtilityTabButton active={tab === 'knowledge'} icon={BookOpen} onClick={() => onSelectTab('knowledge')}>
+            Knowledge
+          </UtilityTabButton>
+        )}
+        {hasChanges && (
+          <UtilityTabButton active={tab === 'changes'} icon={GitCompareArrows} onClick={() => onSelectTab('changes')}>
+            Changes
+          </UtilityTabButton>
+        )}
+        <Button
+          className="ml-auto"
+          plain
+          aria-label={hasKnowledge && !hasChanges ? 'Close Workstream knowledge' : 'Close utility panel'}
+          onClick={onClose}
+        >
+          <PanelRightClose aria-hidden="true" data-slot="icon" />
+        </Button>
+      </div>
+      {tab === 'knowledge' && workstream?.goal ? (
+        <WorkstreamContext
+          workstream={workstream}
+          stateResource={stateResource}
+          onShowWorkingLocation={onShowWorkingLocation}
+        />
+      ) : tab === 'changes' && activeSession ? (
+        <SessionChanges sessionId={activeSession.id} selection={changesSelection} />
+      ) : null}
+    </div>
+  )
+}
+
+function UtilityTabButton({
+  active,
+  children,
+  icon: Icon,
+  onClick,
+}: Readonly<{
+  active: boolean
+  children: ReactNode
+  icon: typeof BookOpen
+  onClick: () => void
+}>) {
+  return (
+    <button
+      aria-selected={active}
+      className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs/5 text-content-muted-foreground hover:bg-content-interaction data-[active=true]:bg-content-interaction-strong data-[active=true]:text-content-foreground"
+      data-active={active}
+      onClick={onClick}
+      role="tab"
+      type="button"
+    >
+      <Icon aria-hidden="true" className="size-3.5" />
+      {children}
+    </button>
   )
 }

--- a/src/renderer/components/workstream-context.tsx
+++ b/src/renderer/components/workstream-context.tsx
@@ -257,7 +257,7 @@ export function WorkstreamContextLayout({
   const hasChanges = Boolean(activeSession && activeSession.mode !== 'brainstorm')
   const [open, setOpen] = useState(hasKnowledge)
   const [tab, setTab] = useState<UtilityTab>(hasKnowledge ? 'knowledge' : 'changes')
-  const [dockWidth, setDockWidth] = useState(420)
+  const [dockWidth, setDockWidth] = useState(520)
   const [layoutWidth, setLayoutWidth] = useState(0)
   const layoutRef = useRef<HTMLDivElement>(null)
   const persistent = layoutWidth >= 400 + dockWidth

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -38,6 +38,10 @@
   --color-danger-on-background: var(--theme-danger-on-background);
   --color-dropdown-background: var(--theme-dropdown-background);
   --color-dropdown-focus-foreground: var(--theme-dropdown-focus-foreground);
+  --color-diff-addition-background: var(--theme-diff-addition-background);
+  --color-diff-addition-foreground: var(--theme-diff-addition-foreground);
+  --color-diff-deletion-background: var(--theme-diff-deletion-background);
+  --color-diff-deletion-foreground: var(--theme-diff-deletion-foreground);
   --color-overlay-background: var(--theme-overlay-background);
   --color-success-background: var(--theme-success-background);
   --color-success-foreground: var(--theme-success-foreground);
@@ -108,6 +112,10 @@
   --theme-composer-reference-border: var(--theme-content-border);
   --theme-composer-reference-foreground: var(--theme-content-foreground);
   --theme-dropdown-focus-foreground: var(--theme-accent-foreground);
+  --theme-diff-addition-background: color-mix(in oklab, var(--theme-success-foreground) 14%, transparent);
+  --theme-diff-addition-foreground: var(--theme-success-foreground);
+  --theme-diff-deletion-background: color-mix(in oklab, var(--theme-danger-foreground) 14%, transparent);
+  --theme-diff-deletion-foreground: var(--theme-danger-foreground);
   --theme-focus-ring: var(--theme-accent);
   --theme-form-error-foreground: var(--theme-danger-foreground);
   --theme-skill-reference-foreground: var(--theme-link-foreground);

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -12,6 +12,7 @@ import type {
 import { bundledReleaseNotes } from '@/src/release-notes'
 import { SessionArea } from '@/src/renderer/components/session-area'
 import { WorkstreamContextLayout, WorkstreamSelectionScreen } from '@/src/renderer/components/workstream-context'
+import type { SessionChangesSelection } from '@/src/renderer/components/session-changes'
 import { WorkspaceNavigation } from '@/src/renderer/components/workspace-navigation'
 import { WorkstreamNavigation } from '@/src/renderer/components/workstream-navigation'
 import { initialMainContentState, updateMainContent } from '@/src/renderer/main-content'
@@ -84,6 +85,10 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     Readonly<{ sessionId: SessionId; request: number }> | undefined
   >()
   const [sessionTitleEditing, setSessionTitleEditing] = useState<SessionTitleEditing>()
+  const changesRequestNumber = useRef(0)
+  const [changesSelection, setChangesSelection] = useState<
+    (SessionChangesSelection & Readonly<{ sessionId: SessionId }>) | undefined
+  >()
 
   const selectedWorkspaceAuthorityToken = (): SelectedWorkspaceAuthorityToken => {
     const workspaceId = selectedWorkspaceIdRef.current
@@ -187,6 +192,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
   const workstreamLifecycles = new Map(workstreams.map((workstream) => [workstream.id, workstream.lifecycle]))
   const recentSessions = sessions.slice(-5).reverse()
   const visibleSessionIds = getVisibleSessionIds(sessionPinning, workstreamSelection.sessionId)
+  const activeSession = sessions.find((session) => session.id === workstreamSelection.sessionId)
   const visibleSessions = visibleSessionIds.flatMap((ownedSessionId) => {
     const ownedSession = sessions.find((candidate) => candidate.id === ownedSessionId)
     return ownedSession ? [ownedSession] : []
@@ -227,6 +233,12 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     window.requestAnimationFrame(() => {
       setSessionRevealRequest({ sessionId, request })
     })
+  }
+
+  const openCurrentDiff = (sessionId: SessionId, repositoryId: string | undefined, path: string) => {
+    activateSession(sessionId)
+    changesRequestNumber.current += 1
+    setChangesSelection({ sessionId, repositoryId, path, request: changesRequestNumber.current })
   }
 
   const toggleSessionPin = (sessionId: SessionId) => {
@@ -441,6 +453,8 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
     >
       <WorkstreamContextLayout
         workstream={selectedWorkstream}
+        activeSession={activeSession}
+        changesSelection={changesSelection?.sessionId === activeSession?.id ? changesSelection : undefined}
         stateResource={workstreamKnowledgeResource}
         onShowWorkingLocation={(workstreamId, repositoryId) =>
           window.piWorkspace.workstreams.showWorkingLocation(workstreamId, repositoryId)
@@ -481,6 +495,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             onToggleSessionPin={toggleSessionPin}
             acceptActionCard={window.piWorkspace.transcript.acceptActionCard}
             onStartImplementSession={(workstreamId) => createSession(workstreamId, { mode: 'implement' })}
+            onOpenCurrentDiff={openCurrentDiff}
           />
         ) : selectedWorkstream?.goal ? (
           <WorkstreamSelectionScreen workstream={selectedWorkstream} />

--- a/src/session-changes-ipc.test.ts
+++ b/src/session-changes-ipc.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { sessionId } from '@/src/domain/session'
-import { parseSessionFileDiffRequest } from './session-changes-ipc'
+import { parseSessionFileDiffRequest, parseSessionFileStageRequest } from './session-changes-ipc'
 
 const id = sessionId('session-a')
 
@@ -30,6 +30,31 @@ test('accepts only bounded Session file diff requests', () => {
   )
   assert.equal(
     parseSessionFileDiffRequest({ sessionId: id, repositoryId: 'repository-a', path: 'src/file.ts', view: 'raw' }),
+    undefined
+  )
+})
+
+test('accepts only explicit Session file staging requests', () => {
+  assert.deepEqual(
+    parseSessionFileStageRequest({
+      sessionId: id,
+      repositoryId: 'repository-a',
+      path: 'src/file.ts',
+      staged: true,
+    }),
+    { sessionId: id, repositoryId: 'repository-a', path: 'src/file.ts', staged: true }
+  )
+  assert.equal(
+    parseSessionFileStageRequest({ sessionId: id, repositoryId: 'repository-a', path: 'src/file.ts' }),
+    undefined
+  )
+  assert.equal(
+    parseSessionFileStageRequest({
+      sessionId: id,
+      repositoryId: 'repository-a',
+      path: 'src/file.ts',
+      staged: 'yes',
+    }),
     undefined
   )
 })

--- a/src/session-changes-ipc.test.ts
+++ b/src/session-changes-ipc.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { sessionId } from '@/src/domain/session'
+import { parseSessionFileDiffRequest } from './session-changes-ipc'
+
+const id = sessionId('session-a')
+
+test('accepts only bounded Session file diff requests', () => {
+  assert.deepEqual(
+    parseSessionFileDiffRequest({
+      sessionId: id,
+      repositoryId: 'repository-a',
+      path: 'src/file.ts',
+      view: 'staged',
+    }),
+    { sessionId: id, repositoryId: 'repository-a', path: 'src/file.ts', view: 'staged' }
+  )
+  assert.equal(
+    parseSessionFileDiffRequest({ sessionId: id, repositoryId: '', path: 'src/file.ts', view: 'all' }),
+    undefined
+  )
+  assert.equal(
+    parseSessionFileDiffRequest({
+      sessionId: id,
+      repositoryId: 'repository-a',
+      path: 'x'.repeat(8_193),
+      view: 'all',
+    }),
+    undefined
+  )
+  assert.equal(
+    parseSessionFileDiffRequest({ sessionId: id, repositoryId: 'repository-a', path: 'src/file.ts', view: 'raw' }),
+    undefined
+  )
+})

--- a/src/session-changes-ipc.ts
+++ b/src/session-changes-ipc.ts
@@ -1,0 +1,39 @@
+import { isSessionId, type SessionId } from '@/src/domain/session'
+import type { SessionFileDiffView } from '@/src/session-changes'
+
+export const sessionChangesIpcChannels = {
+  getSnapshot: 'session-changes:get-snapshot',
+  loadFileDiff: 'session-changes:load-file-diff',
+} as const
+
+export function parseSessionChangesRequest(value: unknown): Readonly<{ sessionId: SessionId }> | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const sessionId = (value as { sessionId?: unknown }).sessionId
+  return isSessionId(sessionId) ? { sessionId } : undefined
+}
+
+export function parseSessionFileDiffRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionId; repositoryId: string; path: string; view: SessionFileDiffView }> | undefined {
+  const request = parseSessionChangesRequest(value)
+  if (!request) return undefined
+
+  const repositoryId = (value as { repositoryId?: unknown }).repositoryId
+  const path = (value as { path?: unknown }).path
+  const view = (value as { view?: unknown }).view
+
+  if (
+    typeof repositoryId !== 'string' ||
+    repositoryId.length === 0 ||
+    repositoryId.length > 256 ||
+    typeof path !== 'string' ||
+    path.length === 0 ||
+    path.length > 8_192 ||
+    (view !== 'all' && view !== 'staged' && view !== 'unstaged')
+  ) {
+    return undefined
+  }
+
+  return { ...request, repositoryId, path, view }
+}

--- a/src/session-changes-ipc.ts
+++ b/src/session-changes-ipc.ts
@@ -4,6 +4,7 @@ import type { SessionFileDiffView } from '@/src/session-changes'
 export const sessionChangesIpcChannels = {
   getSnapshot: 'session-changes:get-snapshot',
   loadFileDiff: 'session-changes:load-file-diff',
+  setFileStaged: 'session-changes:set-file-staged',
 } as const
 
 export function parseSessionChangesRequest(value: unknown): Readonly<{ sessionId: SessionId }> | undefined {
@@ -16,12 +17,33 @@ export function parseSessionChangesRequest(value: unknown): Readonly<{ sessionId
 export function parseSessionFileDiffRequest(
   value: unknown
 ): Readonly<{ sessionId: SessionId; repositoryId: string; path: string; view: SessionFileDiffView }> | undefined {
+  const request = parseSessionFileRequest(value)
+  if (!request) return undefined
+
+  const view = (value as { view?: unknown }).view
+  if (view !== 'all' && view !== 'staged' && view !== 'unstaged') return undefined
+
+  return { ...request, view }
+}
+
+export function parseSessionFileStageRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionId; repositoryId: string; path: string; staged: boolean }> | undefined {
+  const request = parseSessionFileRequest(value)
+  if (!request) return undefined
+
+  const staged = (value as { staged?: unknown }).staged
+  return typeof staged === 'boolean' ? { ...request, staged } : undefined
+}
+
+function parseSessionFileRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionId; repositoryId: string; path: string }> | undefined {
   const request = parseSessionChangesRequest(value)
   if (!request) return undefined
 
   const repositoryId = (value as { repositoryId?: unknown }).repositoryId
   const path = (value as { path?: unknown }).path
-  const view = (value as { view?: unknown }).view
 
   if (
     typeof repositoryId !== 'string' ||
@@ -29,11 +51,10 @@ export function parseSessionFileDiffRequest(
     repositoryId.length > 256 ||
     typeof path !== 'string' ||
     path.length === 0 ||
-    path.length > 8_192 ||
-    (view !== 'all' && view !== 'staged' && view !== 'unstaged')
+    path.length > 8_192
   ) {
     return undefined
   }
 
-  return { ...request, repositoryId, path, view }
+  return { ...request, repositoryId, path }
 }

--- a/src/session-changes.ts
+++ b/src/session-changes.ts
@@ -1,0 +1,56 @@
+import type { SessionId } from '@/src/domain/session'
+
+export type SessionChangeFileStatus =
+  'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'untracked' | 'conflicted'
+
+export type SessionChangeFile = Readonly<{
+  path: string
+  previousPath?: string
+  status: SessionChangeFileStatus
+  staged: boolean
+  unstaged: boolean
+  additions?: number
+  deletions?: number
+  binary?: boolean
+}>
+
+export type SessionChangesBranch = Readonly<{
+  head: string
+  upstream?: string
+  ahead: number
+  behind: number
+  detached: boolean
+  unborn: boolean
+}>
+
+export type SessionRepositoryChanges = Readonly<{
+  repositoryId: string
+  repositoryName: string
+  branch: SessionChangesBranch
+  files: readonly SessionChangeFile[]
+  error?: string
+}>
+
+export type SessionChangesSnapshot = Readonly<{
+  sessionId: SessionId
+  repositories: readonly SessionRepositoryChanges[]
+}>
+
+export type SessionFileDiffView = 'all' | 'staged' | 'unstaged'
+
+export type SessionFileDiff = Readonly<{
+  status: 'available' | 'binary' | 'too-large' | 'unavailable'
+  content?: string
+  truncated?: boolean
+  message?: string
+}>
+
+export interface SessionChangesBridge {
+  getSnapshot(sessionId: SessionId): Promise<SessionChangesSnapshot>
+  loadFileDiff(
+    sessionId: SessionId,
+    repositoryId: string,
+    path: string,
+    view: SessionFileDiffView
+  ): Promise<SessionFileDiff>
+}

--- a/src/session-changes.ts
+++ b/src/session-changes.ts
@@ -53,4 +53,10 @@ export interface SessionChangesBridge {
     path: string,
     view: SessionFileDiffView
   ): Promise<SessionFileDiff>
+  setFileStaged(
+    sessionId: SessionId,
+    repositoryId: string,
+    path: string,
+    staged: boolean
+  ): Promise<SessionChangesSnapshot>
 }

--- a/src/session-code-review.test.ts
+++ b/src/session-code-review.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  boundSessionCodeReferencePatch,
+  formatSessionCodeReviewText,
+  maximumSessionCodeReferencePatchLength,
+  parseSessionCodeReview,
+  projectSessionCodeReviewDraft,
+  type SessionCodeReview,
+} from './session-code-review'
+
+const review: SessionCodeReview = {
+  kind: 'review',
+  comments: [
+    {
+      id: 'comment-1',
+      text: '/skill:tdd Keep the previous diff visible while refreshing.',
+      createdAt: 1,
+      reference: {
+        repositoryId: 'repository-1',
+        repositoryName: 'Pi Workspace',
+        path: 'src/renderer/components/session-changes.tsx',
+        oldStart: 184,
+        oldLines: 3,
+        newStart: 184,
+        newLines: 4,
+        patch: '@@ -184,3 +184,4 @@\n const diff = current\n+setRefreshing(true)',
+      },
+    },
+  ],
+}
+
+describe('Session code reviews', () => {
+  test('parses a bounded structured review and formats model-readable referenced context', () => {
+    assert.deepEqual(parseSessionCodeReview(review), review)
+
+    assert.equal(
+      formatSessionCodeReviewText(review),
+      'Code review with 1 comment across 1 file.\n\n' +
+        '## Pi Workspace · src/renderer/components/session-changes.tsx · +184–187\n\n' +
+        '~~~~diff\n' +
+        '@@ -184,3 +184,4 @@\n const diff = current\n+setRefreshing(true)\n' +
+        '~~~~\n\n' +
+        '/skill:tdd Keep the previous diff visible while refreshing.'
+    )
+  })
+
+  test('restores the latest unfinished comments from append-only records', () => {
+    assert.deepEqual(
+      projectSessionCodeReviewDraft([
+        { type: 'code-review-comment', comment: review.comments[0]! },
+        {
+          type: 'code-review-comment',
+          comment: { ...review.comments[0]!, text: 'Updated comment' },
+        },
+        { type: 'code-review-comments-cleared', commentIds: ['comment-1'] },
+        {
+          type: 'code-review-comment',
+          comment: { ...review.comments[0]!, id: 'comment-2', text: 'Still pending' },
+        },
+      ]),
+      { comments: [{ ...review.comments[0]!, id: 'comment-2', text: 'Still pending' }] }
+    )
+  })
+
+  test('does not restore comments already included in an accepted review message', () => {
+    assert.deepEqual(
+      projectSessionCodeReviewDraft([
+        { type: 'code-review-comment', comment: review.comments[0]! },
+        {
+          type: 'code-review-message',
+          review,
+          text: formatSessionCodeReviewText(review),
+          acceptedAt: 2,
+        },
+      ]),
+      { comments: [] }
+    )
+  })
+
+  test('rejects a follow-up containing more than one referenced comment', () => {
+    assert.equal(
+      parseSessionCodeReview({ ...review, kind: 'follow-up', comments: [...review.comments, ...review.comments] }),
+      undefined
+    )
+  })
+
+  test('creates an explicitly truncated immutable snapshot for an oversized hunk', () => {
+    const bounded = boundSessionCodeReferencePatch('x'.repeat(maximumSessionCodeReferencePatchLength + 1))
+
+    assert.equal(bounded.patch.length, maximumSessionCodeReferencePatchLength)
+    assert.equal(bounded.truncated, true)
+    assert.match(bounded.patch, /Referenced diff truncated\.$/)
+  })
+
+  test('rejects unsafe Repository-relative paths and oversized patches', () => {
+    assert.equal(
+      parseSessionCodeReview({
+        ...review,
+        comments: [
+          {
+            ...review.comments[0],
+            reference: { ...review.comments[0]!.reference, path: '../outside.ts' },
+          },
+        ],
+      }),
+      undefined
+    )
+
+    assert.equal(
+      parseSessionCodeReview({
+        ...review,
+        comments: [
+          {
+            ...review.comments[0],
+            reference: { ...review.comments[0]!.reference, patch: 'x'.repeat(50_001) },
+          },
+        ],
+      }),
+      undefined
+    )
+  })
+})

--- a/src/session-code-review.ts
+++ b/src/session-code-review.ts
@@ -1,0 +1,236 @@
+export const maximumSessionCodeReviewComments = 50
+export const maximumSessionCodeReviewCommentLength = 20_000
+export const maximumSessionCodeReferencePatchLength = 50_000
+export const maximumSessionCodeReviewLength = 200_000
+const maximumSessionCodeReviewIdLength = 256
+const maximumSessionCodeReviewRepositoryNameLength = 256
+const maximumSessionCodeReviewPathLength = 8_192
+
+export type SessionCodeReference = Readonly<{
+  repositoryId: string
+  repositoryName: string
+  path: string
+  oldStart: number
+  oldLines: number
+  newStart: number
+  newLines: number
+  patch: string
+  truncated?: boolean
+}>
+
+export type SessionCodeReviewComment = Readonly<{
+  id: string
+  text: string
+  reference: SessionCodeReference
+  createdAt: number
+}>
+
+export type SessionCodeReview = Readonly<{
+  kind: 'follow-up' | 'review'
+  comments: readonly SessionCodeReviewComment[]
+}>
+
+export type SessionCodeReviewDraft = Readonly<{
+  comments: readonly SessionCodeReviewComment[]
+}>
+
+export type SessionCodeReviewCommentInput = Readonly<{
+  commentId?: string
+  text: string
+  reference: SessionCodeReference
+}>
+
+export function boundSessionCodeReferencePatch(patch: string): Readonly<{ patch: string; truncated: boolean }> {
+  if (patch.length <= maximumSessionCodeReferencePatchLength) return { patch, truncated: false }
+
+  const marker = '\n… Referenced diff truncated.'
+  return {
+    patch: `${patch.slice(0, maximumSessionCodeReferencePatchLength - marker.length)}${marker}`,
+    truncated: true,
+  }
+}
+
+export type SessionCodeReviewRecord =
+  | Readonly<{ type: 'code-review-comment'; comment: SessionCodeReviewComment }>
+  | Readonly<{ type: 'code-review-comment-removed'; commentId: string }>
+  | Readonly<{ type: 'code-review-comments-cleared'; commentIds: readonly string[] }>
+  | Readonly<{
+      type: 'code-review-message'
+      review: SessionCodeReview
+      text: string
+      acceptedAt: number
+    }>
+
+export function projectSessionCodeReviewDraft(records: readonly SessionCodeReviewRecord[]): SessionCodeReviewDraft {
+  const comments = new Map<string, SessionCodeReviewComment>()
+
+  for (const record of records) {
+    if (record.type === 'code-review-comment') comments.set(record.comment.id, record.comment)
+    if (record.type === 'code-review-comment-removed') comments.delete(record.commentId)
+    if (record.type === 'code-review-comments-cleared') {
+      record.commentIds.forEach((commentId) => comments.delete(commentId))
+    }
+    if (record.type === 'code-review-message' && record.review.kind === 'review') {
+      record.review.comments.forEach((comment) => comments.delete(comment.id))
+    }
+  }
+
+  return { comments: [...comments.values()].sort((left, right) => left.createdAt - right.createdAt) }
+}
+
+export function parseSessionCodeReview(value: unknown): SessionCodeReview | undefined {
+  if (!isRecord(value) || (value.kind !== 'follow-up' && value.kind !== 'review') || !Array.isArray(value.comments)) {
+    return undefined
+  }
+  if (
+    value.comments.length === 0 ||
+    value.comments.length > maximumSessionCodeReviewComments ||
+    (value.kind === 'follow-up' && value.comments.length !== 1)
+  ) {
+    return undefined
+  }
+
+  const comments = value.comments.map(parseSessionCodeReviewComment)
+  if (comments.some((comment) => !comment)) return undefined
+
+  const review: SessionCodeReview = { kind: value.kind, comments: comments as SessionCodeReviewComment[] }
+  return formatSessionCodeReviewText(review).length <= maximumSessionCodeReviewLength ? review : undefined
+}
+
+export function parseSessionCodeReviewCommentInput(value: unknown): SessionCodeReviewCommentInput | undefined {
+  if (!isRecord(value)) return undefined
+  if (value.commentId !== undefined && !isBoundedString(value.commentId, maximumSessionCodeReviewIdLength)) {
+    return undefined
+  }
+  if (!isReviewText(value.text)) return undefined
+
+  const reference = parseSessionCodeReference(value.reference)
+  if (!reference) return undefined
+
+  return {
+    commentId: value.commentId as string | undefined,
+    text: value.text,
+    reference,
+  }
+}
+
+export function formatSessionCodeReviewText(
+  review: SessionCodeReview,
+  formatCommentText: (text: string, outputOffset: number) => string = (text) => text
+): string {
+  const fileCount = new Set(review.comments.map(({ reference }) => `${reference.repositoryId}\0${reference.path}`)).size
+  const heading =
+    review.kind === 'review'
+      ? `Code review with ${review.comments.length} ${review.comments.length === 1 ? 'comment' : 'comments'} across ${fileCount} ${fileCount === 1 ? 'file' : 'files'}.`
+      : 'Follow-up about a referenced code change.'
+  let output = heading
+
+  for (const comment of review.comments) {
+    const reference = comment.reference
+    const context = [
+      `## ${reference.repositoryName} · ${reference.path} · ${formatLineRange(reference)}`,
+      `~~~~diff\n${reference.patch}\n~~~~`,
+    ].join('\n\n')
+
+    output += `\n\n${context}\n\n`
+    output += formatCommentText(comment.text, output.length)
+  }
+
+  return output
+}
+
+function formatLineRange(reference: SessionCodeReference): string {
+  if (reference.newLines > 0) {
+    const end = reference.newStart + reference.newLines - 1
+    return `+${reference.newStart}${end === reference.newStart ? '' : `–${end}`}`
+  }
+
+  const end = reference.oldStart + Math.max(1, reference.oldLines) - 1
+  return `-${reference.oldStart}${end === reference.oldStart ? '' : `–${end}`}`
+}
+
+function parseSessionCodeReviewComment(value: unknown): SessionCodeReviewComment | undefined {
+  if (
+    !isRecord(value) ||
+    !isBoundedString(value.id, maximumSessionCodeReviewIdLength) ||
+    !isReviewText(value.text) ||
+    !isTimestamp(value.createdAt)
+  ) {
+    return undefined
+  }
+
+  const reference = parseSessionCodeReference(value.reference)
+  if (!reference) return undefined
+
+  return { id: value.id, text: value.text, reference, createdAt: value.createdAt }
+}
+
+function parseSessionCodeReference(value: unknown): SessionCodeReference | undefined {
+  if (
+    !isRecord(value) ||
+    !isBoundedString(value.repositoryId, maximumSessionCodeReviewIdLength) ||
+    !isBoundedString(value.repositoryName, maximumSessionCodeReviewRepositoryNameLength) ||
+    !isSafeRelativePath(value.path) ||
+    !isCount(value.oldStart) ||
+    !isCount(value.oldLines) ||
+    !isCount(value.newStart) ||
+    !isCount(value.newLines) ||
+    typeof value.patch !== 'string' ||
+    value.patch.length === 0 ||
+    value.patch.length > maximumSessionCodeReferencePatchLength ||
+    (value.truncated !== undefined && typeof value.truncated !== 'boolean')
+  ) {
+    return undefined
+  }
+
+  return {
+    repositoryId: value.repositoryId,
+    repositoryName: value.repositoryName,
+    path: value.path,
+    oldStart: value.oldStart,
+    oldLines: value.oldLines,
+    newStart: value.newStart,
+    newLines: value.newLines,
+    patch: value.patch,
+    ...(value.truncated === true ? { truncated: true } : {}),
+  }
+}
+
+function isReviewText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && value.length <= maximumSessionCodeReviewCommentLength
+}
+
+function isSafeRelativePath(value: unknown): value is string {
+  if (
+    !isBoundedString(value, maximumSessionCodeReviewPathLength) ||
+    value.startsWith('/') ||
+    value.startsWith('\\') ||
+    value.includes('\\') ||
+    value.includes('\0')
+  ) {
+    return false
+  }
+
+  const parts = value.split('/')
+  return parts.every((part) => part.length > 0 && part !== '.' && part !== '..')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function isBoundedString(value: unknown, maximumLength: number): value is string {
+  return isNonEmptyString(value) && value.length <= maximumLength
+}
+
+function isCount(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function isTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}

--- a/src/session-timeline.ts
+++ b/src/session-timeline.ts
@@ -34,6 +34,7 @@ export type InspectedFileArtifact = Readonly<{
 export type FileChangeArtifact = Readonly<{
   type: 'file-change'
   path: string
+  repositoryId?: string
   additions?: number
   deletions?: number
 }>
@@ -108,6 +109,14 @@ export type SessionWorkingStateSnapshot = Readonly<{
   isWorking: boolean
 }>
 
+export type ActivityMutationPreview = Readonly<{
+  kind: 'diff' | 'code'
+  path: string
+  repositoryId?: string
+  content: string
+  truncated: boolean
+}>
+
 export type ActivityOperationDetail = Readonly<{
   toolCallId: string
   label: string
@@ -115,6 +124,7 @@ export type ActivityOperationDetail = Readonly<{
   inputPreview?: string
   input: string
   output?: string
+  preview?: ActivityMutationPreview
   truncated: boolean
 }>
 

--- a/src/session-timeline.ts
+++ b/src/session-timeline.ts
@@ -1,5 +1,6 @@
 import type { SessionId } from '@/src/domain/session'
 import type { SessionSkillMention } from '@/src/session-skills'
+import type { SessionCodeReview } from '@/src/session-code-review'
 
 export const agentActivityKinds = [
   'exploration',
@@ -22,6 +23,7 @@ export type ConversationEntry = Readonly<{
   role: 'user' | 'assistant'
   text: string
   skills?: readonly SessionSkillMention[]
+  codeReview?: SessionCodeReview
   delivery?: 'steer'
   timestamp: number
 }>

--- a/src/session-transcript.ts
+++ b/src/session-transcript.ts
@@ -2,6 +2,7 @@ import type { SessionId } from '@/src/domain/session'
 import type { QueuedFollowUp } from '@/src/queued-follow-up'
 import type { SessionSkillMention } from '@/src/session-skills'
 import type { SessionActionCard } from '@/src/session-action-cards'
+import type { SessionCodeReview } from '@/src/session-code-review'
 
 const allowedExternalUrlProtocols = new Set(['http:', 'https:', 'mailto:'])
 export const maximumExternalUrlLength = 8_192
@@ -28,6 +29,7 @@ export type SessionTranscriptMessage = Readonly<{
   role: 'user' | 'assistant'
   text: string
   skills?: readonly SessionSkillMention[]
+  codeReview?: SessionCodeReview
   delivery?: 'steer'
   state: 'complete' | 'streaming'
   revision: number


### PR DESCRIPTION
## Summary

- add Session-authorized Git status and lazy diff inspection, immutable Agent Activity mutation previews, and a responsive Knowledge/Changes utility dock
- show wrapped, independently expandable file diffs with accessible whole-file staged, unstaged, partial, and conflict states
- add Skill-aware hunk comments and immediate referenced follow-ups, persistent Finish review batching, bounded immutable snapshots, queued summaries, and structured transcript cards
- harden review replay, stale-comment management, and Skill expansion while extracting the review draft runtime lifecycle

## Related issue

None.

## Validation

- [x] `bun run check` — formatting, ESLint, TypeScript, 594 tests, and production build passed
- [x] Focused tests: `bun test src/session-code-review.test.ts src/main/session-transcript-runtime.test.ts src/renderer/components/session-changes.test.tsx`
- [x] `bun run security:scan` — no leaks or unfiltered vulnerabilities found
- [x] `git diff --check` and `git diff --cached --check`

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed; no documentation change is required for this interface-only feature.
- [x] No new dependencies, copied/generated material, assets, or license implications are introduced.
- [x] I have read and will follow the Code of Conduct.
