### PR TITLE
feat: make Session action cards dismissible

### DIFF
--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -359,8 +359,27 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       async acceptActionCard() {
         return false
       },
-      async dismissActionCard() {
-        return false
+      async dismissActionCard(sessionId, actionCardId) {
+        const transcript = transcriptSnapshot(sessionId)
+        const card = transcript.actionCards?.find(
+          (candidate) => candidate.id === actionCardId && candidate.status === 'available'
+        )
+        if (!card) return false
+
+        const snapshot = {
+          ...transcript,
+          revision: transcript.revision + 1,
+          actionCards: transcript.actionCards?.map((candidate) =>
+            candidate.id === actionCardId ? { ...candidate, status: 'dismissed' as const } : candidate
+          ),
+        }
+        transcriptsBySessionId[sessionId] = snapshot
+
+        for (const listener of transcriptListeners) {
+          listener({ sessionId, revision: snapshot.revision, snapshot })
+        }
+
+        return true
       },
       async openExternalLink() {},
       subscribe(listener) {

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -209,6 +209,9 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
       async acceptActionCard() {
         return false
       },
+      async dismissActionCard() {
+        return false
+      },
       async openExternalLink() {},
       subscribe(listener) {
         transcriptListeners.add(listener)

--- a/src/demo/demo-renderer.test.tsx
+++ b/src/demo/demo-renderer.test.tsx
@@ -3,6 +3,15 @@ import { test } from 'node:test'
 import { act, fireEvent, waitFor } from '@testing-library/react'
 import { createDemoBridge } from '@/src/demo/demo-bridge'
 import { getDemoScenario, getDemoScenarioPresentation } from '@/src/demo/demo-scenarios'
+import { sessionId } from '@/src/domain/session'
+
+test('the demo bridge dismisses an available action card', async () => {
+  const bridge = createDemoBridge('workstream')
+  const implementationSessionId = sessionId('offline-implementation')
+
+  assert.equal(await bridge.transcript.dismissActionCard(implementationSessionId, 'prepare-offline-pull-request'), true)
+  assert.equal((await bridge.transcript.getSnapshot(implementationSessionId)).actionCards?.[0]?.status, 'dismissed')
+})
 
 test('the multi-Session demo includes empty, half-full, and full context windows', () => {
   const scenario = getDemoScenario('multi-session')

--- a/src/demo/demo-scenarios.test.ts
+++ b/src/demo/demo-scenarios.test.ts
@@ -2,6 +2,23 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { getDemoScenario, getDemoScenarioPresentation } from './demo-scenarios'
 
+test('provides a pull-request action card in the workstream scenario', () => {
+  const scenario = getDemoScenario('workstream')
+  const transcript = scenario.transcriptsBySessionId['offline-implementation']
+
+  assert.deepEqual(transcript?.actionCards, [
+    {
+      id: 'prepare-offline-pull-request',
+      sessionId: 'offline-implementation',
+      kind: 'prepare-pull-request',
+      title: 'Prepare the pull request',
+      description: 'The offline editing changes are ready for review.',
+      status: 'available',
+      createdAt: Date.UTC(2026, 6, 15, 10, 22, 18),
+    },
+  ])
+})
+
 test('provides an active Session with transcript-visible steering and queued follow-ups', () => {
   const scenario = getDemoScenario('queued-messages')
   const transcript = scenario.transcriptsBySessionId['queued-messages']

--- a/src/demo/demo-scenarios.ts
+++ b/src/demo/demo-scenarios.ts
@@ -330,7 +330,7 @@ const workstreamScenario: DemoScenario = {
     },
     [implementationSessionId]: {
       sessionId: implementationSessionId,
-      revision: 6,
+      revision: 7,
       isWorking: false,
       contextUsage: demoContextUsage(0.5),
       runs: [
@@ -341,6 +341,17 @@ const workstreamScenario: DemoScenario = {
           activityIds: ['inspect-save-pipeline', 'implement-offline-editing', 'validate-offline-editing'],
           startedAt: implementationRunStartedAt,
           completedAt: implementationRunStartedAt + 438_000,
+        },
+      ],
+      actionCards: [
+        {
+          id: 'prepare-offline-pull-request',
+          sessionId: implementationSessionId,
+          kind: 'prepare-pull-request',
+          title: 'Prepare the pull request',
+          description: 'The offline editing changes are ready for review.',
+          status: 'available',
+          createdAt: implementationRunStartedAt + 438_000,
         },
       ],
       entries: [

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -53,7 +53,7 @@ import {
 import { broadcastToTrustedRenderers, handleTrustedIpc } from '@/src/main/trusted-ipc'
 import { isAllowedExternalUrl } from '@/src/session-transcript'
 import {
-  parseActionCardAcceptanceRequest,
+  parseActionCardStatusRequest,
   parseSessionTranscriptRequest,
   parseTranscriptActivityDetailsRequest,
   sessionTranscriptIpcChannels,
@@ -729,10 +729,18 @@ export function initializeComposer(authority: ApplicationAuthority): void {
   })
 
   handleTrustedIpc(sessionTranscriptIpcChannels.acceptActionCard, (_event, value: unknown) => {
-    const request = parseActionCardAcceptanceRequest(value)
+    const request = parseActionCardStatusRequest(value)
 
     return request
       ? registry.acceptActionCard(sessionId(request.sessionId), request.actionCardId)
+      : Promise.resolve(false)
+  })
+
+  handleTrustedIpc(sessionTranscriptIpcChannels.dismissActionCard, (_event, value: unknown) => {
+    const request = parseActionCardStatusRequest(value)
+
+    return request
+      ? registry.dismissActionCard(sessionId(request.sessionId), request.actionCardId)
       : Promise.resolve(false)
   })
 

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -154,6 +154,7 @@ export interface PiSessionRuntimeRegistry {
   removeQueuedFollowUp(sessionId: SessionId, followUpId: string): Promise<boolean>
   resumeQueuedFollowUps(sessionId: SessionId): Promise<boolean>
   acceptActionCard(sessionId: SessionId, actionCardId: string): Promise<boolean>
+  dismissActionCard(sessionId: SessionId, actionCardId: string): Promise<boolean>
   renameSession(sessionId: SessionId, title: string): Promise<void>
   getWorkingStateSnapshots(): readonly SessionWorkingStateSnapshot[]
   loadActivityDetails(sessionId: SessionId, activityId: string): Promise<AgentActivityDetails | undefined>
@@ -255,7 +256,7 @@ export function createPiSessionRuntimeRegistry({
     return true
   }
 
-  function acceptActionCard(sessionId: SessionId, actionCardId: string): boolean {
+  function setActionCardStatus(sessionId: SessionId, actionCardId: string, status: 'accepted' | 'dismissed'): boolean {
     const timeline = getTimeline(sessionId)
     const cardIndex = timeline.actionCards.findIndex(
       (card) => card.id === actionCardId && card.sessionId === sessionId && card.status === 'available'
@@ -270,12 +271,12 @@ export function createPiSessionRuntimeRegistry({
       version: 1,
       type: 'action-card-status',
       actionCardId,
-      status: 'accepted',
+      status,
     })
 
     if (!persisted) return false
 
-    timeline.actionCards[cardIndex] = { ...card, status: 'accepted' }
+    timeline.actionCards[cardIndex] = { ...card, status }
     publishTimeline(sessionId)
     return true
   }
@@ -1533,7 +1534,11 @@ export function createPiSessionRuntimeRegistry({
     },
     async acceptActionCard(sessionId, actionCardId) {
       await getRuntime(sessionId)
-      return acceptActionCard(sessionId, actionCardId)
+      return setActionCardStatus(sessionId, actionCardId, 'accepted')
+    },
+    async dismissActionCard(sessionId, actionCardId) {
+      await getRuntime(sessionId)
+      return setActionCardStatus(sessionId, actionCardId, 'dismissed')
     },
     async renameSession(sessionId, title) {
       const runtime = await getRuntime(sessionId)

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -96,6 +96,55 @@ test('persists an accepted action card across a runtime restart', async () => {
   assert.equal((await restartedRegistry.getTranscript(id)).actionCards?.[0]?.status, 'accepted')
 })
 
+test('persists a dismissed action card across a runtime restart', async () => {
+  let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}
+  const records: import('@/src/main/activity-records').ActivityLayerRecord[] = []
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe(listener) {
+      emit = listener
+      return () => {}
+    },
+    loadHistory() {
+      return { conversations: [], activityRecords: records, finalState: 'completed' }
+    },
+    appendActivityRecord(record) {
+      records.push(record)
+    },
+    dispose() {},
+  }
+  const id = sessionId('dismissed-action-card-session')
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  await registry.getTranscript(id)
+  emit({
+    type: 'action_card_created',
+    input: {
+      kind: 'prepare-pull-request',
+      title: 'Prepare the pull request',
+      description: 'The changes are ready for review.',
+    },
+    createdAt: 1,
+  })
+
+  const created = (await registry.getTranscript(id)).actionCards?.[0]
+  assert.ok(created)
+  assert.equal(await registry.dismissActionCard(id, created.id), true)
+  assert.equal(await registry.dismissActionCard(id, created.id), false)
+  assert.equal((await registry.getTranscript(id)).actionCards?.[0]?.status, 'dismissed')
+
+  const restartedRegistry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  assert.equal((await restartedRegistry.getTranscript(id)).actionCards?.[0]?.status, 'dismissed')
+})
+
 test('persists queued follow-ups until the user resumes the queue', async () => {
   let streaming = true
   let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -235,6 +235,12 @@ const sessionTranscriptBridge: SessionTranscriptBridge = {
       actionCardId,
     }) as Promise<boolean>
   },
+  dismissActionCard(sessionId, actionCardId) {
+    return ipcRenderer.invoke(sessionTranscriptIpcChannels.dismissActionCard, {
+      sessionId,
+      actionCardId,
+    }) as Promise<boolean>
+  },
   openExternalLink(url) {
     return ipcRenderer.invoke(sessionTranscriptIpcChannels.openExternalLink, url) as Promise<void>
   },

--- a/src/renderer/components/session-area.tsx
+++ b/src/renderer/components/session-area.tsx
@@ -37,6 +37,7 @@ type SessionAreaProperties = {
   sessionSkills?: SessionSkillsBridge
   onToggleSessionPin: (sessionId: SessionId) => void
   acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
+  dismissActionCard?: SessionTranscriptBridge['dismissActionCard']
   onStartImplementSession?: (workstreamId: string) => Promise<void>
 }
 
@@ -64,6 +65,7 @@ export function SessionArea({
   sessionSkills,
   onToggleSessionPin,
   acceptActionCard = async () => false,
+  dismissActionCard = async () => false,
   onStartImplementSession = async () => {},
 }: SessionAreaProperties) {
   const sessionPaneRefs = useRef(new Map<SessionId, HTMLDivElement>())
@@ -121,6 +123,7 @@ export function SessionArea({
             sessionSkills={sessionSkills}
             onTogglePin={() => onToggleSessionPin(session.id)}
             acceptActionCard={acceptActionCard}
+            dismissActionCard={dismissActionCard}
             onStartImplementSession={onStartImplementSession}
           />
         </div>

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -36,6 +36,7 @@ type SessionContainerProperties = {
   sessionSkills?: SessionSkillsBridge
   onTogglePin: () => void
   acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
+  dismissActionCard?: SessionTranscriptBridge['dismissActionCard']
   onStartImplementSession?: (workstreamId: string) => Promise<void>
 }
 
@@ -61,6 +62,7 @@ export function SessionContainer({
   sessionSkills,
   onTogglePin,
   acceptActionCard = async () => false,
+  dismissActionCard = async () => false,
   onStartImplementSession = async () => {},
 }: SessionContainerProperties) {
   const headingId = useId()
@@ -143,7 +145,7 @@ export function SessionContainer({
         timelineAnnouncement={transcriptState.announcement}
         timelineError={transcriptState.error}
         onReloadTimeline={transcriptState.reload}
-        onActionCard={async (card: SessionActionCard, option) => {
+        onActionCard={async (card: SessionActionCard) => {
           if (card.kind === 'start-implement-session') {
             await onStartImplementSession(session.workstreamId)
             return acceptActionCard(session.id, card.id)
@@ -152,14 +154,12 @@ export function SessionContainer({
           const result = await submitMessage({
             sessionId: session.id,
             delivery: 'action',
-            text:
-              option === 'ready'
-                ? 'Create a pull request for the completed work. Review the current changes, validation results, and branch status, then prepare a clear title and description for my approval.'
-                : 'Create a draft pull request for the completed work. Review the current changes, validation results, and branch status, then prepare a clear title and description for my approval.',
+            text: 'Create a draft pull request for the completed work. Review the current changes, validation results, and branch status, then prepare a clear title and description for my approval.',
           })
 
           return result.status === 'accepted' && (await acceptActionCard(session.id, card.id))
         }}
+        onDismissActionCard={(card) => dismissActionCard(session.id, card.id)}
       />
       {!composerUnavailable && transcriptState.snapshot?.queuedFollowUps && (
         <QueuedFollowUpTray

--- a/src/renderer/components/session-messages.test.tsx
+++ b/src/renderer/components/session-messages.test.tsx
@@ -193,6 +193,68 @@ test('hides an accepted action card', () => {
   assert.equal(view.queryByText('Start implementation', { exact: true }), null)
 })
 
+test('offers only draft preparation for a pull-request action card', () => {
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking={false}
+      transcript={{
+        ...transcript([]),
+        actionCards: [
+          {
+            id: 'card-1',
+            sessionId: id,
+            kind: 'prepare-pull-request',
+            title: 'Prepare the pull request',
+            description: 'The changes are ready for review.',
+            status: 'available',
+            createdAt: 1,
+          },
+        ],
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  assert.ok(view.getByRole('button', { name: 'Prepare draft pull request' }))
+  assert.equal(view.queryByRole('button', { name: 'Prepare pull request' }), null)
+})
+
+test('allows dismissing an available action card for later', async () => {
+  let dismissedCardId: string | undefined
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = render(
+    <SessionMessages
+      sessionId={id}
+      isWorking={false}
+      transcript={{
+        ...transcript([]),
+        actionCards: [
+          {
+            id: 'card-1',
+            sessionId: id,
+            kind: 'prepare-pull-request',
+            title: 'Prepare the pull request',
+            description: 'The changes are ready for review.',
+            status: 'available',
+            createdAt: 1,
+          },
+        ],
+      }}
+      onDismissActionCard={async (card) => {
+        dismissedCardId = card.id
+        return true
+      }}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await user.click(view.getByRole('button', { name: 'Not now' }))
+
+  assert.equal(dismissedCardId, 'card-1')
+  assert.equal(view.queryByText('Prepare the pull request', { exact: true }), null)
+})
+
 test('allows retrying an action after its request fails', async () => {
   let attempts = 0
   const view = render(

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -16,7 +16,8 @@ type SessionMessagesProperties = Readonly<{
   timelineAnnouncement?: string
   timelineError?: string
   onReloadTimeline?: () => void
-  onActionCard?: (card: SessionActionCard, option?: 'draft' | 'ready') => Promise<boolean>
+  onActionCard?: (card: SessionActionCard) => Promise<boolean>
+  onDismissActionCard?: (card: SessionActionCard) => Promise<boolean>
 }>
 
 type TranscriptEntry =
@@ -38,6 +39,7 @@ export function SessionMessages({
   timelineError,
   onReloadTimeline,
   onActionCard = async () => false,
+  onDismissActionCard = async () => false,
 }: SessionMessagesProperties) {
   const isLoading = !canonicalTranscript
   const loadError = Boolean(timelineError)
@@ -131,7 +133,12 @@ export function SessionMessages({
             canonicalTranscript?.actionCards
               ?.filter((card) => card.status === 'available')
               .map((card) => (
-                <SessionActionCardView key={card.id} card={card} onAction={(option) => onActionCard(card, option)} />
+                <SessionActionCardView
+                  key={card.id}
+                  card={card}
+                  onAction={() => onActionCard(card)}
+                  onDismiss={() => onDismissActionCard(card)}
+                />
               ))}
           {isCompacting && <SessionActivityIndicator label="Pi is compacting this Session…" />}
           {!isLoading && runFailureReason ? (
@@ -190,17 +197,35 @@ export function SessionMessages({
 function SessionActionCardView({
   card,
   onAction,
-}: Readonly<{ card: SessionActionCard; onAction: (option?: 'draft' | 'ready') => Promise<boolean> }>) {
-  const [state, setState] = useState<'idle' | 'working' | 'complete' | 'failed'>('idle')
-  const runAction = async (option?: 'draft' | 'ready') => {
-    setState('working')
+  onDismiss,
+}: Readonly<{
+  card: SessionActionCard
+  onAction: () => Promise<boolean>
+  onDismiss: () => Promise<boolean>
+}>) {
+  const [actionState, setActionState] = useState<'idle' | 'working' | 'complete' | 'failed'>('idle')
+  const [dismissState, setDismissState] = useState<'idle' | 'working' | 'dismissed' | 'failed'>('idle')
+  const disabled = actionState === 'working' || actionState === 'complete' || dismissState === 'working'
+  const runAction = async () => {
+    setActionState('working')
 
     try {
-      setState((await onAction(option)) ? 'complete' : 'failed')
+      setActionState((await onAction()) ? 'complete' : 'failed')
     } catch {
-      setState('failed')
+      setActionState('failed')
     }
   }
+  const dismiss = async () => {
+    setDismissState('working')
+
+    try {
+      setDismissState((await onDismiss()) ? 'dismissed' : 'failed')
+    } catch {
+      setDismissState('failed')
+    }
+  }
+
+  if (dismissState === 'dismissed') return null
 
   return (
     <aside
@@ -210,42 +235,36 @@ function SessionActionCardView({
       <p className="text-xs/5 font-medium text-content-muted-foreground">Suggested by Pi</p>
       <h2 className="mt-1 text-sm/5 font-medium text-content-foreground">{card.title}</h2>
       <p className="mt-1 text-sm/5 text-content-muted-foreground">{card.description}</p>
-      {card.kind === 'start-implement-session' ? (
-        <>
-          <Button
-            className="mt-3"
-            disabled={state === 'working' || state === 'complete'}
-            onClick={() => void runAction()}
-          >
-            {state === 'working'
+      <div className="mt-3 flex flex-wrap gap-2">
+        {card.kind === 'start-implement-session' ? (
+          <Button disabled={disabled} onClick={() => void runAction()}>
+            {actionState === 'working'
               ? 'Starting…'
-              : state === 'complete'
+              : actionState === 'complete'
                 ? 'Implement Session started'
                 : 'Start Implement Session'}
           </Button>
-          {state === 'failed' ? (
-            <p className="mt-2 text-sm/5 text-activity-failed">Could not start this action.</p>
-          ) : null}
-        </>
-      ) : (
-        <div className="mt-3 flex flex-wrap gap-2">
-          <Button disabled={state === 'working' || state === 'complete'} onClick={() => void runAction('draft')}>
-            {state === 'working'
+        ) : (
+          <Button disabled={disabled} onClick={() => void runAction()}>
+            {actionState === 'working'
               ? 'Preparing pull request…'
-              : state === 'complete'
+              : actionState === 'complete'
                 ? 'Pull request request sent'
                 : 'Prepare draft pull request'}
           </Button>
-          <Button
-            outline
-            disabled={state === 'working' || state === 'complete'}
-            onClick={() => void runAction('ready')}
-          >
-            Prepare pull request
-          </Button>
-          {state === 'failed' ? <p className="text-sm/5 text-activity-failed">Could not start this request.</p> : null}
-        </div>
-      )}
+        )}
+        <Button outline disabled={disabled} onClick={() => void dismiss()}>
+          {dismissState === 'working' ? 'Dismissing…' : 'Not now'}
+        </Button>
+      </div>
+      {actionState === 'failed' ? (
+        <p className="mt-2 text-sm/5 text-activity-failed">
+          {card.kind === 'start-implement-session' ? 'Could not start this action.' : 'Could not start this request.'}
+        </p>
+      ) : null}
+      {dismissState === 'failed' ? (
+        <p className="mt-2 text-sm/5 text-activity-failed">Could not dismiss this suggestion.</p>
+      ) : null}
     </aside>
   )
 }

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -480,6 +480,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             sessionSkills={window.piWorkspace.sessionSkills}
             onToggleSessionPin={toggleSessionPin}
             acceptActionCard={window.piWorkspace.transcript.acceptActionCard}
+            dismissActionCard={window.piWorkspace.transcript.dismissActionCard}
             onStartImplementSession={(workstreamId) => createSession(workstreamId, { mode: 'implement' })}
           />
         ) : selectedWorkstream?.goal ? (

--- a/src/session-transcript-ipc.test.ts
+++ b/src/session-transcript-ipc.test.ts
@@ -1,15 +1,15 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { parseActionCardAcceptanceRequest } from './session-transcript-ipc'
+import { parseActionCardStatusRequest } from './session-transcript-ipc'
 
-test('accepts a bounded action-card acceptance request', () => {
-  assert.deepEqual(parseActionCardAcceptanceRequest({ sessionId: 'session-a', actionCardId: 'card-1' }), {
+test('accepts a bounded action-card status request', () => {
+  assert.deepEqual(parseActionCardStatusRequest({ sessionId: 'session-a', actionCardId: 'card-1' }), {
     sessionId: 'session-a',
     actionCardId: 'card-1',
   })
 })
 
 test('rejects an empty or oversized action-card id', () => {
-  assert.equal(parseActionCardAcceptanceRequest({ sessionId: 'session-a', actionCardId: '' }), undefined)
-  assert.equal(parseActionCardAcceptanceRequest({ sessionId: 'session-a', actionCardId: 'x'.repeat(257) }), undefined)
+  assert.equal(parseActionCardStatusRequest({ sessionId: 'session-a', actionCardId: '' }), undefined)
+  assert.equal(parseActionCardStatusRequest({ sessionId: 'session-a', actionCardId: 'x'.repeat(257) }), undefined)
 })

--- a/src/session-transcript-ipc.ts
+++ b/src/session-transcript-ipc.ts
@@ -5,6 +5,7 @@ export const sessionTranscriptIpcChannels = {
   getWorkingStateSnapshots: 'session-transcript:get-working-state-snapshots',
   loadActivityDetails: 'session-transcript:load-activity-details',
   acceptActionCard: 'session-transcript:accept-action-card',
+  dismissActionCard: 'session-transcript:dismiss-action-card',
   openExternalLink: 'session-transcript:open-external-link',
   changed: 'session-transcript:changed',
 } as const
@@ -17,9 +18,7 @@ export function parseSessionTranscriptRequest(value: unknown): { sessionId: stri
   return isSessionId(sessionId) ? { sessionId } : undefined
 }
 
-export function parseActionCardAcceptanceRequest(
-  value: unknown
-): { sessionId: string; actionCardId: string } | undefined {
+export function parseActionCardStatusRequest(value: unknown): { sessionId: string; actionCardId: string } | undefined {
   const request = parseSessionTranscriptRequest(value)
   if (!request || typeof (value as Record<string, unknown>).actionCardId !== 'string') return undefined
 

--- a/src/session-transcript.ts
+++ b/src/session-transcript.ts
@@ -71,6 +71,7 @@ export interface SessionTranscriptBridge {
   getWorkingStateSnapshots(): Promise<readonly SessionWorkingStateSnapshot[]>
   loadActivityDetails(sessionId: SessionId, activityId: string): Promise<AgentActivityDetails | undefined>
   acceptActionCard(sessionId: SessionId, actionCardId: string): Promise<boolean>
+  dismissActionCard(sessionId: SessionId, actionCardId: string): Promise<boolean>
   openExternalLink(url: string): Promise<void>
   subscribe(listener: (mutation: SessionTranscriptMutation) => void): () => void
 }


### PR DESCRIPTION
## Summary

- add a persistent **Not now** action to suggested Session action cards
- limit pull-request suggestions to preparing a draft pull request
- persist dismissed cards across Session restarts
- expose dismissal through the validated Electron IPC bridge
- add renderer, IPC, and runtime persistence coverage

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 552 tests passed
- `bun run build`
- `bun run security:scan`
