### PR TITLE
feat: add file tagging to Session Composer

### DIFF
--- a/docs/file-tagging.md
+++ b/docs/file-tagging.md
@@ -48,7 +48,7 @@ type SessionFileMention = Readonly<{
 }>
 ```
 
-The Composer bridge should expose a scoped candidate query, rather than returning an entire repository index. Results should be bounded and ordered by exact path/name match, then prefix match, then substring match.
+The Composer bridge should expose a scoped candidate query, rather than returning an entire repository index. Results should be bounded and ordered by path hierarchy, then exact path/name match, prefix match, and substring match.
 
 ## Implementation sequence
 

--- a/docs/file-tagging.md
+++ b/docs/file-tagging.md
@@ -1,0 +1,67 @@
+# File and folder tagging
+
+## Phase 1 contract
+
+The Composer accepts `@` references to files and folders in the current Session's allowed Repository working paths. Selecting a result creates a structured inline reference while displaying the relative path. The persisted text remains canonical and backwards-compatible; file metadata is optional and unavailable references remain renderable. Paths that need whitespace or otherwise cannot be represented unquoted use an escaped JSON-quoted token such as `@@"src/my file.ts"`.
+
+At the Agent boundary, references are resolved in the main process and rendered as readable Markdown:
+
+````markdown
+## Referenced file: `src/main/composer-ipc.ts`
+
+```typescript
+...bounded contents...
+```
+````
+
+Folders render a bounded listing rather than recursively injecting every file.
+
+## Resolution and security
+
+The renderer never resolves paths. The main process must:
+
+- resolve only against allowed Repository working paths;
+- reject absolute paths, traversal, and symlink escapes;
+- revalidate at submission time because autocomplete results can become stale;
+- skip binary files and cap individual and aggregate content sizes;
+- preserve unavailable references instead of silently substituting another path;
+- use the stable Repository ID as the managed Session prefix, so duplicate Repository names cannot select another Repository's content.
+
+## Suggested types
+
+```ts
+type SessionFile = Readonly<{
+  path: string
+  kind: 'file' | 'folder'
+  name: string
+}>
+
+type SessionFileReference = Readonly<{
+  path: string
+  kind: 'file' | 'folder'
+  availability: 'available' | 'unavailable'
+}>
+
+type SessionFileMention = Readonly<{
+  file: SessionFileReference
+  offset: number
+}>
+```
+
+The Composer bridge should expose a scoped candidate query, rather than returning an entire repository index. Results should be bounded and ordered by exact path/name match, then prefix match, then substring match.
+
+## Implementation sequence
+
+1. Add file reference domain and projection helpers, mirroring Skills.
+2. Add main-process scoped candidate discovery and validated Markdown resolution.
+3. Extend the Composer submission/transcript contract with optional file mentions.
+4. Add `ComposerFileNode` and `@` autocomplete to the existing Lexical editor.
+5. Add transcript and queued-follow-up rendering for unavailable references.
+6. Add tests for parsing, path escape rejection, stale references, Markdown limits, and selection/serialization.
+
+## Product decisions
+
+- `@` means attach context, matching OpenCode, Claude Code, Cursor, and Cline conventions.
+- File contents are injected as Markdown context; XML is not required.
+- Folder tags initially provide bounded listings.
+- Existing messages without file metadata continue to load unchanged.

--- a/src/composer-ipc.test.ts
+++ b/src/composer-ipc.test.ts
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { sessionId } from '@/src/domain/session'
+import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
 import {
   maximumSessionMessageLength,
   parseQueuedFollowUpRemovalRequest,
   parseSessionMessageSubmission,
   parseSessionRunStopRequest,
 } from './composer-ipc'
+import { managedSessionFileRoots } from './main/managed-session-file-roots'
 
 test('accepts a narrow serializable Agent Run stop request', () => {
   assert.deepEqual(parseSessionRunStopRequest({ sessionId: 'session-a' }), { sessionId: sessionId('session-a') })
@@ -54,6 +56,45 @@ test('rejects unsupported delivery behavior at the IPC boundary', () => {
 
 test('rejects an invalid Session id at the IPC boundary', () => {
   assert.equal(parseSessionMessageSubmission({ sessionId: '', text: 'Hello', delivery: 'steer' }), undefined)
+})
+
+test('uses managed Repository IDs as unambiguous file prefixes', () => {
+  const policy: ManagedSessionRuntimePolicy = {
+    workspaceId: 'workspace-a',
+    workstreamId: 'workstream-a',
+    sessionId: sessionId('session-a'),
+    mode: 'implement',
+    lifecycle: 'active',
+    piSessionPath: '/tmp/session.jsonl',
+    resourcePolicyRevision: 1,
+    repositories: [
+      {
+        id: 'repository-one',
+        name: 'app',
+        commonDirectoryPath: '/tmp/one/.git',
+        role: '',
+        relationships: [],
+        availability: 'available',
+        workingPath: '/tmp/one/app',
+        workingLocation: 'session-worktree',
+      },
+      {
+        id: 'repository-two',
+        name: 'app',
+        commonDirectoryPath: '/tmp/two/.git',
+        role: '',
+        relationships: [],
+        availability: 'available',
+        workingPath: '/tmp/two/app',
+        workingLocation: 'session-worktree',
+      },
+    ],
+  }
+
+  assert.deepEqual(managedSessionFileRoots(policy), [
+    { path: '/tmp/one/app', prefix: 'repository-one' },
+    { path: '/tmp/two/app', prefix: 'repository-two' },
+  ])
 })
 
 test('rejects message text beyond the IPC limit', () => {

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -168,6 +168,14 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
         ]
       },
     },
+    sessionFiles: {
+      async getAvailable() {
+        return [
+          { path: 'src/main/composer-ipc.ts', name: 'composer-ipc.ts', kind: 'file' as const },
+          { path: 'src/renderer/components', name: 'components', kind: 'folder' as const },
+        ]
+      },
+    },
     sessionConfiguration: {
       async getSnapshot(sessionId) {
         return {

--- a/src/main/activity-records.test.ts
+++ b/src/main/activity-records.test.ts
@@ -84,6 +84,22 @@ test('rejects malformed queued follow-up records', () => {
     }),
     false
   )
+  assert.equal(
+    isActivityLayerRecord({
+      version: 1,
+      type: 'queued-follow-up',
+      followUp: { id: 'follow-up-1', text: 'Continue.', files: 'invalid', createdAt: 1 },
+    }),
+    false
+  )
+  assert.equal(
+    isActivityLayerRecord({
+      version: 1,
+      type: 'queued-follow-up',
+      followUp: { id: 'follow-up-1', text: 'Continue.', sourceText: 1, createdAt: 1 },
+    }),
+    false
+  )
   assert.equal(isActivityLayerRecord({ version: 1, type: 'queued-follow-up-removed', followUpId: '' }), false)
 })
 
@@ -99,6 +115,13 @@ test('accepts queued follow-up records', () => {
           {
             offset: 0,
             skill: { name: 'tdd', description: 'Develop test first.', availability: 'available' },
+          },
+        ],
+        sourceText: 'Continue after this response.',
+        files: [
+          {
+            offset: 28,
+            file: { path: 'src/app.ts', kind: 'file', availability: 'available' },
           },
         ],
         createdAt: 1,

--- a/src/main/activity-records.ts
+++ b/src/main/activity-records.ts
@@ -100,7 +100,9 @@ function isQueuedFollowUp(value: unknown): value is QueuedFollowUp {
   return (
     isNonEmptyString(value.id) &&
     typeof value.text === 'string' &&
+    (value.sourceText === undefined || typeof value.sourceText === 'string') &&
     (value.skills === undefined || (Array.isArray(value.skills) && value.skills.every(isSessionSkillMention))) &&
+    (value.files === undefined || (Array.isArray(value.files) && value.files.every(isSessionFileMention))) &&
     isTimestamp(value.createdAt)
   )
 }
@@ -113,6 +115,17 @@ function isSessionSkillMention(value: unknown): boolean {
   return (
     (value.skill.availability === 'available' && typeof value.skill.description === 'string') ||
     value.skill.availability === 'unavailable'
+  )
+}
+
+function isSessionFileMention(value: unknown): boolean {
+  if (!isRecord(value) || !isCount(value.offset) || !isRecord(value.file) || !isNonEmptyString(value.file.path)) {
+    return false
+  }
+
+  return (
+    (value.file.kind === 'file' || value.file.kind === 'folder') &&
+    (value.file.availability === 'available' || value.file.availability === 'unavailable')
   )
 }
 

--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -1,5 +1,11 @@
 import { app, shell } from 'electron'
 import { readFileSync } from 'node:fs'
+import {
+  findSessionFiles,
+  getSessionFileReference,
+  renderSessionFileContext,
+  type SessionFileRoot,
+} from '@/src/main/session-file-context'
 import type { SessionManager } from '@earendil-works/pi-coding-agent'
 import { isSessionSkillName, type SessionMessageSubmissionResult, type SessionRunStopResult } from '@/src/composer'
 import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
@@ -17,6 +23,7 @@ import {
 import { sessionId } from '@/src/domain/session'
 import { parseSessionActionCardToolInput } from '@/src/session-action-cards'
 import { parseSessionSkillsRequest, sessionSkillsIpcChannels } from '@/src/session-skills-ipc'
+import { parseSessionFilesRequest, sessionFilesIpcChannels } from '@/src/session-files-ipc'
 import type {
   SessionConfigurationEffort,
   SessionConfigurationModelSelection,
@@ -44,6 +51,7 @@ import {
 import { canCompactSessionHistory } from '@/src/main/pi-session-compaction'
 import { classifyPersistedAgentState } from '@/src/main/pi-session-history'
 import { createManagedSessionServices } from '@/src/main/managed-session-resources'
+import { managedSessionFileRoots } from '@/src/main/managed-session-file-roots'
 import { createManagedSessionRuntimePolicyGuard } from '@/src/main/managed-session-runtime-policy'
 import {
   managedSessionMethodology,
@@ -300,6 +308,11 @@ export async function createPiSessionRuntime(
     const body = stripFrontmatter(readFileSync(skill.filePath, 'utf8')).trim()
     return `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${body}\n</skill>`
   }
+  const sessionFileRoots = async (): Promise<readonly SessionFileRoot[]> => {
+    if (options.kind === 'default') return [{ path: directoryPath }]
+
+    return managedSessionFileRoots(await validateManagedPolicy())
+  }
   const configuredHttpIdleTimeoutMs = session.settingsManager.getHttpIdleTimeoutMs()
   const modelTurnNoProgressTimeoutMs =
     configuredHttpIdleTimeoutMs === 0
@@ -417,7 +430,7 @@ export async function createPiSessionRuntime(
           message.role === 'user' ? projectPiUserMessage(content.text, getAvailableSkills()) : { text: content.text }
 
         if (message.role === 'assistant' && content.hasToolCalls) return []
-        if (projected.text.length === 0 && !projected.skills?.length) return []
+        if (projected.text.length === 0 && !projected.skills?.length && !projected.files?.length) return []
 
         return [
           {
@@ -463,6 +476,15 @@ export async function createPiSessionRuntime(
     },
     getSkills: getAvailableSkills,
     getSkillPrompt,
+    async getFiles(query) {
+      return findSessionFiles(await sessionFileRoots(), query)
+    },
+    async getFileReference(path) {
+      return getSessionFileReference(await sessionFileRoots(), path)
+    },
+    async getFileContext(path) {
+      return renderSessionFileContext(await sessionFileRoots(), path)
+    },
     loadRawOperation(toolCallId) {
       let input: unknown
       let result: unknown
@@ -679,6 +701,14 @@ export function initializeComposer(authority: ApplicationAuthority): void {
     const request = parseSessionSkillsRequest(value)
 
     return request ? registry.getAvailableSkills(request.sessionId) : Promise.reject(new Error('Invalid Session.'))
+  })
+
+  handleTrustedIpc(sessionFilesIpcChannels.getAvailable, (_event, value: unknown) => {
+    const request = parseSessionFilesRequest(value)
+
+    return request
+      ? registry.getAvailableFiles(request.sessionId, request.query)
+      : Promise.reject(new Error('Invalid Session.'))
   })
 
   handleTrustedIpc(sessionTranscriptIpcChannels.getSnapshot, (_event, value: unknown) => {

--- a/src/main/managed-session-file-roots.ts
+++ b/src/main/managed-session-file-roots.ts
@@ -1,0 +1,12 @@
+import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
+
+export type ManagedSessionFileRoot = Readonly<{
+  path: string
+  prefix: string
+}>
+
+export function managedSessionFileRoots(policy: ManagedSessionRuntimePolicy): readonly ManagedSessionFileRoot[] {
+  return policy.repositories.flatMap((repository) =>
+    repository.availability === 'available' ? [{ path: repository.workingPath, prefix: repository.id }] : []
+  )
+}

--- a/src/main/pi-session-message-mapping.test.ts
+++ b/src/main/pi-session-message-mapping.test.ts
@@ -71,6 +71,45 @@ test('restores a persisted raw Skill token as an inline reference', () => {
   })
 })
 
+test('restores a persisted raw file tag as an unavailable inline reference', () => {
+  assert.deepEqual(projectPiUserMessage('Review @src/main/index.ts.'), {
+    text: 'Review .',
+    files: [
+      {
+        offset: 7,
+        file: { path: 'src/main/index.ts', kind: 'file', availability: 'unavailable' },
+      },
+    ],
+  })
+})
+
+test('restores a quoted file tag as an unavailable inline reference', () => {
+  assert.deepEqual(projectPiUserMessage('Review @@"src/my file.ts".'), {
+    text: 'Review .',
+    files: [
+      {
+        offset: 7,
+        file: { path: 'src/my file.ts', kind: 'file', availability: 'unavailable' },
+      },
+    ],
+  })
+})
+
+test('restores file tags from persisted expanded context', () => {
+  const source = 'Review @src/main/index.ts.'
+  const persisted = `## Referenced file: \`src/main/index.ts\`\n\n\`\`\`ts\nexport {}\n\`\`\`\n\n<!-- pi-workspace-source:${Buffer.from(source).toString('base64url')} -->`
+
+  assert.deepEqual(projectPiUserMessage(persisted), {
+    text: 'Review .',
+    files: [
+      {
+        offset: 7,
+        file: { path: 'src/main/index.ts', kind: 'file', availability: 'unavailable' },
+      },
+    ],
+  })
+})
+
 test('projects multiple persisted Pi Skill invocations at their authored positions', () => {
   const projected = projectPiUserMessage(
     'Use <skill name="code-review" location="/private/code-review/SKILL.md">\nReview instructions\n</skill> and <skill name="tdd" location="/private/tdd/SKILL.md">\nTDD instructions\n</skill>.',

--- a/src/main/pi-session-message-mapping.ts
+++ b/src/main/pi-session-message-mapping.ts
@@ -2,6 +2,7 @@ import type { AgentSessionEvent, SessionEntry } from '@earendil-works/pi-coding-
 import type { AgentMessage } from '@earendil-works/pi-agent-core'
 import type { TextContent } from '@earendil-works/pi-ai'
 import { projectSessionSkillSelections, type SessionSkill } from '@/src/session-skills'
+import { projectSessionFileSelections } from '@/src/session-files'
 import type { SessionTranscriptMessage } from '@/src/session-transcript'
 
 export type PiSessionMessageEvent = Readonly<{
@@ -132,7 +133,7 @@ function toSessionMessage(
   const content = textFromMessage(message)
   const projected = message.role === 'user' ? projectPiUserMessage(content, skills) : { text: content }
 
-  if (!projected.text && !projected.skills?.length) {
+  if (!projected.text && !projected.skills?.length && !projected.files?.length) {
     return undefined
   }
 
@@ -147,8 +148,18 @@ function toSessionMessage(
 
 export function projectPiUserMessage(
   source: string,
-  skills: readonly SessionSkill[] = []
-): Pick<SessionTranscriptMessage, 'text' | 'skills'> {
+  skills: readonly SessionSkill[] = [],
+  readMetadata = true
+): Pick<SessionTranscriptMessage, 'text' | 'skills' | 'files'> {
+  const persistedSource = readMetadata ? /\n\n<!-- pi-workspace-source:([A-Za-z0-9_-]+) -->$/.exec(source) : undefined
+  if (persistedSource?.[1]) {
+    try {
+      return projectPiUserMessage(Buffer.from(persistedSource[1], 'base64url').toString('utf8'), skills, false)
+    } catch {
+      // Fall through to the visible prompt when a persisted marker is malformed.
+    }
+  }
+
   const nativeInvocation = source.match(
     /^<skill name="([^"]+)" location="[^"]+">\n[\s\S]*?\n<\/skill>(?:\n\n([\s\S]+))?$/
   )
@@ -179,11 +190,31 @@ export function projectPiUserMessage(
   if (mentions.length > 0) return { text: text + source.slice(sourceOffset), skills: mentions }
 
   const projected = projectSessionSkillSelections(source)
-  if (projected.selections.length === 0) return { text: source }
+  const fileProjected = projectSessionFileSelections(projected.text)
+  if (projected.selections.length === 0 && fileProjected.selections.length === 0) return { text: source }
 
   return {
-    text: projected.text,
-    skills: projected.selections.map(({ name, offset }) => ({ offset, skill: skillReference(name, skills) })),
+    text: fileProjected.text,
+    ...(projected.selections.length > 0
+      ? {
+          skills: projected.selections.map(({ name, offset }) => ({
+            offset:
+              offset -
+              fileProjected.selections
+                .filter((selection) => selection.offset < offset)
+                .reduce((sum, selection) => sum + selection.tokenLength, 0),
+            skill: skillReference(name, skills),
+          })),
+        }
+      : {}),
+    ...(fileProjected.selections.length > 0
+      ? {
+          files: fileProjected.selections.map(({ path, offset }) => ({
+            offset,
+            file: { path, kind: 'file' as const, availability: 'unavailable' as const },
+          })),
+        }
+      : {}),
   }
 }
 

--- a/src/main/pi-session-runtimes.ts
+++ b/src/main/pi-session-runtimes.ts
@@ -14,6 +14,13 @@ import {
   type SessionSkill,
   type SessionSkillMention,
 } from '@/src/session-skills'
+import {
+  projectSessionFileSelections,
+  replaceSessionFileTokensAsync,
+  type SessionFile,
+  type SessionFileMention,
+  type SessionFileReference,
+} from '@/src/session-files'
 import type { ActivityLayerRecord, AgentRunDiagnosticKind } from '@/src/main/activity-records'
 import {
   countArtifactFiles,
@@ -77,6 +84,9 @@ export interface PiSessionRuntime {
   loadRawOperation?(toolCallId: string): Readonly<{ input: unknown; result?: unknown }> | undefined
   getSkills?(): readonly SessionSkill[]
   getSkillPrompt?(name: string): string | undefined
+  getFiles?(query?: string): Promise<readonly SessionFile[]>
+  getFileReference?(path: string): Promise<SessionFileReference>
+  getFileContext?(path: string): Promise<string | undefined>
   getContextUsage?(): SessionContextUsage | undefined
   getConfiguration?(): Promise<Omit<SessionConfigurationSnapshot, 'sessionId' | 'revision' | 'persistenceWarning'>>
   setConfigurationModel?(model: SessionConfigurationModelSelection): Promise<void>
@@ -159,6 +169,7 @@ export interface PiSessionRuntimeRegistry {
   loadActivityDetails(sessionId: SessionId, activityId: string): Promise<AgentActivityDetails | undefined>
   getTranscript(sessionId: SessionId): Promise<SessionTranscriptSnapshot>
   getAvailableSkills(sessionId: SessionId): Promise<readonly SessionSkill[]>
+  getAvailableFiles(sessionId: SessionId, query?: string): Promise<readonly SessionFile[]>
   subscribeTranscript(listener: (mutation: SessionTranscriptMutation) => void): () => void
   getConfigurationSnapshot(sessionId: SessionId): Promise<SessionConfigurationSnapshot>
   setConfigurationModel(
@@ -181,6 +192,8 @@ const declaredActivityKinds = new Set<AgentActivityKind>(agentActivityKinds)
 export const maximumConcurrentAgentRuns = 10
 /** Preserves normal follow-up use while bounding queued future provider work per Session. */
 export const maximumPendingSessionFollowUps = 3
+/** Bounds injected tagged-file context independently of the user message limit. */
+export const maximumSessionFileContextLength = 100_000
 
 export function createPiSessionRuntimeRegistry({
   findSession,
@@ -287,7 +300,7 @@ export function createPiSessionRuntimeRegistry({
 
     if (!followUp) return
 
-    const result = await submit({ sessionId, text: followUp.text, delivery: 'follow-up' })
+    const result = await submit({ sessionId, text: followUp.sourceText ?? followUp.text, delivery: 'follow-up' })
 
     if (result.status === 'accepted' && result.delivery !== 'follow-up') {
       if (!removeQueuedFollowUp(sessionId, followUp.id)) {
@@ -1062,6 +1075,7 @@ export function createPiSessionRuntimeRegistry({
     messageId: string,
     text: string,
     skills?: readonly SessionSkillMention[],
+    files?: readonly SessionFileMention[],
     delivery?: 'steer'
   ): void {
     const timeline = getTimeline(sessionId)
@@ -1070,6 +1084,7 @@ export function createPiSessionRuntimeRegistry({
       role: 'user',
       text,
       skills,
+      files,
       delivery,
       state: 'complete',
       revision: timeline.revision + 1,
@@ -1078,10 +1093,10 @@ export function createPiSessionRuntimeRegistry({
     timeline.messages.set(message.id, message)
   }
 
-  function queueFollowUp(
+  async function queueFollowUp(
     submission: SessionMessageSubmission,
     runtime: PiSessionRuntime
-  ): SessionMessageSubmissionResult {
+  ): Promise<SessionMessageSubmissionResult> {
     const projected = projectSessionSkillSelections(submission.text)
     const availableSkills = runtime.getSkills?.() ?? []
     const skillsAvailable = projected.selections.every((selection) =>
@@ -1109,10 +1124,18 @@ export function createPiSessionRuntimeRegistry({
 
       return available ? [{ offset: selection.offset, skill: { ...available, availability: 'available' } }] : []
     })
+    const files = await fileMentions(projected.text, runtime)
+    if (!files) return { status: 'rejected', reason: 'unexpected' }
+
     const followUp = {
       id: createId(),
-      text: submission.text,
-      skills: skills.length > 0 ? skills : undefined,
+      text: files.text,
+      sourceText: submission.text,
+      skills:
+        skills.length > 0
+          ? skills.map((mention) => ({ ...mention, offset: files.skillOffsetAdjustment(mention.offset) }))
+          : undefined,
+      files: files.files,
       createdAt: now(),
     }
     const persisted = persistActivityRecord(getTimeline(submission.sessionId), {
@@ -1129,11 +1152,60 @@ export function createPiSessionRuntimeRegistry({
     return { status: 'accepted', delivery: 'follow-up' }
   }
 
+  async function fileMentions(
+    source: string,
+    runtime: PiSessionRuntime
+  ): Promise<
+    | Readonly<{
+        text: string
+        files?: readonly SessionFileMention[]
+        skillOffsetAdjustment: (offset: number) => number
+      }>
+    | undefined
+  > {
+    const projected = projectSessionFileSelections(source)
+    const files = await Promise.all(
+      projected.selections.map(async ({ path, offset }) => ({
+        offset,
+        file: await runtime.getFileReference?.(path),
+      }))
+    ).catch(() => undefined)
+    if (!files) return undefined
+
+    const mentions = files.map(({ offset, file }, index) => ({
+      offset,
+      file: file ?? {
+        path: projected.selections[index]!.path,
+        kind: 'file' as const,
+        availability: 'unavailable' as const,
+      },
+    }))
+
+    return {
+      text: projected.text,
+      files: mentions.length > 0 ? mentions : undefined,
+      skillOffsetAdjustment(offset) {
+        return (
+          offset -
+          projected.selections
+            .filter((selection) => selection.offset < offset)
+            .reduce((sum, selection) => sum + selection.tokenLength, 0)
+        )
+      },
+    }
+  }
+
   async function deliverSubmission(
     submission: SessionMessageSubmission,
     runtime: PiSessionRuntime,
     authorize: () => boolean | Promise<boolean>
   ): Promise<SessionMessageSubmissionResult> {
+    try {
+      if (!(await authorize())) return { status: 'rejected', reason: 'session-unavailable' }
+    } catch {
+      return { status: 'rejected', reason: 'unexpected' }
+    }
+
     const projected = projectSessionSkillSelections(submission.text)
     const availableSkills = runtime.getSkills?.() ?? []
     const skills = projected.selections.flatMap((selection): SessionSkillMention[] => {
@@ -1144,15 +1216,62 @@ export function createPiSessionRuntimeRegistry({
     if (skills.length !== projected.selections.length) {
       return { status: 'rejected', reason: 'skill-unavailable' }
     }
-    const skillMentions = skills.length > 0 ? skills : undefined
+    const files = await fileMentions(projected.text, runtime)
+    if (!files) return { status: 'rejected', reason: 'unexpected' }
 
+    const skillMentions =
+      skills.length > 0
+        ? skills.map((mention) => ({ ...mention, offset: files.skillOffsetAdjustment(mention.offset) }))
+        : undefined
+
+    const skillPrompts = new Map<string, string>()
+    let nextSkillPrompt = 0
     let promptText: string | undefined
     try {
-      promptText = replaceSessionSkillTokens(submission.text, (name) => runtime.getSkillPrompt?.(name))
+      promptText = replaceSessionSkillTokens(submission.text, (name) => {
+        const prompt = runtime.getSkillPrompt?.(name)
+        if (prompt === undefined) return undefined
+
+        const placeholder = `\uE000${nextSkillPrompt++}\uE001`
+        skillPrompts.set(placeholder, prompt)
+        return placeholder
+      })
     } catch {
       return { status: 'rejected', reason: 'unexpected' }
     }
     if (promptText === undefined) return { status: 'rejected', reason: 'skill-unavailable' }
+
+    const sourceMetadata = files.files?.length
+      ? `\n\n<!-- pi-workspace-source:${Buffer.from(submission.text).toString('base64url')} -->`
+      : ''
+    let fileContextLength = Buffer.byteLength(sourceMetadata)
+    if (fileContextLength > maximumSessionFileContextLength) {
+      return { status: 'rejected', reason: 'preflight-rejected' }
+    }
+    try {
+      promptText = await replaceSessionFileTokensAsync(promptText, async (path) => {
+        const context = await runtime.getFileContext?.(path)
+        const contextLength = context === undefined ? undefined : Buffer.byteLength(context)
+        if (
+          context === undefined ||
+          contextLength === undefined ||
+          fileContextLength + contextLength > maximumSessionFileContextLength
+        ) {
+          return undefined
+        }
+
+        fileContextLength += contextLength
+        return context
+      })
+    } catch {
+      return { status: 'rejected', reason: 'unexpected' }
+    }
+    if (promptText === undefined) return { status: 'rejected', reason: 'preflight-rejected' }
+    for (const [placeholder, prompt] of skillPrompts) {
+      promptText = promptText.replace(placeholder, prompt)
+    }
+    promptText += sourceMetadata
+
     const result = await activationGate.run<SessionMessageSubmissionResult>(submission.sessionId, async () => {
       try {
         if (!(await authorize())) return { status: 'rejected', reason: 'session-unavailable' }
@@ -1213,8 +1332,9 @@ export function createPiSessionRuntimeRegistry({
               acceptRun(
                 submission.sessionId,
                 messageId,
-                projected.text,
+                files.text,
                 skillMentions,
+                files.files,
                 acceptedDelivery === 'steer' ? 'steer' : undefined
               )
             }
@@ -1589,6 +1709,13 @@ export function createPiSessionRuntimeRegistry({
     },
     async getAvailableSkills(sessionId) {
       return (await getRuntime(sessionId))?.getSkills?.() ?? []
+    },
+    async getAvailableFiles(sessionId, query) {
+      try {
+        return (await getRuntime(sessionId))?.getFiles?.(query) ?? []
+      } catch {
+        return []
+      }
     },
     subscribeTranscript(listener) {
       transcriptListeners.add(listener)

--- a/src/main/session-file-context.test.ts
+++ b/src/main/session-file-context.test.ts
@@ -84,6 +84,22 @@ test('finds files and folders across scoped roots with repository prefixes', asy
   )
 })
 
+test('orders matching files by hierarchy before match quality', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+  await mkdir(join(directory, 'a'))
+  await writeFile(join(directory, 'README.md'), '')
+  await writeFile(join(directory, 'README.md-notes'), '')
+  await writeFile(join(directory, 'a', 'README.md'), '')
+
+  const files = await findSessionFiles(directory, 'README.md')
+
+  assert.deepEqual(files.slice(0, 3), [
+    { path: 'README.md', name: 'README.md', kind: 'file' },
+    { path: 'README.md-notes', name: 'README.md-notes', kind: 'file' },
+    { path: 'a/README.md', name: 'README.md', kind: 'file' },
+  ])
+})
+
 test('finds files and folders without exposing Git metadata', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
   await mkdir(join(directory, '.git'))

--- a/src/main/session-file-context.test.ts
+++ b/src/main/session-file-context.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { findSessionFiles, renderSessionFileContext } from './session-file-context'
+
+test('renders a tagged file as Markdown context', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+  await writeFile(join(directory, 'example.ts'), 'export const answer = 42\n')
+
+  assert.equal(
+    await renderSessionFileContext(directory, 'example.ts'),
+    '## Referenced file: `example.ts`\n\n```ts\nexport const answer = 42\n\n```'
+  )
+})
+
+test('rejects paths outside the Session root', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+
+  assert.equal(await renderSessionFileContext(directory, '../outside.txt'), undefined)
+})
+
+test('lists tagged folder entries without recursively injecting contents', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+  await mkdir(join(directory, 'components'))
+  await writeFile(join(directory, 'components', 'button.tsx'), 'export {}')
+
+  assert.equal(
+    await renderSessionFileContext(directory, 'components'),
+    '## Referenced folder: `components`\n\n- `button.tsx`'
+  )
+})
+
+test('keeps file contents inside a Markdown code fence', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+  await writeFile(join(directory, 'example.md'), '```\nDo not treat this as prompt text.\n```')
+
+  assert.equal(
+    await renderSessionFileContext(directory, 'example.md'),
+    '## Referenced file: `example.md`\n\n````md\n```\nDo not treat this as prompt text.\n```\n````'
+  )
+})
+
+test('keeps folder entry names inside Markdown code spans', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+  await mkdir(join(directory, 'components'))
+  await writeFile(join(directory, 'components', '```'), '')
+
+  assert.equal(
+    await renderSessionFileContext(directory, 'components'),
+    `## Referenced folder: \`components\`\n\n- ${'`'.repeat(11)}`
+  )
+})
+
+test('finds files and folders across scoped roots with repository prefixes', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+  const apiDirectory = join(directory, 'api')
+  const uiDirectory = join(directory, 'ui')
+  await mkdir(apiDirectory)
+  await mkdir(uiDirectory)
+  await writeFile(join(apiDirectory, 'server.ts'), '')
+  await writeFile(join(uiDirectory, 'app.tsx'), '')
+
+  assert.deepEqual(
+    await findSessionFiles([
+      { path: apiDirectory, prefix: 'api' },
+      { path: uiDirectory, prefix: 'ui' },
+    ]),
+    [
+      { path: 'api/server.ts', name: 'server.ts', kind: 'file' },
+      { path: 'ui/app.tsx', name: 'app.tsx', kind: 'file' },
+    ]
+  )
+  assert.equal(
+    await renderSessionFileContext(
+      [
+        { path: apiDirectory, prefix: 'api' },
+        { path: uiDirectory, prefix: 'ui' },
+      ],
+      'ui/app.tsx'
+    ),
+    '## Referenced file: `ui/app.tsx`\n\n```tsx\n\n```'
+  )
+})
+
+test('finds files and folders without exposing Git metadata', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'pi-workspace-file-context-'))
+  await mkdir(join(directory, '.git'))
+  await mkdir(join(directory, 'src'))
+  await writeFile(join(directory, 'src', 'app.ts'), '')
+
+  assert.deepEqual(await findSessionFiles(directory, 'app'), [{ path: 'src/app.ts', name: 'app.ts', kind: 'file' }])
+})

--- a/src/main/session-file-context.ts
+++ b/src/main/session-file-context.ts
@@ -1,0 +1,202 @@
+import { readdir, readFile, realpath, stat } from 'node:fs/promises'
+import { extname, relative, resolve, sep } from 'node:path'
+import type { SessionFile, SessionFileReference } from '@/src/session-files'
+
+const maximumCandidates = 50
+const maximumTraversalEntries = 2_000
+const maximumFileBytes = 50_000
+const maximumFolderEntries = 100
+
+export type SessionFileRoot = Readonly<{
+  path: string
+  prefix?: string
+}>
+
+type SessionFileRoots = string | readonly SessionFileRoot[]
+
+function normalizedRoots(roots: SessionFileRoots): readonly SessionFileRoot[] {
+  return typeof roots === 'string' ? [{ path: roots }] : roots
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${sep}`)
+}
+
+function isTaggedPathSyntaxValid(path: string): boolean {
+  return path.length > 0 && !path.startsWith('/') && !path.includes('\\') && !path.split('/').includes('..')
+}
+
+async function resolveTaggedPath(
+  root: string,
+  path: string
+): Promise<Readonly<{ absolutePath: string; relativePath: string }> | undefined> {
+  if (!isTaggedPathSyntaxValid(path)) return undefined
+
+  const rootPath = await realpath(root)
+  const absolutePath = resolve(rootPath, path)
+  if (!isWithin(rootPath, absolutePath)) return undefined
+
+  try {
+    const resolvedPath = await realpath(absolutePath)
+    if (!isWithin(rootPath, resolvedPath)) return undefined
+
+    return { absolutePath: resolvedPath, relativePath: relative(rootPath, resolvedPath) }
+  } catch {
+    return undefined
+  }
+}
+
+function rootForTaggedPath(
+  roots: SessionFileRoots,
+  path: string
+): Readonly<{ root: string; path: string; displayPath: string }> | undefined {
+  for (const candidate of normalizedRoots(roots)) {
+    if (!candidate.prefix) return { root: candidate.path, path, displayPath: path }
+    if (path.startsWith(`${candidate.prefix}/`)) {
+      return { root: candidate.path, path: path.slice(candidate.prefix.length + 1), displayPath: path }
+    }
+  }
+
+  return undefined
+}
+
+function isBinary(contents: Buffer): boolean {
+  return contents.includes(0)
+}
+
+function language(path: string): string {
+  const extension = extname(path).slice(1)
+  return /^[a-z0-9_-]+$/i.test(extension) ? extension : 'text'
+}
+
+function MarkdownCode(value: string): string {
+  const longestDelimiter = Math.max(0, ...(value.match(/`+/g) ?? []).map((delimiter) => delimiter.length))
+  const delimiter = '`'.repeat(longestDelimiter + 1)
+
+  return `${delimiter}${value}${delimiter}`
+}
+
+function markdownCodeFence(value: string): string {
+  const longestDelimiter = Math.max(0, ...(value.match(/`+/g) ?? []).map((delimiter) => delimiter.length))
+  return '`'.repeat(Math.max(3, longestDelimiter + 1))
+}
+
+function candidateRank(candidate: SessionFile, query: string): number {
+  const path = candidate.path.toLowerCase()
+  const name = candidate.name.toLowerCase()
+  if (path === query || name === query) return 0
+  if (path.startsWith(query) || name.startsWith(query)) return 1
+  return 2
+}
+
+export async function findSessionFiles(roots: SessionFileRoots, query = ''): Promise<readonly SessionFile[]> {
+  const normalizedQuery = query.toLowerCase()
+  const candidates: SessionFile[] = []
+
+  for (const root of normalizedRoots(roots)) {
+    const pending = ['']
+    let visited = 0
+
+    while (pending.length > 0 && candidates.length < maximumCandidates && visited < maximumTraversalEntries) {
+      const directory = pending.shift()
+      if (directory === undefined) break
+
+      let entries
+      try {
+        entries = await readdir(resolve(root.path, directory), { withFileTypes: true })
+      } catch {
+        continue
+      }
+
+      for (const entry of entries) {
+        visited += 1
+        if (entry.name === '.git' || visited > maximumTraversalEntries) continue
+
+        const relativePath = directory ? `${directory}/${entry.name}` : entry.name
+        const path = root.prefix ? `${root.prefix}/${relativePath}` : relativePath
+        const kind = entry.isDirectory() ? 'folder' : 'file'
+        const searchable = `${path} ${entry.name}`.toLowerCase()
+
+        if (normalizedQuery.length === 0 || searchable.includes(normalizedQuery)) {
+          candidates.push({ path, name: entry.name, kind })
+        }
+        if (entry.isDirectory()) pending.push(relativePath)
+        if (candidates.length >= maximumCandidates) break
+      }
+    }
+  }
+
+  return candidates.sort(
+    (left, right) =>
+      candidateRank(left, normalizedQuery) - candidateRank(right, normalizedQuery) ||
+      left.path.localeCompare(right.path)
+  )
+}
+
+export async function getSessionFileReference(roots: SessionFileRoots, path: string): Promise<SessionFileReference> {
+  const selectedRoot = rootForTaggedPath(roots, path)
+  if (!selectedRoot) return { path, kind: 'file', availability: 'unavailable' }
+
+  const taggedPath = await resolveTaggedPath(selectedRoot.root, selectedRoot.path)
+  if (!taggedPath) return { path, kind: 'file', availability: 'unavailable' }
+
+  try {
+    const details = await stat(taggedPath.absolutePath)
+    return {
+      path,
+      kind: details.isDirectory() ? 'folder' : 'file',
+      availability: details.isFile() || details.isDirectory() ? 'available' : 'unavailable',
+    }
+  } catch {
+    return { path, kind: 'file', availability: 'unavailable' }
+  }
+}
+
+export async function renderSessionFileContext(roots: SessionFileRoots, path: string): Promise<string | undefined> {
+  if (!isTaggedPathSyntaxValid(path)) return undefined
+
+  const selectedRoot = rootForTaggedPath(roots, path)
+  if (!selectedRoot) return `## Referenced path unavailable: ${MarkdownCode(path)}`
+
+  const taggedPath = await resolveTaggedPath(selectedRoot.root, selectedRoot.path)
+  if (!taggedPath) return `## Referenced path unavailable: ${MarkdownCode(path)}`
+
+  let details
+  try {
+    details = await stat(taggedPath.absolutePath)
+  } catch {
+    return `## Referenced path unavailable: ${MarkdownCode(path)}`
+  }
+
+  if (details.isDirectory()) {
+    let entries
+    try {
+      entries = await readdir(taggedPath.absolutePath, { withFileTypes: true })
+    } catch {
+      return `## Referenced path unavailable: ${MarkdownCode(path)}`
+    }
+    const listing = entries
+      .filter((entry) => entry.name !== '.git')
+      .slice(0, maximumFolderEntries)
+      .map((entry) => `- ${MarkdownCode(`${entry.name}${entry.isDirectory() ? '/' : ''}`)}`)
+      .join('\n')
+    const suffix = entries.length > maximumFolderEntries ? '\n- …' : ''
+
+    return `## Referenced folder: ${MarkdownCode(path)}\n\n${listing}${suffix}`
+  }
+  if (!details.isFile() || details.size > maximumFileBytes)
+    return `## Referenced path unavailable: ${MarkdownCode(path)}`
+
+  let contents: Buffer
+  try {
+    contents = await readFile(taggedPath.absolutePath)
+  } catch {
+    return `## Referenced path unavailable: ${MarkdownCode(path)}`
+  }
+  if (isBinary(contents)) return `## Referenced path unavailable: ${MarkdownCode(path)}`
+
+  const text = contents.toString('utf8')
+  const fence = markdownCodeFence(text)
+
+  return `## Referenced file: ${MarkdownCode(path)}\n\n${fence}${language(taggedPath.relativePath)}\n${text}\n${fence}`
+}

--- a/src/main/session-file-context.ts
+++ b/src/main/session-file-context.ts
@@ -81,9 +81,14 @@ function markdownCodeFence(value: string): string {
   return '`'.repeat(Math.max(3, longestDelimiter + 1))
 }
 
-function candidateRank(candidate: SessionFile, query: string): number {
+function candidateDepth(candidate: SessionFile): number {
+  return candidate.path.split('/').length - 1
+}
+
+function candidateMatchRank(candidate: SessionFile, query: string): number {
   const path = candidate.path.toLowerCase()
   const name = candidate.name.toLowerCase()
+
   if (path === query || name === query) return 0
   if (path.startsWith(query) || name.startsWith(query)) return 1
   return 2
@@ -128,7 +133,8 @@ export async function findSessionFiles(roots: SessionFileRoots, query = ''): Pro
 
   return candidates.sort(
     (left, right) =>
-      candidateRank(left, normalizedQuery) - candidateRank(right, normalizedQuery) ||
+      candidateDepth(left) - candidateDepth(right) ||
+      candidateMatchRank(left, normalizedQuery) - candidateMatchRank(right, normalizedQuery) ||
       left.path.localeCompare(right.path)
   )
 }

--- a/src/main/session-transcript-runtime.test.ts
+++ b/src/main/session-transcript-runtime.test.ts
@@ -96,6 +96,65 @@ test('persists an accepted action card across a runtime restart', async () => {
   assert.equal((await restartedRegistry.getTranscript(id)).actionCards?.[0]?.status, 'accepted')
 })
 
+test('rejects a tagged submission when file reference lookup fails', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {
+      assert.fail('A rejected file reference must not prompt the Agent.')
+    },
+    subscribe() {
+      return () => {}
+    },
+    async getFileReference() {
+      throw new Error('The managed Session policy is stale.')
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  assert.deepEqual(
+    await registry.submit({ sessionId: sessionId('file-lookup-session'), text: '@src/app.ts', delivery: 'steer' }),
+    { status: 'rejected', reason: 'unexpected' }
+  )
+})
+
+test('keeps file source metadata within the file context budget', async () => {
+  const prompts: string[] = []
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt(text) {
+      prompts.push(text)
+    },
+    subscribe() {
+      return () => {}
+    },
+    async getFileReference() {
+      return { path: 'src/app.ts', kind: 'file', availability: 'available' }
+    },
+    async getFileContext() {
+      return '## Referenced file: `src/app.ts`\\n\\n```ts\\nexport {}\\n```'
+    },
+    dispose() {},
+  }
+  const registry = createPiSessionRuntimeRegistry({
+    findSession: () => ({ directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl' }),
+    createSession: async () => runtime,
+  })
+
+  assert.deepEqual(
+    await registry.submit({
+      sessionId: sessionId('file-source-budget-session'),
+      text: `@src/app.ts ${'a'.repeat(75_000)}`,
+      delivery: 'steer',
+    }),
+    { status: 'rejected', reason: 'preflight-rejected' }
+  )
+  assert.deepEqual(prompts, [])
+})
+
 test('persists queued follow-ups until the user resumes the queue', async () => {
   let streaming = true
   let emit: (event: Parameters<Parameters<PiSessionRuntime['subscribe']>[0]>[0]) => void = () => {}

--- a/src/pi-workspace.ts
+++ b/src/pi-workspace.ts
@@ -2,6 +2,7 @@ import type { ComposerBridge } from '@/src/composer'
 import type { ApplicationStateBridge } from '@/src/application-state-ipc'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
+import type { SessionFilesBridge } from '@/src/session-files'
 import type { SessionTranscriptBridge } from '@/src/session-transcript'
 import type { SettingsBridge } from '@/src/settings'
 import type { WorkstreamsBridge } from '@/src/workstreams'
@@ -11,6 +12,7 @@ export type PiWorkspaceBridge = Readonly<{
   applicationState: ApplicationStateBridge
   composer: ComposerBridge
   sessionSkills: SessionSkillsBridge
+  sessionFiles: SessionFilesBridge
   sessionConfiguration: SessionConfigurationBridge
   transcript: SessionTranscriptBridge
   settings: SettingsBridge

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,8 @@ import type { PiWorkspaceBridge } from '@/src/pi-workspace'
 import { composerIpcChannels } from '@/src/composer-ipc'
 import type { SessionSkillsBridge } from '@/src/session-skills'
 import { sessionSkillsIpcChannels } from '@/src/session-skills-ipc'
+import type { SessionFilesBridge } from '@/src/session-files'
+import { sessionFilesIpcChannels } from '@/src/session-files-ipc'
 import type {
   SessionConfigurationBridge,
   SessionConfigurationCommandResult,
@@ -171,6 +173,12 @@ const sessionSkillsBridge: SessionSkillsBridge = {
   },
 }
 
+const sessionFilesBridge: SessionFilesBridge = {
+  getAvailable(sessionId, query) {
+    return ipcRenderer.invoke(sessionFilesIpcChannels.getAvailable, { sessionId, query })
+  },
+}
+
 const sessionConfigurationBridge: SessionConfigurationBridge = {
   getSnapshot(sessionId) {
     return ipcRenderer.invoke(sessionConfigurationIpcChannels.getSnapshot, {
@@ -242,6 +250,7 @@ const piWorkspaceBridge: PiWorkspaceBridge = {
   applicationState: applicationStateBridge,
   composer: composerBridge,
   sessionSkills: sessionSkillsBridge,
+  sessionFiles: sessionFilesBridge,
   sessionConfiguration: sessionConfigurationBridge,
   transcript: sessionTranscriptBridge,
   settings: settingsBridge,

--- a/src/queued-follow-up.ts
+++ b/src/queued-follow-up.ts
@@ -1,9 +1,12 @@
 import type { SessionSkillMention } from '@/src/session-skills'
+import type { SessionFileMention } from '@/src/session-files'
 
 export type QueuedFollowUp = Readonly<{
   id: string
   text: string
+  sourceText?: string
   skills?: readonly SessionSkillMention[]
+  files?: readonly SessionFileMention[]
   createdAt: number
 }>
 

--- a/src/renderer/components/composer-editor.tsx
+++ b/src/renderer/components/composer-editor.tsx
@@ -27,7 +27,7 @@ import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin'
-import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import type { SessionMessageDelivery } from '@/src/composer'
 import {
   $createComposerFileNode,
@@ -243,6 +243,12 @@ function ComposerEditorPlugins({
   editorHandle: React.Ref<ComposerEditorHandle>
 }) {
   const [editor] = useLexicalComposerContext()
+  const latestEditorDraft = useRef(draft)
+  const editorDraftIsPending = useRef(false)
+  if (latestEditorDraft.current !== draft) {
+    latestEditorDraft.current = draft
+    editorDraftIsPending.current = false
+  }
 
   useImperativeHandle(editorHandle, () => ({
     focus() {
@@ -285,19 +291,62 @@ function ComposerEditorPlugins({
 
   useEffect(() => {
     editor.getEditorState().read(() => {
-      if (normalizeComposerCaretMarkers($getRoot().getTextContent()) === draft) return
+      const currentDraft = normalizeComposerCaretMarkers($getRoot().getTextContent())
+      if (currentDraft === draft) return
+      if (editorDraftIsPending.current && latestEditorDraft.current === currentDraft) return
 
+      latestEditorDraft.current = draft
+      editorDraftIsPending.current = false
       editor.update(() => replaceDraft(draft, availableSkills, availableFiles), { tag: externalDraftUpdateTag })
     })
   }, [availableFiles, availableSkills, draft, editor])
 
   useEffect(() => {
+    let needsUpdate = false
+    editor.getEditorState().read(() => {
+      for (const node of $nodesOfType(ComposerSkillNode)) {
+        const skill = skillReference(node.getSkill().name, availableSkills)
+        const currentSkill = node.getSkill()
+        if (currentSkill.name !== skill.name || currentSkill.availability !== skill.availability) {
+          needsUpdate = true
+          break
+        }
+      }
+
+      if (needsUpdate) return
+
+      for (const node of $nodesOfType(ComposerFileNode)) {
+        const file = fileReference(node.getFile().path, availableFiles)
+        const currentFile = node.getFile()
+        if (
+          currentFile.path !== file.path ||
+          currentFile.kind !== file.kind ||
+          currentFile.availability !== file.availability
+        ) {
+          needsUpdate = true
+          break
+        }
+      }
+    })
+
+    if (!needsUpdate) return
+
     editor.update(() => {
       for (const node of $nodesOfType(ComposerSkillNode)) {
-        node.setSkill(skillReference(node.getSkill().name, availableSkills))
+        const skill = skillReference(node.getSkill().name, availableSkills)
+        const currentSkill = node.getSkill()
+        if (currentSkill.name !== skill.name || currentSkill.availability !== skill.availability) node.setSkill(skill)
       }
       for (const node of $nodesOfType(ComposerFileNode)) {
-        node.setFile(fileReference(node.getFile().path, availableFiles))
+        const file = fileReference(node.getFile().path, availableFiles)
+        const currentFile = node.getFile()
+        if (
+          currentFile.path !== file.path ||
+          currentFile.kind !== file.kind ||
+          currentFile.availability !== file.availability
+        ) {
+          node.setFile(file)
+        }
       }
     })
   }, [availableFiles, availableSkills, editor])
@@ -413,7 +462,24 @@ function ComposerEditorPlugins({
       editor.registerCommand(
         CONTROLLED_TEXT_INSERTION_COMMAND,
         (text) => {
-          if ($getSelection() !== null || typeof text !== 'string') return false
+          if (typeof text !== 'string') return false
+
+          const selection = $getSelection()
+          if ($isRangeSelection(selection) && selection.isCollapsed() && selection.anchor.type === 'text') {
+            const marker = selection.anchor.getNode()
+            const referenceNode = $isTextNode(marker) ? marker.getPreviousSibling() : undefined
+            if (
+              $isTextNode(marker) &&
+              marker.getTextContent() === composerCaretMarker &&
+              selection.anchor.offset === composerCaretMarker.length &&
+              ($isComposerSkillNode(referenceNode) || $isComposerFileNode(referenceNode))
+            ) {
+              marker.setTextContent(`${composerCaretMarker}${text}`).selectEnd()
+              return true
+            }
+          }
+
+          if (selection !== null) return false
 
           const firstElement = $getRoot().getFirstChild()
           if (!$isElementNode(firstElement)) return false
@@ -515,6 +581,8 @@ function ComposerEditorPlugins({
         editorState.read(() => {
           const nextDraft = normalizeComposerCaretMarkers($getRoot().getTextContent())
 
+          latestEditorDraft.current = nextDraft
+          editorDraftIsPending.current = true
           if (nextDraft !== draft) {
             onChange(nextDraft)
           }
@@ -564,7 +632,7 @@ function findSkillQuery(draft: string, caretOffset: number): SkillQuery | undefi
 
 function findFileQuery(draft: string, caretOffset: number): SkillQuery | undefined {
   const textBeforeCaret = draft.slice(0, caretOffset)
-  const match = /(?:^|\s)@([^\s@,.;:!?)}\]]*)$/.exec(textBeforeCaret)
+  const match = /(?:^|\s)@([^\s@,;:!?)}\]]*)$/.exec(textBeforeCaret)
   if (!match) return undefined
 
   const search = (match[1] ?? '').toLowerCase()
@@ -641,6 +709,29 @@ function canonicalDraftOffset(draft: string, visibleOffset: number): number {
   }
 
   return sourceOffset + visibleOffset - currentVisibleOffset
+}
+
+function visibleDraftOffset(draft: string, canonicalOffset: number): number {
+  let sourceOffset = 0
+  let visibleOffset = 0
+
+  for (const token of composerReferenceTokens(draft)) {
+    const plainTextLength = token.startOffset - sourceOffset
+    if (canonicalOffset <= sourceOffset + plainTextLength) {
+      return visibleOffset + canonicalOffset - sourceOffset
+    }
+
+    visibleOffset += plainTextLength
+
+    if (canonicalOffset <= token.endOffset) {
+      return visibleOffset + (canonicalOffset === token.startOffset ? 0 : token.visibleLength)
+    }
+
+    sourceOffset = token.endOffset
+    visibleOffset += token.visibleLength
+  }
+
+  return visibleOffset + canonicalOffset - sourceOffset
 }
 
 function insertSkillAtSelection(skill: SessionSkill): string | undefined {
@@ -964,6 +1055,19 @@ function SkillAutocomplete({
   )
 }
 
+function scrollOptionIntoView(listbox: HTMLElement, option: HTMLElement): void {
+  const optionTop = option.offsetTop
+  const optionBottom = optionTop + option.offsetHeight
+
+  if (optionTop < listbox.scrollTop) {
+    listbox.scrollTop = optionTop
+    return
+  }
+
+  const visibleBottom = listbox.scrollTop + listbox.clientHeight
+  if (optionBottom > visibleBottom) listbox.scrollTop = optionBottom - listbox.clientHeight
+}
+
 function FileAutocomplete({
   availableFiles,
   availableSkills,
@@ -977,6 +1081,7 @@ function FileAutocomplete({
 }>) {
   const [editor] = useLexicalComposerContext()
   const listboxId = useId()
+  const listboxRef = useRef<HTMLDivElement>(null)
   const [activeIndex, setActiveIndex] = useState(0)
   const [query, setQuery] = useState<SkillQuery>()
   const [dismissedQuery, setDismissedQuery] = useState<string>()
@@ -987,11 +1092,28 @@ function FileAutocomplete({
         : availableFiles.filter((file) => file.path.toLowerCase().includes(query.search)),
     [availableFiles, disabled, dismissedQuery, query]
   )
+  const activeOptionId = options[activeIndex] ? `${listboxId}-option-${activeIndex}` : undefined
+
+  useEffect(() => {
+    if (!activeOptionId || !listboxRef.current) return
+
+    const activeOption = listboxRef.current.ownerDocument.getElementById(activeOptionId)
+    if (activeOption) scrollOptionIntoView(listboxRef.current, activeOption)
+  }, [activeOptionId])
 
   useEffect(() => {
     const root = editor.getRootElement()
     if (!root) return
-    const update = () => setQuery(disabled ? undefined : getDOMFileQuery(editor))
+
+    let frame: number | undefined
+    const update = () => {
+      if (frame !== undefined) window.cancelAnimationFrame(frame)
+      frame = window.requestAnimationFrame(() => {
+        frame = undefined
+        setQuery(disabled ? undefined : getDOMFileQuery(editor))
+      })
+    }
+
     root.addEventListener('input', update)
     root.addEventListener('keyup', update)
     root.addEventListener('focus', update)
@@ -1002,6 +1124,7 @@ function FileAutocomplete({
       root.removeEventListener('keyup', update)
       root.removeEventListener('focus', update)
       document.removeEventListener('selectionchange', update)
+      if (frame !== undefined) window.cancelAnimationFrame(frame)
     }
   }, [disabled, editor])
 
@@ -1011,7 +1134,7 @@ function FileAutocomplete({
 
   useEffect(() => {
     setActiveIndex(0)
-    if (dismissedQuery !== query?.signature) setDismissedQuery(undefined)
+    if (query?.signature && dismissedQuery !== query.signature) setDismissedQuery(undefined)
   }, [dismissedQuery, query?.signature])
 
   const select = useCallback(
@@ -1025,20 +1148,34 @@ function FileAutocomplete({
       const token = sessionFileToken(file.path)
       const nextDraft = `${currentDraft.slice(0, query.startOffset)}${token}${suffix.length > 0 ? ` ${suffix}` : ''}`
       let markerKey: string | undefined
+
+      setQuery(undefined)
+      setDismissedQuery(`${query.startOffset}:${query.startOffset + token.length}:${file.path.toLowerCase()}`)
       editor.update(
         () => {
           replaceDraft(currentDraft, availableSkills, availableFiles)
-          selectDraftOffset(query.endOffset)
+          selectDraftOffset(visibleDraftOffset(currentDraft, query.endOffset))
           markerKey = insertFileAtSelection(file)
-          if (!markerKey) replaceDraft(nextDraft, availableSkills, availableFiles)
+          if (!markerKey) replaceDraft(nextDraft, availableSkills, availableFiles, true)
         },
         {
           discrete: true,
           onUpdate() {
-            setDismissedQuery(
-              `${query.startOffset}:${query.startOffset + file.path.length + 1}:${file.path.toLowerCase()}`
-            )
-            root.focus()
+            if (!markerKey) return
+
+            const rootElement = editor.getRootElement()
+            const markerElement = editor.getElementByKey(markerKey)
+            const markerText = markerElement?.firstChild
+            if (!rootElement || !markerText) return
+
+            rootElement.focus()
+            const range = document.createRange()
+            range.setStart(markerText, markerText.textContent?.length ?? 0)
+            range.collapse(true)
+
+            const selection = window.getSelection()
+            selection?.removeAllRanges()
+            selection?.addRange(range)
           },
         }
       )
@@ -1098,6 +1235,7 @@ function FileAutocomplete({
 
   return (
     <div
+      ref={listboxRef}
       aria-label="Files and folders"
       id={listboxId}
       className="absolute right-3.5 bottom-full left-3.5 z-30 mb-1 max-h-64 overflow-y-auto rounded-lg border border-content-border bg-content-background p-1 shadow-lg"

--- a/src/renderer/components/composer-editor.tsx
+++ b/src/renderer/components/composer-editor.tsx
@@ -30,13 +30,26 @@ import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin'
 import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useState } from 'react'
 import type { SessionMessageDelivery } from '@/src/composer'
 import {
+  $createComposerFileNode,
+  $getComposerFileNode,
+  $isComposerFileNode,
+  ComposerFileNode,
+  removeComposerFileCommand,
+} from '@/src/renderer/components/composer-file-node'
+import {
   $createComposerSkillNode,
   $getComposerSkillNode,
   $isComposerSkillNode,
   ComposerSkillNode,
   removeComposerSkillCommand,
 } from '@/src/renderer/components/composer-skill-node'
-import { projectSessionSkillSelections, type SessionSkill, type SessionSkillReference } from '@/src/session-skills'
+import type { SessionSkill, SessionSkillReference } from '@/src/session-skills'
+import {
+  findSessionFileTokens,
+  sessionFileToken,
+  type SessionFile,
+  type SessionFileReference,
+} from '@/src/session-files'
 
 const externalDraftUpdateTag = 'composer-external-draft'
 const composerCaretMarker = '\u00a0'
@@ -49,12 +62,14 @@ export type ComposerEditorHandle = Readonly<{
 
 type ComposerEditorProperties = Readonly<{
   availableSkills: readonly SessionSkill[]
+  availableFiles: readonly SessionFile[]
   describedBy: string
   draft: string
   label: string
   readOnly: boolean
   onChange: (draft: string) => void
   onFocus: () => void
+  onFileQuery: (query: string) => void
   onSubmit: (delivery: SessionMessageDelivery) => void
 }>
 
@@ -78,20 +93,70 @@ function skillReference(skillName: string, availableSkills: readonly SessionSkil
   return available ? { ...available, availability: 'available' } : { name: skillName, availability: 'unavailable' }
 }
 
-function replaceDraft(draft: string, availableSkills: readonly SessionSkill[], selectEnd = false): void {
+function fileReference(path: string, availableFiles: readonly SessionFile[]): SessionFileReference {
+  const available = availableFiles.find((file) => file.path === path)
+
+  return available
+    ? { path: available.path, kind: available.kind, availability: 'available' }
+    : { path, kind: 'file', availability: 'unavailable' }
+}
+
+type ComposerReferenceToken = Readonly<{
+  startOffset: number
+  endOffset: number
+  visibleLength: number
+  type: 'skill' | 'file'
+  value: string
+}>
+
+function composerReferenceTokens(draft: string): readonly ComposerReferenceToken[] {
+  const skills = [...draft.matchAll(/(?<!\S)\/skill:([a-z0-9]+(?:-[a-z0-9]+)*)/g)].flatMap((match) => {
+    const name = match[1]
+    const startOffset = match.index
+    if (!name || startOffset === undefined) return []
+
+    return [
+      {
+        startOffset,
+        endOffset: startOffset + match[0].length,
+        visibleLength: name.length,
+        type: 'skill' as const,
+        value: name,
+      },
+    ]
+  })
+  const files = findSessionFileTokens(draft).map((token) => ({
+    startOffset: token.startOffset,
+    endOffset: token.endOffset,
+    visibleLength: token.path.length + 1,
+    type: 'file' as const,
+    value: token.path,
+  }))
+
+  return [...skills, ...files].sort((left, right) => left.startOffset - right.startOffset)
+}
+
+function replaceDraft(
+  draft: string,
+  availableSkills: readonly SessionSkill[],
+  availableFiles: readonly SessionFile[] = [],
+  selectEnd = false
+): void {
   const root = $getRoot()
   const paragraph = $createParagraphNode()
-  const projected = projectSessionSkillSelections(draft)
   let textOffset = 0
 
-  for (const selection of projected.selections) {
-    appendPlainText(paragraph, projected.text.slice(textOffset, selection.offset))
-    paragraph.append($createComposerSkillNode(skillReference(selection.name, availableSkills)))
-    textOffset = selection.offset
+  for (const token of composerReferenceTokens(draft)) {
+    appendPlainText(paragraph, draft.slice(textOffset, token.startOffset))
+    if (token.type === 'skill') paragraph.append($createComposerSkillNode(skillReference(token.value, availableSkills)))
+    else paragraph.append($createComposerFileNode(fileReference(token.value, availableFiles)))
+    textOffset = token.endOffset
   }
 
-  appendPlainText(paragraph, projected.text.slice(textOffset))
-  if ($isComposerSkillNode(paragraph.getLastChild())) paragraph.append($createTextNode(composerCaretMarker))
+  appendPlainText(paragraph, draft.slice(textOffset))
+  if ($isComposerSkillNode(paragraph.getLastChild()) || $isComposerFileNode(paragraph.getLastChild())) {
+    paragraph.append($createTextNode(composerCaretMarker))
+  }
   root.clear().append(paragraph)
 
   if (selectEnd) paragraph.selectEnd()
@@ -116,11 +181,22 @@ function getDOMComposerDraft(node: Node): string {
   if (node instanceof HTMLElement && node.hasAttribute('data-skill-reference')) {
     return `/skill:${node.getAttribute('data-skill-reference') ?? ''}`
   }
+  if (node instanceof HTMLElement && node.hasAttribute('data-file-reference')) {
+    return sessionFileToken(node.getAttribute('data-file-reference') ?? '')
+  }
 
   if (node.nodeType === Node.TEXT_NODE) return normalizeComposerCaretMarkers(node.textContent ?? '')
-  if (node.nodeName === 'BR') return '\n'
+  if (node.nodeName === 'BR') {
+    return node instanceof HTMLElement && node.hasAttribute('data-lexical-managed-linebreak') ? '' : '\n'
+  }
 
-  const childText = Array.from(node.childNodes, getDOMComposerDraft).join('')
+  const children =
+    node instanceof HTMLElement &&
+    node.hasAttribute('data-lexical-editor') &&
+    node.querySelector('[data-file-reference]')
+      ? Array.from(node.childNodes).filter((child) => child.nodeType !== Node.TEXT_NODE)
+      : Array.from(node.childNodes)
+  const childText = children.map(getDOMComposerDraft).join('')
   return htmlBlockNames.has(node.nodeName) && childText.length > 0 && !childText.endsWith('\n')
     ? `${childText}\n`
     : childText
@@ -142,24 +218,28 @@ function getPlainClipboardText(clipboardData: DataTransfer): string {
   return getDOMPlainText(new DOMParser().parseFromString(html, 'text/html').body).replace(/\n+$/, '')
 }
 
-function removeSkillNode(skillNode: ComposerSkillNode): void {
-  const nextSibling = skillNode.getNextSibling()
+function removeInlineReferenceNode(referenceNode: ComposerSkillNode | ComposerFileNode): void {
+  const nextSibling = referenceNode.getNextSibling()
   if ($isTextNode(nextSibling) && nextSibling.getTextContent().includes(composerCaretMarker)) {
     const text = nextSibling.getTextContent().replaceAll(composerCaretMarker, '')
     if (text.length > 0) nextSibling.setTextContent(text)
     else nextSibling.remove()
   }
-  skillNode.remove()
+  referenceNode.remove()
 }
 
 function ComposerEditorPlugins({
   availableSkills,
+  availableFiles,
   draft,
   readOnly,
   onChange,
   onSubmit,
   editorHandle,
-}: Pick<ComposerEditorProperties, 'availableSkills' | 'draft' | 'readOnly' | 'onChange' | 'onSubmit'> & {
+}: Pick<
+  ComposerEditorProperties,
+  'availableSkills' | 'availableFiles' | 'draft' | 'readOnly' | 'onChange' | 'onSubmit'
+> & {
   editorHandle: React.Ref<ComposerEditorHandle>
 }) {
   const [editor] = useLexicalComposerContext()
@@ -207,17 +287,20 @@ function ComposerEditorPlugins({
     editor.getEditorState().read(() => {
       if (normalizeComposerCaretMarkers($getRoot().getTextContent()) === draft) return
 
-      editor.update(() => replaceDraft(draft, availableSkills), { tag: externalDraftUpdateTag })
+      editor.update(() => replaceDraft(draft, availableSkills, availableFiles), { tag: externalDraftUpdateTag })
     })
-  }, [availableSkills, draft, editor])
+  }, [availableFiles, availableSkills, draft, editor])
 
   useEffect(() => {
     editor.update(() => {
       for (const node of $nodesOfType(ComposerSkillNode)) {
         node.setSkill(skillReference(node.getSkill().name, availableSkills))
       }
+      for (const node of $nodesOfType(ComposerFileNode)) {
+        node.setFile(fileReference(node.getFile().path, availableFiles))
+      }
     })
-  }, [availableSkills, editor])
+  }, [availableFiles, availableSkills, editor])
 
   useEffect(
     () =>
@@ -313,6 +396,7 @@ function ComposerEditorPlugins({
             replaceDraft(
               `${normalizeComposerCaretMarkers($getRoot().getTextContent())}${plainText}`,
               availableSkills,
+              availableFiles,
               true
             )
           })
@@ -321,7 +405,7 @@ function ComposerEditorPlugins({
         },
         COMMAND_PRIORITY_HIGH
       ),
-    [availableSkills, editor]
+    [availableFiles, availableSkills, editor]
   )
 
   useEffect(
@@ -337,8 +421,8 @@ function ComposerEditorPlugins({
           const marker = firstElement.getLastChild()
           if (!$isTextNode(marker) || marker.getTextContent() !== composerCaretMarker) return false
 
-          const skillNode = marker.getPreviousSibling()
-          if (!$isComposerSkillNode(skillNode)) return false
+          const referenceNode = marker.getPreviousSibling()
+          if (!$isComposerSkillNode(referenceNode) && !$isComposerFileNode(referenceNode)) return false
 
           marker.setTextContent(`${composerCaretMarker}${text}`).selectEnd()
           return true
@@ -357,11 +441,11 @@ function ComposerEditorPlugins({
 
           const selection = $getSelection()
           if (selection === null) {
-            const skillNode = $nodesOfType(ComposerSkillNode).at(-1)
-            if (!skillNode) return false
+            const referenceNode = [...$nodesOfType(ComposerSkillNode), ...$nodesOfType(ComposerFileNode)].at(-1)
+            if (!referenceNode) return false
 
             event.preventDefault()
-            removeSkillNode(skillNode)
+            removeInlineReferenceNode(referenceNode)
             return true
           }
           if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false
@@ -376,10 +460,10 @@ function ComposerEditorPlugins({
               : anchor.offset === 0 && $isTextNode(anchorNode)
                 ? anchorNode.getPreviousSibling()
                 : undefined
-          if (!$isComposerSkillNode(previousNode)) return false
+          if (!$isComposerSkillNode(previousNode) && !$isComposerFileNode(previousNode)) return false
 
           event.preventDefault()
-          removeSkillNode(previousNode)
+          removeInlineReferenceNode(previousNode)
           return true
         },
         COMMAND_PRIORITY_CRITICAL
@@ -395,7 +479,24 @@ function ComposerEditorPlugins({
           const skillNode = $getComposerSkillNode(nodeKey)
           if (!skillNode) return false
 
-          removeSkillNode(skillNode)
+          removeInlineReferenceNode(skillNode)
+          editor.focus()
+          return true
+        },
+        COMMAND_PRIORITY_CRITICAL
+      ),
+    [editor]
+  )
+
+  useEffect(
+    () =>
+      editor.registerCommand(
+        removeComposerFileCommand,
+        (nodeKey) => {
+          const fileNode = $getComposerFileNode(nodeKey)
+          if (!fileNode) return false
+
+          removeInlineReferenceNode(fileNode)
           editor.focus()
           return true
         },
@@ -425,7 +526,12 @@ function ComposerEditorPlugins({
   return (
     <>
       <HistoryPlugin />
-      <SkillAutocomplete availableSkills={availableSkills} draft={draft} disabled={readOnly} />
+      <SkillAutocomplete
+        availableSkills={availableSkills}
+        availableFiles={availableFiles}
+        draft={draft}
+        disabled={readOnly}
+      />
     </>
   )
 }
@@ -454,6 +560,17 @@ function findSkillQuery(draft: string, caretOffset: number): SkillQuery | undefi
     search,
     signature: `${startOffset}:${caretOffset}:${search}`,
   }
+}
+
+function findFileQuery(draft: string, caretOffset: number): SkillQuery | undefined {
+  const textBeforeCaret = draft.slice(0, caretOffset)
+  const match = /(?:^|\s)@([^\s@,.;:!?)}\]]*)$/.exec(textBeforeCaret)
+  if (!match) return undefined
+
+  const search = (match[1] ?? '').toLowerCase()
+  const startOffset = caretOffset - search.length - 1
+
+  return { draft, startOffset, endOffset: caretOffset, search, signature: `${startOffset}:${caretOffset}:${search}` }
 }
 
 function getDOMTextLength(node: Node): number {
@@ -504,19 +621,26 @@ function getDOMSkillQuery(editor: LexicalEditor): SkillQuery | undefined {
 }
 
 function canonicalDraftOffset(draft: string, visibleOffset: number): number {
-  const { selections } = projectSessionSkillSelections(draft)
-  let precedingSkillNameLength = 0
-  let tokenPrefixLength = 0
+  let sourceOffset = 0
+  let currentVisibleOffset = 0
 
-  for (const selection of selections) {
-    const visibleSkillEnd = selection.offset + precedingSkillNameLength + selection.name.length
-    if (visibleSkillEnd > visibleOffset) break
+  for (const token of composerReferenceTokens(draft)) {
+    const plainTextLength = token.startOffset - sourceOffset
+    if (visibleOffset <= currentVisibleOffset + plainTextLength) {
+      return sourceOffset + visibleOffset - currentVisibleOffset
+    }
 
-    precedingSkillNameLength += selection.name.length
-    tokenPrefixLength += '/skill:'.length
+    currentVisibleOffset += plainTextLength
+
+    if (visibleOffset <= currentVisibleOffset + token.visibleLength) {
+      return visibleOffset === currentVisibleOffset ? token.startOffset : token.endOffset
+    }
+
+    sourceOffset = token.endOffset
+    currentVisibleOffset += token.visibleLength
   }
 
-  return visibleOffset + tokenPrefixLength
+  return sourceOffset + visibleOffset - currentVisibleOffset
 }
 
 function insertSkillAtSelection(skill: SessionSkill): string | undefined {
@@ -536,6 +660,45 @@ function insertSkillAtSelection(skill: SessionSkill): string | undefined {
 
   const marker = $createTextNode(composerCaretMarker)
   selection.insertNodes([$createComposerSkillNode({ ...skill, availability: 'available' }), marker])
+  marker.select(composerCaretMarker.length, composerCaretMarker.length)
+  return marker.getKey()
+}
+
+function getDOMFileQuery(editor: LexicalEditor): SkillQuery | undefined {
+  const rootElement = editor.getRootElement()
+  if (!rootElement) return undefined
+
+  const draft = getDOMComposerDraft(rootElement).replace(/\n+$/, '')
+  const selection = window.getSelection()
+  const visibleCaretOffset =
+    selection?.isCollapsed && selection.anchorNode && rootElement.contains(selection.anchorNode)
+      ? getDOMOffsetWithin(rootElement, selection.anchorNode, selection.anchorOffset)
+      : undefined
+  const caretOffset = visibleCaretOffset === undefined ? undefined : canonicalDraftOffset(draft, visibleCaretOffset)
+
+  return caretOffset === undefined ? undefined : findFileQuery(draft, caretOffset)
+}
+
+function insertFileAtSelection(file: SessionFile): string | undefined {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection) || !selection.isCollapsed() || selection.anchor.type !== 'text') return undefined
+
+  const anchorNode = selection.anchor.getNode()
+  if (!$isTextNode(anchorNode)) return undefined
+
+  const textBeforeCaret = anchorNode.getTextContent().slice(0, selection.anchor.offset)
+  const match = /(?:^|\s)@([^\s@]*)$/.exec(textBeforeCaret)
+  if (!match) return undefined
+
+  const queryLength = (match[1]?.length ?? 0) + 1
+  const queryStart = selection.anchor.offset - queryLength
+  selection.setTextNodeRange(anchorNode, queryStart, anchorNode, selection.anchor.offset)
+
+  const marker = $createTextNode(composerCaretMarker)
+  selection.insertNodes([
+    $createComposerFileNode({ path: file.path, kind: file.kind, availability: 'available' }),
+    marker,
+  ])
   marker.select(composerCaretMarker.length, composerCaretMarker.length)
   return marker.getKey()
 }
@@ -562,10 +725,12 @@ function selectDraftOffset(offset: number): void {
 
 function SkillAutocomplete({
   availableSkills,
+  availableFiles,
   draft,
   disabled,
 }: Readonly<{
   availableSkills: readonly SessionSkill[]
+  availableFiles: readonly SessionFile[]
   draft: string
   disabled: boolean
 }>) {
@@ -671,12 +836,12 @@ function SkillAutocomplete({
       const nextDraft = `${currentDraft.slice(0, startOffset)}${token}${currentDraft.slice(endOffset)}`
       let markerKey: string | undefined
       const insert = () => {
-        replaceDraft(currentDraft, availableSkills)
+        replaceDraft(currentDraft, availableSkills, availableFiles)
         selectDraftOffset(endOffset)
         markerKey = insertSkillAtSelection(skill)
 
         if (!markerKey) {
-          replaceDraft(nextDraft, availableSkills)
+          replaceDraft(nextDraft, availableSkills, availableFiles)
           selectDraftOffset(startOffset + token.length)
         }
       }
@@ -702,7 +867,7 @@ function SkillAutocomplete({
         },
       })
     },
-    [availableSkills, editor, query]
+    [availableFiles, availableSkills, editor, query]
   )
 
   useEffect(() => {
@@ -799,8 +964,168 @@ function SkillAutocomplete({
   )
 }
 
+function FileAutocomplete({
+  availableFiles,
+  availableSkills,
+  disabled,
+  onQuery,
+}: Readonly<{
+  availableFiles: readonly SessionFile[]
+  availableSkills: readonly SessionSkill[]
+  disabled: boolean
+  onQuery: (query: string) => void
+}>) {
+  const [editor] = useLexicalComposerContext()
+  const listboxId = useId()
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [query, setQuery] = useState<SkillQuery>()
+  const [dismissedQuery, setDismissedQuery] = useState<string>()
+  const options = useMemo(
+    () =>
+      disabled || !query || dismissedQuery === query.signature
+        ? []
+        : availableFiles.filter((file) => file.path.toLowerCase().includes(query.search)),
+    [availableFiles, disabled, dismissedQuery, query]
+  )
+
+  useEffect(() => {
+    const root = editor.getRootElement()
+    if (!root) return
+    const update = () => setQuery(disabled ? undefined : getDOMFileQuery(editor))
+    root.addEventListener('input', update)
+    root.addEventListener('keyup', update)
+    root.addEventListener('focus', update)
+    document.addEventListener('selectionchange', update)
+    update()
+    return () => {
+      root.removeEventListener('input', update)
+      root.removeEventListener('keyup', update)
+      root.removeEventListener('focus', update)
+      document.removeEventListener('selectionchange', update)
+    }
+  }, [disabled, editor])
+
+  useEffect(() => {
+    onQuery(query?.search ?? '')
+  }, [onQuery, query?.search])
+
+  useEffect(() => {
+    setActiveIndex(0)
+    if (dismissedQuery !== query?.signature) setDismissedQuery(undefined)
+  }, [dismissedQuery, query?.signature])
+
+  const select = useCallback(
+    (file: SessionFile) => {
+      if (!query) return
+      const root = editor.getRootElement()
+      if (!root) return
+
+      const currentDraft = getDOMComposerDraft(root).replace(/\n+$/, '')
+      const suffix = currentDraft.slice(query.endOffset)
+      const token = sessionFileToken(file.path)
+      const nextDraft = `${currentDraft.slice(0, query.startOffset)}${token}${suffix.length > 0 ? ` ${suffix}` : ''}`
+      let markerKey: string | undefined
+      editor.update(
+        () => {
+          replaceDraft(currentDraft, availableSkills, availableFiles)
+          selectDraftOffset(query.endOffset)
+          markerKey = insertFileAtSelection(file)
+          if (!markerKey) replaceDraft(nextDraft, availableSkills, availableFiles)
+        },
+        {
+          discrete: true,
+          onUpdate() {
+            setDismissedQuery(
+              `${query.startOffset}:${query.startOffset + file.path.length + 1}:${file.path.toLowerCase()}`
+            )
+            root.focus()
+          },
+        }
+      )
+    },
+    [availableFiles, availableSkills, editor, query]
+  )
+
+  useEffect(() => {
+    const unregister = [
+      editor.registerCommand(
+        KEY_ARROW_DOWN_COMMAND,
+        (event) => {
+          if (options.length === 0) return false
+          event?.preventDefault()
+          setActiveIndex((index) => (index + 1) % options.length)
+          return true
+        },
+        COMMAND_PRIORITY_CRITICAL
+      ),
+      editor.registerCommand(
+        KEY_ARROW_UP_COMMAND,
+        (event) => {
+          if (options.length === 0) return false
+          event?.preventDefault()
+          setActiveIndex((index) => (index - 1 + options.length) % options.length)
+          return true
+        },
+        COMMAND_PRIORITY_CRITICAL
+      ),
+      editor.registerCommand(
+        KEY_ENTER_COMMAND,
+        (event) => {
+          const file = options[activeIndex]
+          if (!event || !file) return false
+          event.preventDefault()
+          select(file)
+          return true
+        },
+        COMMAND_PRIORITY_CRITICAL
+      ),
+      editor.registerCommand(
+        KEY_TAB_COMMAND,
+        (event) => {
+          const file = options[activeIndex]
+          if (!event || !file) return false
+          event.preventDefault()
+          select(file)
+          return true
+        },
+        COMMAND_PRIORITY_CRITICAL
+      ),
+    ]
+    return () => unregister.forEach((dispose) => dispose())
+  }, [activeIndex, editor, options, select])
+
+  if (!query || options.length === 0) return null
+
+  return (
+    <div
+      aria-label="Files and folders"
+      id={listboxId}
+      className="absolute right-3.5 bottom-full left-3.5 z-30 mb-1 max-h-64 overflow-y-auto rounded-lg border border-content-border bg-content-background p-1 shadow-lg"
+      role="listbox"
+    >
+      {options.map((file, index) => (
+        <button
+          key={file.path}
+          id={`${listboxId}-option-${index}`}
+          type="button"
+          aria-selected={index === activeIndex}
+          className="block w-full rounded-md px-2.5 py-2 text-left hover:bg-session-interaction data-[selected=true]:bg-session-interaction"
+          onMouseDown={(event) => event.preventDefault()}
+          data-selected={index === activeIndex ? 'true' : undefined}
+          onClick={() => select(file)}
+          onMouseEnter={() => setActiveIndex(index)}
+          role="option"
+        >
+          <div className="text-sm/5 font-medium text-content-foreground">{file.path}</div>
+          <div className="text-xs/5 text-content-muted-foreground">{file.kind}</div>
+        </button>
+      ))}
+    </div>
+  )
+}
+
 export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorProperties>(function ComposerEditor(
-  { availableSkills, describedBy, draft, label, readOnly, onChange, onFocus, onSubmit },
+  { availableSkills, availableFiles, describedBy, draft, label, readOnly, onChange, onFocus, onFileQuery, onSubmit },
   editorHandle
 ) {
   return (
@@ -808,8 +1133,8 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
       initialConfig={{
         namespace: `Composer:${label}`,
         editable: !readOnly,
-        editorState: () => replaceDraft(draft, availableSkills, true),
-        nodes: [ComposerSkillNode],
+        editorState: () => replaceDraft(draft, availableSkills, availableFiles, true),
+        nodes: [ComposerSkillNode, ComposerFileNode],
         onError(error) {
           throw error
         },
@@ -842,11 +1167,18 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         </div>
         <ComposerEditorPlugins
           availableSkills={availableSkills}
+          availableFiles={availableFiles}
           draft={draft}
           readOnly={readOnly}
           onChange={onChange}
           onSubmit={onSubmit}
           editorHandle={editorHandle}
+        />
+        <FileAutocomplete
+          availableFiles={availableFiles}
+          availableSkills={availableSkills}
+          disabled={readOnly}
+          onQuery={onFileQuery}
         />
       </div>
     </LexicalComposer>

--- a/src/renderer/components/composer-file-node.tsx
+++ b/src/renderer/components/composer-file-node.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react'
+import {
+  $applyNodeReplacement,
+  $getNodeByKey,
+  createCommand,
+  DecoratorNode,
+  type LexicalCommand,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from 'lexical'
+import { FileReference } from '@/src/renderer/components/file-reference'
+import { sessionFileToken, type SessionFileReference } from '@/src/session-files'
+
+type SerializedComposerFileNode = Spread<Readonly<{ file: SessionFileReference }>, SerializedLexicalNode>
+
+export const removeComposerFileCommand: LexicalCommand<NodeKey> = createCommand('REMOVE_COMPOSER_FILE_COMMAND')
+
+export class ComposerFileNode extends DecoratorNode<ReactNode> {
+  __file: SessionFileReference
+
+  static getType(): string {
+    return 'composer-file'
+  }
+
+  static clone(node: ComposerFileNode): ComposerFileNode {
+    return new ComposerFileNode(node.__file, node.__key)
+  }
+
+  static importJSON(serializedNode: SerializedComposerFileNode): ComposerFileNode {
+    return $createComposerFileNode(serializedNode.file).updateFromJSON(serializedNode)
+  }
+
+  constructor(file: SessionFileReference, key?: NodeKey) {
+    super(key)
+    this.__file = file
+  }
+
+  isInline(): true {
+    return true
+  }
+
+  createDOM(): HTMLElement {
+    const element = document.createElement('span')
+    element.className = 'inline'
+    return element
+  }
+
+  updateDOM(): false {
+    return false
+  }
+
+  exportJSON(): SerializedComposerFileNode {
+    return { ...super.exportJSON(), file: this.__file }
+  }
+
+  getTextContent(): string {
+    return sessionFileToken(this.getLatest().__file.path)
+  }
+
+  getFile(): SessionFileReference {
+    return this.getLatest().__file
+  }
+
+  setFile(file: SessionFileReference): this {
+    const writable = this.getWritable()
+    writable.__file = file
+    return writable
+  }
+
+  decorate(editor: LexicalEditor): ReactNode {
+    return (
+      <FileReference
+        file={this.__file}
+        onRemove={() => editor.dispatchCommand(removeComposerFileCommand, this.getKey())}
+      />
+    )
+  }
+}
+
+export function $createComposerFileNode(file: SessionFileReference): ComposerFileNode {
+  return $applyNodeReplacement(new ComposerFileNode(file))
+}
+
+export function $isComposerFileNode(node: LexicalNode | null | undefined): node is ComposerFileNode {
+  return node instanceof ComposerFileNode
+}
+
+export function $getComposerFileNode(key: NodeKey): ComposerFileNode | undefined {
+  const node = $getNodeByKey(key)
+  return $isComposerFileNode(node) ? node : undefined
+}

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -93,13 +93,15 @@ function DelayedDraftPublicationComposer({ submitMessage }: { submitMessage: Com
 }
 
 function FileComposer({
+  initialDraft = '',
   submitMessage,
   sessionFiles,
 }: {
+  initialDraft?: string
   submitMessage: ComposerBridge['submit']
   sessionFiles: SessionFilesBridge
 }) {
-  const [draft, setDraft] = useState('')
+  const [draft, setDraft] = useState(initialDraft)
 
   return (
     <Composer
@@ -254,6 +256,101 @@ test('selects a whitespace path from at-sign autocomplete and sends its canonica
   await waitFor(() =>
     assert.deepEqual(submissions, [{ sessionId: session.id, text: '@@"src/my file.ts"', delivery: 'steer' }])
   )
+})
+
+test('closes file autocomplete after selecting a file', async () => {
+  const user = createUser()
+  const view = renderInBrowser(
+    <FileComposer
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+      sessionFiles={{
+        async getAvailable() {
+          return [{ path: 'README.md', name: 'README.md', kind: 'file' }]
+        },
+      }}
+    />
+  )
+  const editor = view.getByRole('textbox')
+
+  await user.click(editor)
+  await user.keyboard('@')
+  await view.findByRole('listbox', { name: 'Files and folders' })
+  await user.keyboard('{Enter}')
+  await act(async () => {
+    await new Promise<void>((resolve) => window.setTimeout(resolve, 30))
+  })
+
+  assert.equal(Boolean(view.queryByRole('listbox', { name: 'Files and folders' })), false)
+})
+
+test('keeps the caret after an inserted file reference', async () => {
+  const user = createUser()
+  const view = renderInBrowser(
+    <FileComposer
+      initialDraft="Review "
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+      sessionFiles={{
+        async getAvailable() {
+          return [{ path: 'README.md', name: 'README.md', kind: 'file' }]
+        },
+      }}
+    />
+  )
+  const editor = view.getByRole('textbox')
+
+  await user.click(editor)
+  await user.keyboard('@README')
+  await user.keyboard('{Enter}')
+  await user.click(editor)
+  await user.keyboard(' next')
+
+  assert.equal(composerText(editor), 'Review @README.md next')
+})
+
+test('scrolls the file results during keyboard navigation', async () => {
+  const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+  HTMLElement.prototype.scrollIntoView = () => {}
+
+  try {
+    const user = createUser()
+    const view = renderInBrowser(
+      <FileComposer
+        submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+        sessionFiles={{
+          async getAvailable() {
+            return Array.from({ length: 12 }, (_, index) => ({
+              path: `src/file-${index + 1}.ts`,
+              name: `file-${index + 1}.ts`,
+              kind: 'file' as const,
+            }))
+          },
+        }}
+      />
+    )
+    const editor = view.getByRole('textbox')
+
+    await user.click(editor)
+    await user.keyboard('@')
+    const listbox = await view.findByRole('listbox', { name: 'Files and folders' })
+    const options = view.getAllByRole('option')
+
+    Object.defineProperties(listbox, {
+      clientHeight: { configurable: true, value: 120 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    })
+    options.forEach((option, index) => {
+      Object.defineProperties(option, {
+        offsetHeight: { configurable: true, value: 40 },
+        offsetTop: { configurable: true, value: index * 40 },
+      })
+    })
+
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}')
+
+    await waitFor(() => assert.ok(listbox.scrollTop > 0))
+  } finally {
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+  }
 })
 
 test('selects a Skill from autocomplete and sends it without prompt text', async () => {

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -9,6 +9,7 @@ import { sessionId, type Session, type SessionId } from '@/src/domain/session'
 import type { OwnedSession } from '@/src/domain/workstream'
 import type { SessionConfigurationBridge, SessionConfigurationSnapshot } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
+import type { SessionFilesBridge } from '@/src/session-files'
 import { Composer } from './composer'
 import { SessionArea } from './session-area'
 
@@ -88,6 +89,28 @@ function DelayedDraftPublicationComposer({ submitMessage }: { submitMessage: Com
         }}
       />
     </>
+  )
+}
+
+function FileComposer({
+  submitMessage,
+  sessionFiles,
+}: {
+  submitMessage: ComposerBridge['submit']
+  sessionFiles: SessionFilesBridge
+}) {
+  const [draft, setDraft] = useState('')
+
+  return (
+    <Composer
+      session={session}
+      draft={draft}
+      isWorking={false}
+      onActivate={() => {}}
+      onDraftChange={setDraft}
+      submitMessage={submitMessage}
+      sessionFiles={sessionFiles}
+    />
   )
 }
 
@@ -202,6 +225,35 @@ test('Enter submits the exact draft to the owning Session once', async () => {
   await user.keyboard('{Enter}')
 
   assert.deepEqual(submissions, [{ sessionId: session.id, text: 'Keep  internal spaces', delivery: 'steer' }])
+})
+
+test('selects a whitespace path from at-sign autocomplete and sends its canonical tag', async () => {
+  const submissions: Parameters<ComposerBridge['submit']>[0][] = []
+  const user = createUser()
+  const view = renderInBrowser(
+    <FileComposer
+      submitMessage={async (submission) => {
+        submissions.push(submission)
+        return { status: 'accepted', delivery: 'prompt' }
+      }}
+      sessionFiles={{
+        async getAvailable() {
+          return [{ path: 'src/my file.ts', name: 'my file.ts', kind: 'file' }]
+        },
+      }}
+    />
+  )
+
+  const editor = view.getByRole('textbox')
+  await user.click(editor)
+  await user.keyboard('@')
+  await waitFor(() => assert.ok(view.getByRole('option', { name: /src\/my file\.ts/ })))
+  await user.keyboard('{Enter}')
+  await user.click(view.getByRole('button', { name: 'Send message' }))
+
+  await waitFor(() =>
+    assert.deepEqual(submissions, [{ sessionId: session.id, text: '@@"src/my file.ts"', delivery: 'steer' }])
+  )
 })
 
 test('selects a Skill from autocomplete and sends it without prompt text', async () => {

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -16,6 +16,7 @@ import type {
 import { ComposerEditor, type ComposerEditorHandle } from '@/src/renderer/components/composer-editor'
 import { getComposerSubmissionState } from '@/src/renderer/composer-submission'
 import type { SessionSkill, SessionSkillsBridge } from '@/src/session-skills'
+import type { SessionFile, SessionFilesBridge } from '@/src/session-files'
 import { useSessionConfiguration } from '@/src/renderer/session-configuration-state'
 
 type ComposerProperties = Readonly<{
@@ -31,6 +32,7 @@ type ComposerProperties = Readonly<{
   stopRun?: ComposerBridge['stop']
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
+  sessionFiles?: SessionFilesBridge
 }>
 
 export function Composer({
@@ -46,6 +48,7 @@ export function Composer({
   stopRun,
   sessionConfiguration,
   sessionSkills,
+  sessionFiles,
 }: ComposerProperties) {
   const descriptionId = useId()
   const statusId = useId()
@@ -54,6 +57,7 @@ export function Composer({
   const currentDraft = useRef(draft)
   const awaitingAcceptance = useRef(false)
   const restoreFocusAfterAcceptance = useRef(false)
+  const fileQueryRequest = useRef(0)
   const [submissionState, setSubmissionState] = useState(() => getComposerSubmissionState({ type: 'edit', draft }))
   const configuration = useSessionConfiguration(session.id, sessionConfiguration)
   const [pendingConfiguration, setPendingConfiguration] = useState<ReadonlySet<'model' | 'effort'>>(() => new Set())
@@ -64,6 +68,7 @@ export function Composer({
   const [compactError, setCompactError] = useState<string>()
   const [availableSkills, setAvailableSkills] = useState<readonly SessionSkill[]>([])
   const [skillsError, setSkillsError] = useState<string>()
+  const [availableFiles, setAvailableFiles] = useState<readonly SessionFile[]>([])
   const configurationPending = pendingConfiguration.size > 0
 
   useEffect(() => {
@@ -98,6 +103,26 @@ export function Composer({
   }, [session.id, sessionSkills])
 
   useEffect(() => {
+    if (!sessionFiles) return
+
+    let active = true
+    setAvailableFiles([])
+    const request = ++fileQueryRequest.current
+    void sessionFiles.getAvailable(session.id).then(
+      (files) => {
+        if (active && request === fileQueryRequest.current) setAvailableFiles(files)
+      },
+      () => {
+        if (active && request === fileQueryRequest.current) setAvailableFiles([])
+      }
+    )
+
+    return () => {
+      active = false
+    }
+  }, [session.id, sessionFiles])
+
+  useEffect(() => {
     if (focusRequest === undefined) {
       return
     }
@@ -117,6 +142,23 @@ export function Composer({
       editorHandle.current?.focus()
     }
   }, [submissionState.awaiting])
+
+  const updateAvailableFiles = useCallback(
+    (query: string) => {
+      if (!sessionFiles) return
+
+      const request = ++fileQueryRequest.current
+      void sessionFiles.getAvailable(session.id, query).then(
+        (files) => {
+          if (request === fileQueryRequest.current) setAvailableFiles(files)
+        },
+        () => {
+          if (request === fileQueryRequest.current) setAvailableFiles([])
+        }
+      )
+    },
+    [session.id, sessionFiles]
+  )
 
   const updateDraft = useCallback(
     (nextDraft: string) => {
@@ -271,12 +313,14 @@ export function Composer({
         <ComposerEditor
           ref={editorHandle}
           availableSkills={availableSkills}
+          availableFiles={availableFiles}
           describedBy={`${descriptionId} ${statusId}`}
           draft={submissionState.draft}
           label={`Message for ${session.title}`}
           readOnly={agentRunDisabled}
           onChange={updateDraft}
           onFocus={onActivate}
+          onFileQuery={updateAvailableFiles}
           onSubmit={(delivery) => void submit(delivery)}
         />
         <div className="flex items-end justify-between gap-2 px-3 pt-1 pb-2" data-slot="composer-control-row">

--- a/src/renderer/components/file-reference.tsx
+++ b/src/renderer/components/file-reference.tsx
@@ -1,0 +1,38 @@
+import { X } from 'lucide-react'
+import type { SessionFileReference } from '@/src/session-files'
+
+type FileReferenceProperties = Readonly<{
+  file: SessionFileReference
+  onRemove?: () => void
+}>
+
+export function FileReference({ file, onRemove }: FileReferenceProperties) {
+  const description = file.availability === 'available' ? file.kind : 'This file or folder is no longer available.'
+
+  return (
+    <span
+      className="group/file inline-flex max-w-full cursor-default items-center align-baseline"
+      contentEditable={false}
+      data-file-reference={file.path}
+    >
+      <span
+        className="truncate border-b border-skill-reference-underline font-medium text-skill-reference-foreground"
+        title={description}
+      >
+        @{file.path}
+      </span>
+      {onRemove ? (
+        <span className="grid max-w-0 grid-cols-[1.25rem] overflow-hidden opacity-0 transition-[max-width,opacity] duration-150 motion-reduce:transition-none group-hover/file:max-w-5 group-hover/file:opacity-100 group-focus-within/file:max-w-5 group-focus-within/file:opacity-100">
+          <button
+            type="button"
+            aria-label={`Remove ${file.path}`}
+            className="ml-0.5 flex size-5 items-center justify-center rounded-sm text-composer-muted-foreground outline-none hover:bg-composer-interaction hover:text-skill-reference-foreground focus-visible:ring-2 focus-visible:ring-focus-ring"
+            onClick={onRemove}
+          >
+            <X aria-hidden="true" className="size-3" />
+          </button>
+        </span>
+      ) : null}
+    </span>
+  )
+}

--- a/src/renderer/components/queued-follow-up-tray.tsx
+++ b/src/renderer/components/queued-follow-up-tray.tsx
@@ -3,7 +3,8 @@ import { useCallback, useState } from 'react'
 import type { ComposerBridge } from '@/src/composer'
 import type { SessionId } from '@/src/domain/session'
 import type { QueuedFollowUp } from '@/src/queued-follow-up'
-import { SkillMentionText } from '@/src/renderer/components/skill-mention-text'
+import { ReferenceMentionText } from '@/src/renderer/components/reference-mention-text'
+import { projectSessionFileSelections } from '@/src/session-files'
 import { projectSessionSkillSelections } from '@/src/session-skills'
 
 const maximumVisibleFollowUps = 3
@@ -22,11 +23,22 @@ type QueuedFollowUpTrayProperties = Readonly<{
 
 function QueuedFollowUpContent({ followUp, next }: Readonly<{ followUp: QueuedFollowUp; next: boolean }>) {
   const projected = projectSessionSkillSelections(followUp.text)
+  const fileProjected = projectSessionFileSelections(projected.text)
   const skills =
     followUp.skills ??
     projected.selections.map(({ name, offset }) => ({
-      offset,
+      offset:
+        offset -
+        fileProjected.selections
+          .filter((selection) => selection.offset < offset)
+          .reduce((sum, selection) => sum + selection.tokenLength, 0),
       skill: { name, availability: 'unavailable' as const },
+    }))
+  const files =
+    followUp.files ??
+    fileProjected.selections.map(({ path, offset }) => ({
+      offset,
+      file: { path, kind: 'file' as const, availability: 'unavailable' as const },
     }))
 
   return (
@@ -35,7 +47,7 @@ function QueuedFollowUpContent({ followUp, next }: Readonly<{ followUp: QueuedFo
         {next ? 'Next follow-up' : 'Follow-up'}
       </span>
       <span className="mt-0.5 line-clamp-2 block whitespace-pre-wrap break-words">
-        <SkillMentionText text={projected.text} skills={skills} />
+        <ReferenceMentionText text={fileProjected.text} skills={skills} files={files} />
       </span>
     </>
   )

--- a/src/renderer/components/reference-mention-text.tsx
+++ b/src/renderer/components/reference-mention-text.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+import { FileReference } from '@/src/renderer/components/file-reference'
+import { SkillReference } from '@/src/renderer/components/skill-reference'
+import type { SessionFileMention } from '@/src/session-files'
+import type { SessionSkillMention } from '@/src/session-skills'
+
+type ReferenceMentionTextProperties = Readonly<{
+  text: string
+  skills: readonly SessionSkillMention[]
+  files: readonly SessionFileMention[]
+}>
+
+type Mention =
+  | Readonly<{ offset: number; type: 'skill'; value: SessionSkillMention['skill']; index: number }>
+  | Readonly<{ offset: number; type: 'file'; value: SessionFileMention['file']; index: number }>
+
+export function ReferenceMentionText({ text, skills, files }: ReferenceMentionTextProperties) {
+  const mentions: Mention[] = [
+    ...skills.map((mention, index) => ({
+      offset: mention.offset,
+      type: 'skill' as const,
+      value: mention.skill,
+      index,
+    })),
+    ...files.map((mention, index) => ({ offset: mention.offset, type: 'file' as const, value: mention.file, index })),
+  ].sort((left, right) => left.offset - right.offset)
+  const content: ReactNode[] = []
+  let textOffset = 0
+
+  for (const mention of mentions) {
+    content.push(text.slice(textOffset, mention.offset))
+    content.push(
+      mention.type === 'skill' ? (
+        <SkillReference key={`skill:${mention.offset}:${mention.index}`} skill={mention.value} />
+      ) : (
+        <FileReference key={`file:${mention.offset}:${mention.index}`} file={mention.value} />
+      )
+    )
+    textOffset = mention.offset
+  }
+
+  content.push(text.slice(textOffset))
+  return content
+}

--- a/src/renderer/components/session-area.tsx
+++ b/src/renderer/components/session-area.tsx
@@ -4,6 +4,7 @@ import type { SessionId } from '@/src/domain/session'
 import type { OwnedSession, WorkstreamLifecycle } from '@/src/domain/workstream'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
+import type { SessionFilesBridge } from '@/src/session-files'
 import type { SessionTranscriptBridge } from '@/src/session-transcript'
 import { SessionContainer } from '@/src/renderer/components/session-container'
 
@@ -35,6 +36,7 @@ type SessionAreaProperties = {
   resumeQueuedFollowUps?: NonNullable<ComposerBridge['resumeQueuedFollowUps']>
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
+  sessionFiles?: SessionFilesBridge
   onToggleSessionPin: (sessionId: SessionId) => void
   acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
   onStartImplementSession?: (workstreamId: string) => Promise<void>
@@ -62,6 +64,7 @@ export function SessionArea({
   resumeQueuedFollowUps,
   sessionConfiguration,
   sessionSkills,
+  sessionFiles,
   onToggleSessionPin,
   acceptActionCard = async () => false,
   onStartImplementSession = async () => {},
@@ -119,6 +122,7 @@ export function SessionArea({
             resumeQueuedFollowUps={resumeQueuedFollowUps}
             sessionConfiguration={sessionConfiguration}
             sessionSkills={sessionSkills}
+            sessionFiles={sessionFiles}
             onTogglePin={() => onToggleSessionPin(session.id)}
             acceptActionCard={acceptActionCard}
             onStartImplementSession={onStartImplementSession}

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -5,6 +5,7 @@ import type { OwnedSession, WorkstreamLifecycle } from '@/src/domain/workstream'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
 import type { SessionActionCard } from '@/src/session-action-cards'
+import type { SessionFilesBridge } from '@/src/session-files'
 import type { SessionTranscriptBridge } from '@/src/session-transcript'
 import { Composer } from '@/src/renderer/components/composer'
 import { QueuedFollowUpTray } from '@/src/renderer/components/queued-follow-up-tray'
@@ -34,6 +35,7 @@ type SessionContainerProperties = {
   resumeQueuedFollowUps?: NonNullable<ComposerBridge['resumeQueuedFollowUps']>
   sessionConfiguration?: SessionConfigurationBridge
   sessionSkills?: SessionSkillsBridge
+  sessionFiles?: SessionFilesBridge
   onTogglePin: () => void
   acceptActionCard?: SessionTranscriptBridge['acceptActionCard']
   onStartImplementSession?: (workstreamId: string) => Promise<void>
@@ -59,6 +61,7 @@ export function SessionContainer({
   resumeQueuedFollowUps,
   sessionConfiguration,
   sessionSkills,
+  sessionFiles,
   onTogglePin,
   acceptActionCard = async () => false,
   onStartImplementSession = async () => {},
@@ -205,6 +208,7 @@ export function SessionContainer({
           stopRun={stopRun}
           sessionConfiguration={sessionConfiguration}
           sessionSkills={sessionSkills}
+          sessionFiles={sessionFiles}
         />
       )}
     </section>

--- a/src/renderer/components/session-messages.tsx
+++ b/src/renderer/components/session-messages.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui-kit/button'
 import type { SessionId } from '@/src/domain/session'
 import type { SessionActionCard } from '@/src/session-action-cards'
 import { AgentActivityCard } from '@/src/renderer/components/agent-activity-card'
+import { ReferenceMentionText } from '@/src/renderer/components/reference-mention-text'
 import { SkillMentionText } from '@/src/renderer/components/skill-mention-text'
 import type { AgentActivity, ContextCompaction } from '@/src/session-timeline'
 import type { SessionTranscriptMessage, SessionTranscriptSnapshot } from '@/src/session-transcript'
@@ -436,7 +437,11 @@ function SessionMessageRow({
       >
         {steering && <p className="mb-1 text-xs/4 font-medium text-content-muted-foreground">Steering</p>}
         <p className="whitespace-pre-wrap break-words">
-          <SkillMentionText text={message.text} skills={message.skills ?? []} />
+          {message.files?.length ? (
+            <ReferenceMentionText text={message.text} skills={message.skills ?? []} files={message.files} />
+          ) : (
+            <SkillMentionText text={message.text} skills={message.skills ?? []} />
+          )}
         </p>
       </article>
     )

--- a/src/renderer/workspace-shell.tsx
+++ b/src/renderer/workspace-shell.tsx
@@ -468,6 +468,7 @@ export function WorkspaceShell({ initialWorkspacesSnapshot, initialSessionDispla
             resumeQueuedFollowUps={resumeQueuedFollowUps}
             sessionConfiguration={window.piWorkspace.sessionConfiguration}
             sessionSkills={window.piWorkspace.sessionSkills}
+            sessionFiles={window.piWorkspace.sessionFiles}
             onToggleSessionPin={toggleSessionPin}
             acceptActionCard={window.piWorkspace.transcript.acceptActionCard}
             onStartImplementSession={(workstreamId) => createSession(workstreamId, { mode: 'implement' })}

--- a/src/session-files-ipc.ts
+++ b/src/session-files-ipc.ts
@@ -1,0 +1,17 @@
+import { isSessionId, type SessionId } from '@/src/domain/session'
+
+export const sessionFilesIpcChannels = {
+  getAvailable: 'session-files:get-available',
+} as const
+
+export function parseSessionFilesRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionId; query?: string }> | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+
+  const request = value as Record<string, unknown>
+  if (!isSessionId(request.sessionId) || (request.query !== undefined && typeof request.query !== 'string'))
+    return undefined
+
+  return { sessionId: request.sessionId, query: request.query }
+}

--- a/src/session-files.test.ts
+++ b/src/session-files.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { projectSessionFileSelections, replaceSessionFileTokens, sessionFileToken } from './session-files'
+
+test('projects file tags while preserving surrounding text', () => {
+  assert.deepEqual(projectSessionFileSelections('Review @src/app.ts and @src/components'), {
+    text: 'Review  and ',
+    selections: [
+      { path: 'src/app.ts', offset: 7, tokenLength: 11 },
+      { path: 'src/components', offset: 12, tokenLength: 15 },
+    ],
+  })
+})
+
+test('only treats standalone at-signs as file tags', () => {
+  assert.deepEqual(projectSessionFileSelections('email@example.com @@literal x@example.com'), {
+    text: 'email@example.com @@literal x@example.com',
+    selections: [],
+  })
+})
+
+test('projects quoted file tags for paths containing whitespace', () => {
+  assert.deepEqual(projectSessionFileSelections('Review @@"src/my file.ts".'), {
+    text: 'Review .',
+    selections: [{ path: 'src/my file.ts', offset: 7, tokenLength: 18 }],
+  })
+  assert.equal(sessionFileToken('src/my file.ts'), '@@"src/my file.ts"')
+})
+
+test('replaces file tokens and rejects unresolved paths', () => {
+  assert.equal(
+    replaceSessionFileTokens('Read @src/app.ts', (path) => `FILE(${path})`),
+    'Read FILE(src/app.ts)'
+  )
+  assert.equal(
+    replaceSessionFileTokens('Read @missing.ts', () => undefined),
+    undefined
+  )
+})

--- a/src/session-files.ts
+++ b/src/session-files.ts
@@ -1,0 +1,163 @@
+import type { SessionId } from '@/src/domain/session'
+
+export type SessionFile = Readonly<{
+  path: string
+  kind: 'file' | 'folder'
+  name: string
+}>
+
+export type SessionFileReference = Readonly<{
+  path: string
+  kind: 'file' | 'folder'
+  availability: 'available' | 'unavailable'
+}>
+
+export type SessionFileSelection = Readonly<{
+  path: string
+  offset: number
+  tokenLength: number
+}>
+
+export type SessionFileMention = Readonly<{
+  file: SessionFileReference
+  offset: number
+}>
+
+export interface SessionFilesBridge {
+  getAvailable(sessionId: SessionId, query?: string): Promise<readonly SessionFile[]>
+}
+
+export type SessionFileToken = Readonly<{
+  path: string
+  startOffset: number
+  endOffset: number
+}>
+
+const trailingPathPunctuation = new Set([',', '.', ';', ':', '!', '?', ')', '}', ']'])
+const unquotedPathPattern = /^[^\s@]*[^\s@,.;:!?)}\]]$/
+
+/** Canonical form used in persisted messages and Agent prompts. */
+export function sessionFileToken(path: string): string {
+  return unquotedPathPattern.test(path) ? `@${path}` : `@@${JSON.stringify(path)}`
+}
+
+function quotedToken(source: string, startOffset: number, quoteOffset: number): SessionFileToken | undefined {
+  let offset = quoteOffset + 1
+  let escaped = false
+
+  while (offset < source.length) {
+    const character = source[offset]
+    if (escaped) {
+      escaped = false
+      offset += 1
+      continue
+    }
+    if (character === '\\') {
+      escaped = true
+      offset += 1
+      continue
+    }
+    if (character === '"') {
+      const token = source.slice(quoteOffset, offset + 1)
+
+      try {
+        const path = JSON.parse(token)
+        return typeof path === 'string' && path.length > 0 ? { path, startOffset, endOffset: offset + 1 } : undefined
+      } catch {
+        return undefined
+      }
+    }
+
+    offset += 1
+  }
+
+  return undefined
+}
+
+function unquotedToken(source: string, startOffset: number): SessionFileToken | undefined {
+  let endOffset = startOffset + 1
+  while (endOffset < source.length && !/\s|@/.test(source[endOffset] ?? '')) endOffset += 1
+
+  while (endOffset > startOffset + 1 && trailingPathPunctuation.has(source[endOffset - 1] ?? '')) endOffset -= 1
+  if (endOffset === startOffset + 1) return undefined
+
+  return { path: source.slice(startOffset + 1, endOffset), startOffset, endOffset }
+}
+
+export function findSessionFileTokens(source: string): readonly SessionFileToken[] {
+  const tokens: SessionFileToken[] = []
+
+  for (let startOffset = 0; startOffset < source.length; startOffset += 1) {
+    if (source[startOffset] !== '@' || source[startOffset - 1]?.match(/\S/)) continue
+
+    let token: SessionFileToken | undefined
+    if (source[startOffset + 1] === '@') {
+      token = source[startOffset + 2] === '"' ? quotedToken(source, startOffset, startOffset + 2) : undefined
+    } else {
+      token = unquotedToken(source, startOffset)
+    }
+    if (!token) continue
+
+    tokens.push(token)
+    startOffset = token.endOffset - 1
+  }
+
+  return tokens
+}
+
+export function projectSessionFileSelections(source: string): Readonly<{
+  text: string
+  selections: readonly SessionFileSelection[]
+}> {
+  const selections: SessionFileSelection[] = []
+  let text = ''
+  let sourceOffset = 0
+
+  for (const token of findSessionFileTokens(source)) {
+    text += source.slice(sourceOffset, token.startOffset)
+    selections.push({ path: token.path, offset: text.length, tokenLength: token.endOffset - token.startOffset })
+    sourceOffset = token.endOffset
+  }
+
+  return { text: text + source.slice(sourceOffset), selections }
+}
+
+export function replaceSessionFileTokens(
+  source: string,
+  replacement: (path: string) => string | undefined
+): string | undefined {
+  let text = ''
+  let sourceOffset = 0
+
+  for (const token of findSessionFileTokens(source)) {
+    const value = replacement(token.path)
+    if (value === undefined) return undefined
+
+    text += source.slice(sourceOffset, token.startOffset) + value
+    sourceOffset = token.endOffset
+  }
+
+  return text + source.slice(sourceOffset)
+}
+
+export async function replaceSessionFileTokensAsync(
+  source: string,
+  replacement: (path: string) => Promise<string | undefined>
+): Promise<string | undefined> {
+  let text = ''
+  let sourceOffset = 0
+
+  for (const token of findSessionFileTokens(source)) {
+    const value = await replacement(token.path)
+    if (value === undefined) return undefined
+
+    text += source.slice(sourceOffset, token.startOffset) + value
+    sourceOffset = token.endOffset
+  }
+
+  return text + source.slice(sourceOffset)
+}
+
+export function sessionFileReference(file: SessionFile, available = true): SessionFileReference {
+  return { path: file.path, kind: file.kind, availability: available ? 'available' : 'unavailable' }
+}

--- a/src/session-timeline.ts
+++ b/src/session-timeline.ts
@@ -1,5 +1,6 @@
 import type { SessionId } from '@/src/domain/session'
 import type { SessionSkillMention } from '@/src/session-skills'
+import type { SessionFileMention } from '@/src/session-files'
 
 export const agentActivityKinds = [
   'exploration',
@@ -22,6 +23,7 @@ export type ConversationEntry = Readonly<{
   role: 'user' | 'assistant'
   text: string
   skills?: readonly SessionSkillMention[]
+  files?: readonly SessionFileMention[]
   delivery?: 'steer'
   timestamp: number
 }>

--- a/src/session-transcript.ts
+++ b/src/session-transcript.ts
@@ -2,6 +2,7 @@ import type { SessionId } from '@/src/domain/session'
 import type { QueuedFollowUp } from '@/src/queued-follow-up'
 import type { SessionSkillMention } from '@/src/session-skills'
 import type { SessionActionCard } from '@/src/session-action-cards'
+import type { SessionFileMention } from '@/src/session-files'
 
 const allowedExternalUrlProtocols = new Set(['http:', 'https:', 'mailto:'])
 export const maximumExternalUrlLength = 8_192
@@ -28,6 +29,7 @@ export type SessionTranscriptMessage = Readonly<{
   role: 'user' | 'assistant'
   text: string
   skills?: readonly SessionSkillMention[]
+  files?: readonly SessionFileMention[]
   delivery?: 'steer'
   state: 'complete' | 'streaming'
   revision: number


### PR DESCRIPTION
## Summary
- add scoped `@` file and folder references to the Session Composer
- resolve selected references safely in the main process and include bounded file or folder context in submissions
- render structured references across Composer, transcript, and queued follow-ups
- refine autocomplete ordering, keyboard scrolling, caret placement, and picker dismissal

## Validation
- `bun run check`