### PR TITLE
feat: validate repository changes before completion

### DIFF
--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -52,7 +52,7 @@ import {
 } from '@/src/main/pi-session-runtimes'
 import { canCompactSessionHistory } from '@/src/main/pi-session-compaction'
 import { classifyPersistedAgentState } from '@/src/main/pi-session-history'
-import { createManagedSessionServices } from '@/src/main/managed-session-resources'
+import { createDefaultSessionServices, createManagedSessionServices } from '@/src/main/managed-session-resources'
 import { managedSessionFileRoots } from '@/src/main/managed-session-file-roots'
 import { createManagedSessionRuntimePolicyGuard } from '@/src/main/managed-session-runtime-policy'
 import {
@@ -309,20 +309,20 @@ export async function createPiSessionRuntime(
         ]
       : []
   const customTools = [startActivity, completeActivity, setSessionDescription, suggestAction, ...managedTools]
-  const managedServices =
+  const sessionServices =
     options.kind === 'managed'
       ? await createManagedSessionServices(
           directoryPath,
           options.policy,
           managedSessionMethodology(options.policy.mode)
         )
-      : undefined
+      : await createDefaultSessionServices(directoryPath)
   const { session } = await createAgentSession({
     cwd: directoryPath,
     sessionManager,
     customTools,
-    resourceLoader: managedServices?.resourceLoader,
-    settingsManager: managedServices?.settingsManager,
+    resourceLoader: sessionServices.resourceLoader,
+    settingsManager: sessionServices.settingsManager,
   })
   const getAvailableSkillResources = () =>
     session.settingsManager.getEnableSkillCommands()

--- a/src/main/managed-session-resources.test.ts
+++ b/src/main/managed-session-resources.test.ts
@@ -5,12 +5,39 @@ import { join } from 'node:path'
 import { afterEach, test } from 'node:test'
 import { sessionId } from '@/src/domain/session'
 import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
-import { createManagedSessionServices } from './managed-session-resources'
+import { createDefaultSessionServices, createManagedSessionServices } from './managed-session-resources'
 
 const temporaryDirectories: string[] = []
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+test('default Sessions append final local validation guidance', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'pi-workspace-default-resources-'))
+  const agentDir = join(root, 'agent')
+  const cwd = join(root, 'session-cwd')
+  temporaryDirectories.push(root)
+  await Promise.all([mkdir(agentDir, { recursive: true }), mkdir(cwd, { recursive: true })])
+
+  const services = await createDefaultSessionServices(cwd, { agentDir })
+
+  const appendedPrompts = services.resourceLoader.getAppendSystemPrompt()
+
+  assert.ok(
+    appendedPrompts.some((prompt) =>
+      prompt.includes(
+        'After the final workable Repository change, run the relevant local CI/CD checks, including GitHub Actions checks that can run locally.'
+      )
+    )
+  )
+  assert.ok(
+    appendedPrompts.some((prompt) =>
+      prompt.includes(
+        'Do this once as a final self-check immediately before completion—and before pushing or creating a pull request—not after each turn or as a separate pull-request preparation step.'
+      )
+    )
+  )
 })
 
 test('managed Sessions load normal global and Workspace Repository resources', async () => {
@@ -73,6 +100,13 @@ test('managed Sessions load normal global and Workspace Repository resources', a
       )
   )
   assert.ok(services.resourceLoader.getAppendSystemPrompt().includes('Managed methodology.'))
+  assert.ok(
+    services.resourceLoader
+      .getAppendSystemPrompt()
+      .some((prompt) =>
+        prompt.includes('After the final workable Repository change, run the relevant local CI/CD checks')
+      )
+  )
   assert.ok(services.resourceLoader.getExtensions().extensions[0]?.tools.has('trusted_tool'))
 })
 

--- a/src/main/managed-session-resources.ts
+++ b/src/main/managed-session-resources.ts
@@ -9,19 +9,44 @@ import {
 } from '@earendil-works/pi-coding-agent'
 import type { ManagedSessionRuntimePolicy } from '@/src/domain/managed-session'
 
-export type ManagedSessionServices = Readonly<{
+type SessionServices = Readonly<{
   resourceLoader: ResourceLoader
   settingsManager: SettingsManager
 }>
 
-type ManagedSessionServicesOptions = Readonly<{ agentDir?: string }>
+type SessionServicesOptions = Readonly<{ agentDir?: string }>
+
+const finalValidationGuidance = [
+  'When a task changes a Repository, always perform a final validation pass before declaring the work complete.',
+  'After the final workable Repository change, run the relevant local CI/CD checks, including GitHub Actions checks that can run locally.',
+  'Do this once as a final self-check immediately before completion—and before pushing or creating a pull request—not after each turn or as a separate pull-request preparation step.',
+  'Resolve failures caused by the changes before completing, and clearly report any remaining validation blockers.',
+].join('\n')
+
+export async function createDefaultSessionServices(
+  cwd: string,
+  options: SessionServicesOptions = {}
+): Promise<SessionServices> {
+  const agentDir = options.agentDir ?? getAgentDir()
+  const settingsManager = SettingsManager.create(cwd, agentDir)
+  const resourceLoader = new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    settingsManager,
+    appendSystemPromptOverride: (prompts) => [...prompts, finalValidationGuidance],
+  })
+
+  await resourceLoader.reload()
+
+  return { resourceLoader, settingsManager }
+}
 
 export async function createManagedSessionServices(
   cwd: string,
   policy: ManagedSessionRuntimePolicy,
   methodology: string,
-  options: ManagedSessionServicesOptions = {}
-): Promise<ManagedSessionServices> {
+  options: SessionServicesOptions = {}
+): Promise<SessionServices> {
   const agentDir = options.agentDir ?? getAgentDir()
   const settingsManager = SettingsManager.create(cwd, agentDir)
   const repositoryPaths = policy.repositories
@@ -48,7 +73,7 @@ export async function createManagedSessionServices(
     agentsFilesOverride: ({ agentsFiles }) => ({
       agentsFiles: deduplicateContextFiles([...agentsFiles, ...repositoryContextFiles]),
     }),
-    appendSystemPromptOverride: (prompts) => [...prompts, methodology],
+    appendSystemPromptOverride: (prompts) => [...prompts, methodology, finalValidationGuidance],
   })
 
   await resourceLoader.reload()


### PR DESCRIPTION
## Summary

- append completion-time local CI/CD and locally runnable GitHub Actions guidance to Default and managed Pi Sessions
- require the guidance only after final Repository changes, before completion or pull-request creation
- cover the appended prompt for both Session types

## Related issue

None

## Validation

- [x] `bun run check`
- [x] `bun run security:scan`
- [x] Focused prompt-loader coverage is included in `bun run check`.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed.
- [x] I have read and will follow the Code of Conduct.