### PR TITLE
fix: avoid stale policy failures for activity tracking

### DIFF
--- a/src/main/composer-ipc.ts
+++ b/src/main/composer-ipc.ts
@@ -136,8 +136,6 @@ export async function createPiSessionRuntime(
       expectedOutcome: Type.Optional(Type.String({ minLength: 1 })),
     }),
     async execute(toolCallId) {
-      if (options.kind === 'managed') await validateManagedPolicy()
-
       runtimeListeners.forEach((listener) =>
         listener({ type: 'activity_control_accepted', toolCallId, toolName: 'start_activity' })
       )
@@ -156,8 +154,6 @@ export async function createPiSessionRuntime(
       summary: Type.String({ minLength: 1, description: 'A concise summary of the achieved or observed outcome' }),
     }),
     async execute(toolCallId) {
-      if (options.kind === 'managed') await validateManagedPolicy()
-
       runtimeListeners.forEach((listener) =>
         listener({ type: 'activity_control_accepted', toolCallId, toolName: 'complete_activity' })
       )


### PR DESCRIPTION
## Summary
- keep Agent Activity controls available when a managed Session policy changes
- retain policy validation for managed Repository operations

## Validation
- bun test src/main/managed-session-runtime-policy.test.ts src/main/session-transcript-runtime.test.ts
- bunx prettier --check src/main/composer-ipc.ts
- bunx eslint src/main/composer-ipc.ts
- bun run typecheck