### PR TITLE
feat: add secure in-app updates

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -98,7 +98,10 @@ jobs:
           grep --fixed-strings --line-regexp '/NOTICE' /tmp/package-contents
           grep --fixed-strings --line-regexp '/THIRD_PARTY_NOTICES.md' /tmp/package-contents
           grep --fixed-strings --line-regexp '/node_modules/@earendil-works/pi-coding-agent/package.json' /tmp/package-contents
+          grep --fixed-strings --line-regexp '/node_modules/electron-updater/package.json' /tmp/package-contents
           grep --fixed-strings --line-regexp '/node_modules/@mariozechner/clipboard-linux-x64-gnu/package.json' /tmp/package-contents
+          grep --fixed-strings --line-regexp 'owner: pi-workspace' release/linux-unpacked/resources/app-update.yml
+          grep --fixed-strings --line-regexp 'repo: railyard' release/linux-unpacked/resources/app-update.yml
 
       - name: Identify package and create checksum
         id: package
@@ -139,6 +142,7 @@ jobs:
             railyard \
             @earendil-works/pi-coding-agent \
             @earendil-works/pi-tui \
+            electron-updater \
             react \
             @mariozechner/clipboard-linux-x64-gnu; do
             jq --exit-status --arg package "$package" \
@@ -281,6 +285,7 @@ jobs:
             '/NOTICE'
             '/THIRD_PARTY_NOTICES.md'
             '/node_modules/@earendil-works/pi-coding-agent/package.json'
+            '/node_modules/electron-updater/package.json'
             '/node_modules/@mariozechner/clipboard-win32-x64-msvc/package.json'
           )
 
@@ -288,6 +293,11 @@ jobs:
             if ($packageContents -notcontains $expectedPath) {
               throw "Packaged application is missing $expectedPath."
             }
+          }
+
+          $updateConfiguration = Get-Content release/win-unpacked/resources/app-update.yml
+          if ($updateConfiguration -notcontains 'owner: pi-workspace' -or $updateConfiguration -notcontains 'repo: railyard') {
+            throw 'Packaged application has an invalid update source.'
           }
 
       - name: Identify package and create checksum
@@ -334,6 +344,7 @@ jobs:
             'railyard'
             '@earendil-works/pi-coding-agent'
             '@earendil-works/pi-tui'
+            'electron-updater'
             'react'
             '@mariozechner/clipboard-win32-x64-msvc'
           )) {
@@ -483,21 +494,33 @@ jobs:
           grep --fixed-strings --line-regexp '/NOTICE' /tmp/package-contents
           grep --fixed-strings --line-regexp '/THIRD_PARTY_NOTICES.md' /tmp/package-contents
           grep --fixed-strings --line-regexp '/node_modules/@earendil-works/pi-coding-agent/package.json' /tmp/package-contents
+          grep --fixed-strings --line-regexp '/node_modules/electron-updater/package.json' /tmp/package-contents
           grep --fixed-strings --line-regexp '/node_modules/@mariozechner/clipboard/package.json' /tmp/package-contents
 
-      - name: Identify package and create checksum
+          resources_path="$(dirname "${asar_paths[0]}")"
+          grep --fixed-strings --line-regexp 'owner: pi-workspace' "$resources_path/app-update.yml"
+          grep --fixed-strings --line-regexp 'repo: railyard' "$resources_path/app-update.yml"
+
+      - name: Identify updater artifacts and create checksums
         id: package
         working-directory: release
         run: |
           packages=(railyard-*-mac-universal.dmg)
+          archives=(railyard-*-mac-universal.zip)
+          metadata=beta-mac.yml
 
-          if [[ "${#packages[@]}" != 1 ]]; then
-            echo "Expected exactly one universal macOS disk image." >&2
+          if [[ "${#packages[@]}" != 1 || "${#archives[@]}" != 1 || ! -f "$metadata" ]]; then
+            echo "Expected one macOS disk image, update archive, and metadata file." >&2
             exit 1
           fi
 
           package="${packages[0]}"
+          archive="${archives[0]}"
           shasum -a 256 "$package" > "${package%.dmg}.sha256"
+          shasum -a 256 "$archive" > "$archive.sha256"
+          grep --fixed-strings --line-regexp "version: ${{ needs.validate.outputs.version }}" "$metadata"
+          grep --fixed-strings "url: $archive" "$metadata"
+          grep --extended-regexp '^    sha512: .+' "$metadata"
           echo "path=release/$package" >> "$GITHUB_OUTPUT"
           echo "sbom=release/${package%.dmg}.spdx.json" >> "$GITHUB_OUTPUT"
 
@@ -528,6 +551,7 @@ jobs:
             railyard \
             @earendil-works/pi-coding-agent \
             @earendil-works/pi-tui \
+            electron-updater \
             react \
             @mariozechner/clipboard-darwin-arm64; do
             jq --exit-status --arg package "$package" \
@@ -540,6 +564,8 @@ jobs:
           name: railyard-${{ needs.validate.outputs.version }}-mac-universal
           path: |
             release/*.dmg
+            release/*.zip
+            release/*-mac.yml
             release/*.sha256
             release/*.spdx.json
           if-no-files-found: error
@@ -571,16 +597,37 @@ jobs:
           path: release
 
       - name: Verify, mount, and launch release candidate
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
 
           cd release
           shasum -a 256 --check railyard-*-mac-universal.sha256
+          shasum -a 256 --check railyard-*-mac-universal.zip.sha256
 
           disk_image="$(echo railyard-*-mac-universal.dmg)"
+          archive="$(echo railyard-*-mac-universal.zip)"
+          metadata="beta-mac.yml"
+          grep --fixed-strings --line-regexp "version: $VERSION" "$metadata"
+          grep --fixed-strings "url: $archive" "$metadata"
+          grep --extended-regexp '^    sha512: .+' "$metadata"
+
+          update_path="$(mktemp -d)"
+          ditto -x -k "$archive" "$update_path"
+          update_application="$update_path/Railyard.app"
+          test -d "$update_application"
+          codesign --verify --deep --strict --verbose=2 "$update_application"
+          spctl --assess --type execute --verbose=4 "$update_application"
+          xcrun stapler validate "$update_application"
+
           mount_path="$(mktemp -d)"
           hdiutil attach "$disk_image" -nobrowse -readonly -mountpoint "$mount_path"
-          trap 'hdiutil detach "$mount_path"' EXIT
+          cleanup() {
+            hdiutil detach "$mount_path"
+            rm -rf "$update_path" "$mount_path"
+          }
+          trap cleanup EXIT
 
           application_path="$mount_path/Railyard.app"
           test -d "$application_path"
@@ -591,6 +638,7 @@ jobs:
           ./../node_modules/.bin/asar list "$application_path/Contents/Resources/app.asar" > /tmp/package-contents
           grep --fixed-strings --line-regexp '/dist/main/index.js' /tmp/package-contents
           grep --fixed-strings --line-regexp '/dist/preload/index.cjs' /tmp/package-contents
+          grep --fixed-strings --line-regexp '/node_modules/electron-updater/package.json' /tmp/package-contents
 
           "$application_path/Contents/MacOS/Railyard" --no-sandbox >/tmp/railyard.log 2>&1 &
           application_pid=$!
@@ -655,6 +703,8 @@ jobs:
             release/*.deb
             release/*.dmg
             release/*.exe
+            release/*.zip
+            release/*-mac.yml
             release/*.sha256
             release/*.spdx.json
 
@@ -683,14 +733,24 @@ jobs:
 
           release_created=true
 
-          gh release upload "$RELEASE_TAG" release/*.deb release/*.dmg release/*.exe release/*.sha256 release/*.spdx.json
+          gh release upload "$RELEASE_TAG" \
+            release/*.deb \
+            release/*.dmg \
+            release/*.exe \
+            release/*.zip \
+            release/*-mac.yml \
+            release/*.sha256 \
+            release/*.spdx.json
 
           gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' > published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*.deb)" published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*-mac-universal.dmg)" published-assets.txt
+          grep --fixed-strings --line-regexp "$(basename release/*-mac-universal.zip)" published-assets.txt
+          grep --fixed-strings --line-regexp "$(basename release/*-mac.yml)" published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*-win-x64-setup.exe)" published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*-amd64.sha256)" published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*-mac-universal.sha256)" published-assets.txt
+          grep --fixed-strings --line-regexp "$(basename release/*-mac-universal.zip.sha256)" published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*-win-x64-setup.sha256)" published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*-amd64.spdx.json)" published-assets.txt
           grep --fixed-strings --line-regexp "$(basename release/*-mac-universal.spdx.json)" published-assets.txt

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -518,9 +518,10 @@ jobs:
           archive="${archives[0]}"
           shasum -a 256 "$package" > "${package%.dmg}.sha256"
           shasum -a 256 "$archive" > "$archive.sha256"
+          archive_sha512="$(openssl dgst -sha512 -binary "$archive" | openssl base64 -A)"
           grep --fixed-strings --line-regexp "version: ${{ needs.validate.outputs.version }}" "$metadata"
           grep --fixed-strings "url: $archive" "$metadata"
-          grep --extended-regexp '^    sha512: .+' "$metadata"
+          grep --fixed-strings --line-regexp "    sha512: $archive_sha512" "$metadata"
           echo "path=release/$package" >> "$GITHUB_OUTPUT"
           echo "sbom=release/${package%.dmg}.spdx.json" >> "$GITHUB_OUTPUT"
 
@@ -609,9 +610,10 @@ jobs:
           disk_image="$(echo railyard-*-mac-universal.dmg)"
           archive="$(echo railyard-*-mac-universal.zip)"
           metadata="beta-mac.yml"
+          archive_sha512="$(openssl dgst -sha512 -binary "$archive" | openssl base64 -A)"
           grep --fixed-strings --line-regexp "version: $VERSION" "$metadata"
           grep --fixed-strings "url: $archive" "$metadata"
-          grep --extended-regexp '^    sha512: .+' "$metadata"
+          grep --fixed-strings --line-regexp "    sha512: $archive_sha512" "$metadata"
 
           update_path="$(mktemp -d)"
           ditto -x -k "$archive" "$update_path"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ Participation in this repository is governed by the [Code of Conduct](./CODE_OF_
 Railyard supports development with Bun 1.3.14 on Debian-based Linux and macOS. Release validation also uses GitHub-hosted macOS runners for the signed, notarized macOS beta.
 
 ```sh
-git clone https://github.com/pi-workspace/pi-workspace.git
-cd pi-workspace
+git clone https://github.com/pi-workspace/railyard.git
+cd railyard
 bun install --frozen-lockfile
 bun run dev
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Railyard is a local desktop app for working with [Pi](https://github.com/earendi
 
 ## Install the beta
 
-Download the latest build from [GitHub Releases](https://github.com/pi-workspace/pi-workspace/releases).
+Download the latest build from [GitHub Releases](https://github.com/pi-workspace/railyard/releases).
 
 Railyard currently supports:
 
@@ -34,6 +34,10 @@ Railyard currently supports:
 - Windows 11 on x64
 
 AppImage, Windows 10, other Linux distributions, and other CPU architectures are not currently supported.
+
+The first release that includes in-app updates still requires one final manual installation from GitHub Releases. After
+that release is installed, **Settings** → **Updates** can check for newer releases. Update checks happen only when you
+choose **Check for updates**.
 
 ### macOS
 
@@ -46,7 +50,9 @@ AppImage, Windows 10, other Linux distributions, and other CPU architectures are
 
 3. Open the DMG and drag **Railyard** into Applications.
 
-The macOS build is Developer ID signed and notarized. To update, replace the existing app in Applications with the newer version.
+The macOS build is Developer ID signed and notarized. After the first updater-enabled release is installed manually,
+Railyard can download verified macOS updates. Installation happens only when you choose **Restart to update**, and an
+active Agent Run must finish first.
 
 ### Windows
 
@@ -65,8 +71,10 @@ The macOS build is Developer ID signed and notarized. To update, replace the exi
 
 3. Run the installer, then launch **Railyard** from the Start menu.
 
-The Windows installer is not code signed, so Windows may require confirmation before opening it. To update, install the
-newer version. To uninstall, use **Settings** → **Apps** → **Installed apps**.
+The Windows installer is not code signed, so Railyard never downloads or executes it automatically. **Settings** →
+**Updates** opens the matching GitHub Release when a newer version is available; download the installer and checksum,
+verify them with the steps above, and run the installer yourself. To uninstall, use **Settings** → **Apps** →
+**Installed apps**.
 
 ### Debian
 
@@ -86,7 +94,9 @@ To update, install the newer `.deb` with the same command. To uninstall:
 sudo apt remove railyard
 ```
 
-Beta updates are currently manual. Debian packages are not signed; use the published checksum to verify your download.
+Debian packages are not signed, so Railyard never installs them automatically. **Settings** → **Updates** opens the
+matching GitHub Release when a newer version is available; use the published checksum and commands above before
+installing it manually.
 
 ## Before your first Session
 
@@ -105,7 +115,7 @@ Then:
 
 - **No Model is available:** install Pi CLI, run `pi`, and use `/login` to sign in to a provider. Restart Railyard after setup. Never paste credentials into an issue or a Session.
 - **A message cannot start:** confirm that the selected Model is still available through Pi CLI and that its provider login is current, then restart Railyard and retry. Your draft stays in Composer when Pi rejects a submission.
-- **Need help:** report reproducible bugs or feature feedback in [GitHub Issues](https://github.com/pi-workspace/pi-workspace/issues). Include only sanitized logs and screenshots.
+- **Need help:** report reproducible bugs or feature feedback in [GitHub Issues](https://github.com/pi-workspace/railyard/issues). Include only sanitized logs and screenshots.
 
 ## Repository context
 
@@ -123,7 +133,7 @@ Railyard does not add analytics, advertising identifiers, or a crash-reporting s
 
 ## Support, privacy, and security
 
-Railyard is under active development. Use [GitHub Issues](https://github.com/pi-workspace/pi-workspace/issues) for reproducible bugs and feature feedback, [GitHub Releases](https://github.com/pi-workspace/pi-workspace/releases) for Release Notes, and the [contribution guide](./CONTRIBUTING.md) to help improve the app.
+Railyard is under active development. Use [GitHub Issues](https://github.com/pi-workspace/railyard/issues) for reproducible bugs and feature feedback, [GitHub Releases](https://github.com/pi-workspace/railyard/releases) for Release Notes, and the [contribution guide](./CONTRIBUTING.md) to help improve the app.
 
 Read the [privacy, data handling, and agent authority guide](./docs/privacy.md) before using sensitive Repository content. Report security vulnerabilities privately by following the [security policy](./SECURITY.md); do not include sensitive details in a public issue.
 
@@ -175,7 +185,7 @@ Unknown scenario names use `startup`. Use a 1200 by 800 browser viewport as the 
 | `bun run lint`             | Lint the source files.                                                 |
 | `bun run format:check`     | Check formatting.                                                      |
 | `bun run package:linux`    | Build a local Debian package for release troubleshooting.              |
-| `bun run package:mac`      | Build a local universal macOS DMG for release troubleshooting.         |
+| `bun run package:mac`      | Build local universal macOS release and update artifacts.              |
 | `bun run package:win`      | Build a local Windows x64 installer for release troubleshooting.       |
 | `bun run release:validate` | Validate the beta version and latest bundled Release Note.             |
 | `bun run security:scan`    | Scan Git history and dependencies for known risks.                     |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ A security advisory may instruct users to stop using an affected release while a
 
 Do not disclose a suspected vulnerability in a public issue, discussion, pull request, or social-media post.
 
-When GitHub private vulnerability reporting is available, use the repository's [private vulnerability report](https://github.com/pi-workspace/pi-workspace/security/advisories/new). If that form is unavailable, email **security@pi-workspace.com** with the subject `Railyard security report`.
+When GitHub private vulnerability reporting is available, use the repository's [private vulnerability report](https://github.com/pi-workspace/railyard/security/advisories/new). If that form is unavailable, email **security@pi-workspace.com** with the subject `Railyard security report`.
 
 Include as much of the following as is safe to share:
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -24,6 +24,6 @@ complete license text is included in each corresponding Fontsource package distr
 
 ## Production dependencies
 
-The production dependency inventory contains 426 packages. Their declared licenses are permissive and compatible with distribution in the Apache-2.0-licensed application. DOMPurify's `(MPL-2.0 OR Apache-2.0)` declaration is used under its Apache-2.0 option.
+The production dependency inventory contains 441 packages. Their declared licenses are permissive and compatible with distribution in the Apache-2.0-licensed application. DOMPurify's `(MPL-2.0 OR Apache-2.0)` declaration is used under its Apache-2.0 option.
 
 See [`docs/dependency-licenses.md`](./docs/dependency-licenses.md) for the complete versioned inventory. Each dependency remains subject to its own license text and attribution requirements.

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@lexical/react": "0.48.0",
         "@streamdown/code": "^1.1.1",
         "clsx": "^2.1.1",
+        "electron-updater": "^6.8.3",
         "lexical": "0.48.0",
         "lucide-react": "^1.25.0",
         "motion": "^12.42.2",
@@ -830,6 +831,8 @@
 
     "electron-publish": ["electron-publish@26.15.3", "", { "dependencies": { "@types/fs-extra": "^9.0.11", "aws4": "^1.13.2", "builder-util": "26.15.3", "builder-util-runtime": "9.7.0", "chalk": "^4.1.2", "form-data": "^4.0.5", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "mime": "^2.5.2" } }, "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q=="],
 
+    "electron-updater": ["electron-updater@6.8.9", "", { "dependencies": { "builder-util-runtime": "9.7.0", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig=="],
+
     "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1115,6 +1118,10 @@
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -1494,6 +1501,8 @@
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
+
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
@@ -1687,6 +1696,8 @@
     "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "electron/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
+    "electron-updater/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 

--- a/docs/dependency-licenses.md
+++ b/docs/dependency-licenses.md
@@ -4,7 +4,7 @@ This inventory records the declared licenses of the production dependency tree i
 
 It was regenerated with `license-checker` against a frozen production installation. Package licenses can change when dependencies are updated, so regenerate and review this inventory as part of dependency and release maintenance.
 
-**Packages audited:** 428
+**Packages audited:** 441
 
 ## Summary
 
@@ -13,13 +13,14 @@ It was regenerated with `license-checker` against a frozen production installati
 | (MPL-2.0 OR Apache-2.0) |        1 |
 | 0BSD                    |        1 |
 | Apache-2.0              |       61 |
-| BlueOak-1.0.0           |        5 |
+| BlueOak-1.0.0           |        6 |
 | BSD-2-Clause            |        1 |
 | BSD-3-Clause            |       19 |
-| ISC                     |       42 |
-| MIT                     |      294 |
+| ISC                     |       43 |
+| MIT                     |      304 |
 | MIT*                    |        1 |
 | OFL-1.1                 |        2 |
+| Python-2.0              |        1 |
 | Unlicense               |        1 |
 
 All declared production dependency licenses in this inventory are permissive and compatible with distribution in the Apache-2.0-licensed Railyard application. `license-checker` marks `khroma@2.1.0` as `MIT*`; its bundled license text was reviewed and is MIT. Dependencies remain subject to their own license texts and attribution requirements.
@@ -188,14 +189,16 @@ All declared production dependency licenses in this inventory are permissive and
 | `@ungap/structured-clone@1.3.3`                           | ISC                     |
 | `@upsetjs/venn.js@2.0.0`                                  | MIT                     |
 | `agent-base@7.1.4`                                        | MIT                     |
+| `argparse@2.0.1`                                          | Python-2.0              |
 | `aria-hidden@1.2.6`                                       | MIT                     |
 | `bail@2.0.2`                                              | MIT                     |
 | `balanced-match@4.0.4`                                    | MIT                     |
 | `base64-js@1.5.1`                                         | MIT                     |
 | `bignumber.js@9.3.1`                                      | MIT                     |
 | `bowser@2.14.1`                                           | MIT                     |
-| `brace-expansion@5.0.7`                                   | MIT                     |
+| `brace-expansion@5.0.8`                                   | MIT                     |
 | `buffer-equal-constant-time@1.0.1`                        | BSD-3-Clause            |
+| `builder-util-runtime@9.7.0`                              | MIT                     |
 | `ccount@2.0.1`                                            | MIT                     |
 | `chalk@5.6.2`                                             | MIT                     |
 | `character-entities-html4@2.1.0`                          | MIT                     |
@@ -258,6 +261,7 @@ All declared production dependency licenses in this inventory are permissive and
 | `diff@8.0.4`                                              | BSD-3-Clause            |
 | `dompurify@3.4.12`                                        | (MPL-2.0 OR Apache-2.0) |
 | `ecdsa-sig-formatter@1.0.11`                              | Apache-2.0              |
+| `electron-updater@6.8.9`                                  | MIT                     |
 | `entities@6.0.1`                                          | BSD-2-Clause            |
 | `es-toolkit@1.49.0`                                       | MIT                     |
 | `escape-string-regexp@5.0.0`                              | MIT                     |
@@ -266,6 +270,7 @@ All declared production dependency licenses in this inventory are permissive and
 | `fetch-blob@3.2.0`                                        | MIT                     |
 | `formdata-polyfill@4.0.10`                                | MIT                     |
 | `framer-motion@12.42.2`                                   | MIT                     |
+| `fs-extra@10.1.0`                                         | MIT                     |
 | `gaxios@7.2.0`                                            | Apache-2.0              |
 | `gcp-metadata@8.1.2`                                      | Apache-2.0              |
 | `get-east-asian-width@1.6.0`                              | MIT                     |
@@ -302,17 +307,22 @@ All declared production dependency licenses in this inventory are permissive and
 | `isexe@2.0.0`                                             | ISC                     |
 | `isomorphic.js@0.2.5`                                     | MIT                     |
 | `jiti@2.7.0`                                              | MIT                     |
+| `js-yaml@4.3.0`                                           | MIT                     |
 | `json-bigint@1.0.0`                                       | MIT                     |
 | `json-schema-to-ts@3.1.1`                                 | MIT                     |
+| `jsonfile@6.2.1`                                          | MIT                     |
 | `jwa@2.0.1`                                               | MIT                     |
 | `jws@4.0.1`                                               | MIT                     |
 | `katex@0.16.47`                                           | MIT                     |
 | `khroma@2.1.0`                                            | MIT*                    |
 | `layout-base@1.0.2`                                       | MIT                     |
 | `layout-base@2.0.1`                                       | MIT                     |
+| `lazy-val@1.0.5`                                          | MIT                     |
 | `lexical@0.48.0`                                          | MIT                     |
 | `lib0@0.2.117`                                            | MIT                     |
 | `lodash-es@4.18.1`                                        | MIT                     |
+| `lodash.escaperegexp@4.1.2`                               | MIT                     |
+| `lodash.isequal@4.5.0`                                    | MIT                     |
 | `long@5.3.2`                                              | Apache-2.0              |
 | `longest-streak@3.1.0`                                    | MIT                     |
 | `lru-cache@11.5.2`                                        | BlueOak-1.0.0           |
@@ -411,7 +421,9 @@ All declared production dependency licenses in this inventory are permissive and
 | `rw@1.3.3`                                                | BSD-3-Clause            |
 | `safe-buffer@5.2.1`                                       | MIT                     |
 | `safer-buffer@2.1.2`                                      | MIT                     |
+| `sax@1.6.0`                                               | BlueOak-1.0.0           |
 | `scheduler@0.27.0`                                        | MIT                     |
+| `semver@7.7.4`                                            | ISC                     |
 | `semver@7.8.0`                                            | ISC                     |
 | `shebang-command@2.0.0`                                   | MIT                     |
 | `shebang-regex@3.0.0`                                     | MIT                     |
@@ -426,6 +438,7 @@ All declared production dependency licenses in this inventory are permissive and
 | `tabbable@6.5.0`                                          | MIT                     |
 | `tailwind-merge@3.6.0`                                    | MIT                     |
 | `tailwindcss@4.3.3`                                       | MIT                     |
+| `tiny-typed-emitter@2.1.0`                                | MIT                     |
 | `tinyexec@1.2.4`                                          | MIT                     |
 | `trim-lines@3.0.1`                                        | MIT                     |
 | `trough@2.2.0`                                            | MIT                     |
@@ -442,6 +455,7 @@ All declared production dependency licenses in this inventory are permissive and
 | `unist-util-stringify-position@4.0.0`                     | MIT                     |
 | `unist-util-visit-parents@6.0.2`                          | MIT                     |
 | `unist-util-visit@5.1.0`                                  | MIT                     |
+| `universalify@2.0.1`                                      | MIT                     |
 | `use-sync-external-store@1.6.0`                           | MIT                     |
 | `uuid@14.0.1`                                             | MIT                     |
 | `vfile-location@5.0.3`                                    | MIT                     |

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -64,6 +64,21 @@ Railyard.
 
 ## Data sent over the network
 
+### Update checks and downloads
+
+Railyard contacts GitHub only when a user chooses **Check for updates** in **Settings** → **Updates**. Development
+builds do not make update requests. Packaged macOS builds request release metadata from GitHub and, after a separate
+**Download update** action, download the signed and notarized update archive from the corresponding GitHub Release.
+Packaged Windows and Debian builds request the public GitHub Releases API to identify a newer release; they do not
+download or execute the installer or package and instead open the release only when the user asks.
+
+These requests disclose the information ordinarily visible to GitHub and the network path, including the user's IP
+address, request timing, application network headers, installed application version when included by the updater, and
+the release metadata or asset requested. Railyard does not send Workspace, Repository, Workstream, Session, prompt, or
+credential data as part of an update check. GitHub handles these requests under its own privacy and retention terms.
+
+### Model providers
+
 When a message is submitted, Pi sends the configured model provider the material needed for the Agent Run. Depending
 on the Session and what the Agent does, this can include:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -7,11 +7,14 @@ Railyard beta releases are manually started from GitHub Actions. The workflow re
 
 - The beta supports Debian 12 and Debian 13 on x86_64 (`amd64` in Debian package names), macOS 12 or later on Apple
   silicon and Intel through one universal application, and Windows 11 on x64.
-- Each release provides a Debian package, a universal macOS DMG, a Windows x64 installer, a SHA-256 checksum for each
-  installable artifact, and an SPDX JSON software bill of materials (SBOM) generated from each packaged application.
+- Each release provides a Debian package, a universal macOS DMG, a Windows x64 installer, a signed and notarized
+  universal macOS ZIP update payload, the matching `beta-mac.yml` update metadata, SHA-256 checksums for every package
+  and updater payload, and an SPDX JSON software bill of materials (SBOM) generated from each packaged application.
   AppImage, Windows 10, and other CPU architectures are not supported.
-- The macOS DMG is Developer ID signed, notarized by Apple, and stapled before publication. The Windows installer is
-  not code signed. Neither distribution uses an app store and updates are manual.
+- The macOS DMG and ZIP contain the same Developer ID signed, notarized, and stapled application. After the first
+  updater-enabled release is installed manually, packaged macOS builds can download the authenticated ZIP and install
+  it only through **Restart to update**. The unsigned Windows installer and Debian package remain manual downloads;
+  Railyard never executes either automatically.
 - Beta versions use semantic prerelease versions such as `0.1.0-beta.1`.
 - The core version follows semantic versioning relative to the previous release: major for incompatible changes, minor
   for backward-compatible new functionality, and patch for backward-compatible fixes.
@@ -22,9 +25,10 @@ Railyard beta releases are manually started from GitHub Actions. The workflow re
 - The manual workflow must run from the default branch. It creates the `v<package-version>` tag and matching GitHub
   prerelease only after source checks, packaging, and Debian, macOS, and Windows verification pass.
 - A version can be released only once. The workflow stops if its tag already exists.
-- Debian packages and beta Git tags are not separately signed. Every installable artifact has a SHA-256 checksum and
-  an SPDX JSON SBOM generated from the unpacked packaged application. The release workflow adds a keyless GitHub
-  artifact attestation for every package, checksum, and SBOM, binding each to its source commit and workflow.
+- Debian packages and beta Git tags are not separately signed. Every installable artifact and updater payload has a
+  SHA-256 checksum, and every packaged application has an SPDX JSON SBOM. The release workflow adds a keyless GitHub
+  artifact attestation for every package, updater payload, update metadata file, checksum, and SBOM, binding each to
+  its source commit and workflow.
 
 ## Configure macOS signing and notarization
 
@@ -45,6 +49,13 @@ Create a **Developer ID Application** certificate in the Apple Developer portal,
 Use an App Store Connect API key with notarization permission. On Linux, a certificate signing request and `.p12` can
 be created with OpenSSL; the Apple Developer portal and App Store Connect are browser-based. Never commit a
 certificate, private key, `.p12`, or `.p8` file. The workflow fails before packaging if any required secret is absent.
+
+## Bootstrap in-app updates
+
+The first release containing the updater must be installed manually from GitHub Releases because earlier Railyard
+builds cannot discover or install it. Release notes for that version must call out this one-time manual step. Once it
+is installed, later signed and notarized macOS releases can use the in-app flow; Windows and Debian updates remain
+manual until their packages have an authenticated installation path.
 
 ## Prepare a release
 
@@ -70,18 +81,19 @@ gh workflow run release-beta.yml --ref main
 ```
 
 The workflow installs from `bun.lock`, validates the release contract, runs the quality gate, creates the Debian,
-macOS, and Windows packages, checksums, and SBOMs from their unpacked applications, then verifies the Debian package
-on Debian 12 and 13, the signed and notarized macOS DMG, and Windows installer installation, launch, and removal. It
-creates keyless build-provenance attestations for every release asset before creating the version tag and GitHub
-prerelease.
+macOS, and Windows packages, macOS updater payload and metadata, checksums, and SBOMs from their unpacked applications,
+then verifies the Debian package on Debian 12 and 13, the signed and notarized applications in both macOS artifacts,
+and Windows installer installation, launch, and removal. It creates keyless build-provenance attestations for every
+release asset before creating the version tag and GitHub prerelease.
 
 ## Verify release provenance
 
-Download a release's packages, checksums, and SBOMs, then verify every downloaded asset against this repository:
+Download a release's packages, updater payload and metadata, checksums, and SBOMs, then verify every downloaded asset
+against this repository:
 
 ```sh
-for artifact in railyard-*; do
-  gh attestation verify "$artifact" --repo pi-workspace/pi-workspace
+for artifact in railyard-* beta-mac.yml; do
+  gh attestation verify "$artifact" --repo pi-workspace/railyard
 done
 ```
 
@@ -103,14 +115,22 @@ each supported platform:
 7. If the release promises compatibility with the previous beta's application data, upgrade and verify that exact
    compatibility claim. Otherwise, confirm the Release Note states the compatibility limitation before sharing the
    prerelease.
-8. Uninstall Railyard and confirm its launcher is removed.
+8. In **Settings** → **Updates**, confirm the installed version is correct and a check against the published release
+   reports no downgrade or duplicate update.
+9. Uninstall Railyard and confirm its launcher is removed.
 
 On macOS, launch the application from `/Applications` after dragging it from the mounted DMG. Confirm macOS shows the
-expected Railyard icon and does not show an unidentified-developer warning.
+expected Railyard icon and does not show an unidentified-developer warning. For every release after the updater
+bootstrap release, install the previous beta, check for the candidate, confirm download progress, finish every active
+Agent Run, choose **Restart to update**, and verify the candidate version launches.
 
 On Windows 11 x64, use a local Git Repository whose path has a drive letter and spaces. Confirm Git is available on
 `PATH`, Railyard detects the Pi provider configuration created by `pi` and `/login`, Quick Sessions work from both
-the current checkout and a dedicated worktree, and Workstream Sessions can run a shell command.
+the current checkout and a dedicated worktree, and Workstream Sessions can run a shell command. Check for the candidate
+from the previous beta and confirm Railyard opens its GitHub Release without downloading or executing the installer.
+
+On Debian 12 and 13, check for the candidate from the previous beta and confirm Railyard opens its GitHub Release,
+shows the checksum and package-install instructions, and does not download, elevate, or execute the package.
 
 ## Revoke a compromised release
 
@@ -122,15 +142,15 @@ replaced or reused. If a published release or release credential may be compromi
    restoring publishing.
 3. Prefix the GitHub Release title with **[REVOKED]** and put a prominent warning and incident link at the beginning
    of its notes.
-4. Delete the downloadable packages, checksums, and SBOMs from the compromised release while retaining the release
-   page and tag as an audit record.
+4. Delete the downloadable packages, updater payload and metadata, checksums, and SBOMs from the compromised release
+   while retaining the release page and tag as an audit record.
 5. Determine the affected source, workflow, dependencies, credentials, and release assets. Publish a security
    advisory or repository announcement that identifies the revoked version, impact, removal time, and recommended
    user action.
 6. Prepare and publish a new version through the normal release workflow. Never reuse the revoked version or tag.
 
 Checksums hosted with a compromised release cannot establish publisher authenticity. Verify each downloaded artifact
-with `gh attestation verify "$artifact" --repo pi-workspace/pi-workspace` and include that command in incident
+with `gh attestation verify "$artifact" --repo pi-workspace/railyard` and include that command in incident
 communications.
 
 ## Roll back a release

--- a/docs/security-maintenance.md
+++ b/docs/security-maintenance.md
@@ -43,8 +43,8 @@ A deferred finding must record its evidence, scope, compensating controls, owner
 Each release must retain or publish:
 
 - The source commit and workflow run.
-- The Debian package, macOS DMG, and SHA-256 checksums.
+- The Debian package, macOS DMG, Windows installer, macOS ZIP updater payload, update metadata, and SHA-256 checksums.
 - The SPDX JSON SBOM generated from each unpacked packaged application, including representative JavaScript and native dependencies.
 - Successful macOS Developer ID signature, notarization, and stapling verification.
 - A successful release-source security scan.
-- A keyless GitHub artifact attestation for every package, checksum, and SBOM; verify each downloaded asset with `gh attestation verify "$artifact" --repo pi-workspace/pi-workspace`.
+- A keyless GitHub artifact attestation for every package, updater payload, update metadata file, checksum, and SBOM; verify each downloaded asset with `gh attestation verify "$artifact" --repo pi-workspace/railyard`.

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "packageManager": "bun@1.3.14",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pi-workspace/pi-workspace.git"
+    "url": "https://github.com/pi-workspace/railyard.git"
   },
   "bugs": {
-    "url": "https://github.com/pi-workspace/pi-workspace/issues"
+    "url": "https://github.com/pi-workspace/railyard/issues"
   },
   "keywords": [
     "electron",
@@ -21,7 +21,7 @@
   "description": "A local desktop app for working with Pi across Git repositories and long-running goals. Plan, implement, and pick up where you left off.",
   "desktopName": "railyard.desktop",
   "author": "Railyard contributors",
-  "homepage": "https://github.com/pi-workspace/pi-workspace",
+  "homepage": "https://github.com/pi-workspace/railyard",
   "type": "module",
   "main": "dist/main/index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "package:linux": "bun run build && electron-builder --linux deb --x64 --publish never",
-    "package:mac": "bun run build && electron-builder --mac dmg --universal --publish never",
+    "package:mac": "bun run build && electron-builder --mac --universal --publish never",
     "package:win": "bun run build && electron-builder --win nsis --x64 --publish never",
     "release:notes": "bun run scripts/release-note-markdown.ts",
     "release:validate": "bun run scripts/validate-release.ts && bun run scripts/validate-packaging-dependencies.mjs",
@@ -49,6 +49,14 @@
     "asar": true,
     "directories": {
       "output": "release"
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "pi-workspace",
+      "repo": "railyard",
+      "releaseType": "prerelease",
+      "channel": "beta",
+      "publishAutoUpdate": false
     },
     "files": [
       "dist/**/*",
@@ -80,10 +88,24 @@
       "icon": "assets/icons/railyard.icns",
       "minimumSystemVersion": "12.0",
       "notarize": true,
+      "publish": {
+        "provider": "github",
+        "owner": "pi-workspace",
+        "repo": "railyard",
+        "releaseType": "prerelease",
+        "channel": "beta",
+        "publishAutoUpdate": true
+      },
       "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/@earendil-works/pi-tui/native/darwin/prebuilds/**/darwin-modifiers.node,Contents/Resources/app.asar.unpacked/node_modules/@mariozechner/clipboard-darwin-arm64/clipboard.darwin-arm64.node,Contents/Resources/app.asar.unpacked/node_modules/@mariozechner/clipboard-darwin-x64/clipboard.darwin-x64.node}",
       "target": [
         {
           "target": "dmg",
+          "arch": [
+            "universal"
+          ]
+        },
+        {
+          "target": "zip",
           "arch": [
             "universal"
           ]

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "@lexical/react": "0.48.0",
     "@streamdown/code": "^1.1.1",
     "clsx": "^2.1.1",
+    "electron-updater": "^6.8.3",
     "lexical": "0.48.0",
     "lucide-react": "^1.25.0",
     "motion": "^12.42.2",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -12,7 +12,7 @@ await mkdir(join(outputDirectory, 'renderer'), { recursive: true })
 const [mainBuildResult, preloadBuildResult] = await Promise.all([
   Bun.build({
     entrypoints: ['src/main/index.ts'],
-    external: ['electron', '@earendil-works/pi-coding-agent'],
+    external: ['electron', 'electron-updater', '@earendil-works/pi-coding-agent'],
     format: 'esm',
     outdir: join(outputDirectory, 'main'),
     target: 'node',

--- a/scripts/update-release-configuration.test.ts
+++ b/scripts/update-release-configuration.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import { validateUpdateReleaseConfiguration } from './update-release-configuration'
+
+async function packageMetadata(): Promise<unknown> {
+  return JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+}
+
+test('accepts the configured GitHub beta source and universal macOS updater payload', async () => {
+  assert.deepEqual(validateUpdateReleaseConfiguration(await packageMetadata()), [])
+})
+
+test('rejects release configuration without a macOS ZIP updater payload', async () => {
+  const metadata = (await packageMetadata()) as { build: { mac: { target: unknown[] } } }
+  const withoutZip = {
+    ...metadata,
+    build: {
+      ...metadata.build,
+      mac: {
+        ...metadata.build.mac,
+        target: metadata.build.mac.target.filter(
+          (target) => !(target && typeof target === 'object' && 'target' in target && target.target === 'zip')
+        ),
+      },
+    },
+  }
+
+  assert.match(validateUpdateReleaseConfiguration(withoutZip).join('\n'), /ZIP/i)
+})

--- a/scripts/update-release-configuration.ts
+++ b/scripts/update-release-configuration.ts
@@ -1,0 +1,56 @@
+type UnknownRecord = Record<string, unknown>
+
+function record(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as UnknownRecord) : undefined
+}
+
+function hasUniversalTarget(targets: unknown, expectedTarget: string): boolean {
+  return (
+    Array.isArray(targets) &&
+    targets.some((value) => {
+      const target = record(value)
+
+      return target?.target === expectedTarget && Array.isArray(target.arch) && target.arch.includes('universal')
+    })
+  )
+}
+
+export function validateUpdateReleaseConfiguration(packageMetadata: unknown): readonly string[] {
+  const issues: string[] = []
+  const metadata = record(packageMetadata)
+  const scripts = record(metadata?.scripts)
+  const build = record(metadata?.build)
+  const publish = record(build?.publish)
+  const mac = record(build?.mac)
+  const macPublish = record(mac?.publish)
+
+  if (
+    publish?.provider !== 'github' ||
+    publish.owner !== 'pi-workspace' ||
+    publish.repo !== 'railyard' ||
+    publish.releaseType !== 'prerelease' ||
+    publish.channel !== 'beta' ||
+    publish.publishAutoUpdate !== false ||
+    macPublish?.provider !== 'github' ||
+    macPublish.owner !== 'pi-workspace' ||
+    macPublish.repo !== 'railyard' ||
+    macPublish.releaseType !== 'prerelease' ||
+    macPublish.channel !== 'beta' ||
+    macPublish.publishAutoUpdate !== true
+  ) {
+    issues.push('The updater must publish beta prereleases from pi-workspace/railyard.')
+  }
+
+  if (scripts?.['package:mac'] !== 'bun run build && electron-builder --mac --universal --publish never') {
+    issues.push('The macOS packaging command must build every configured release target.')
+  }
+
+  if (!hasUniversalTarget(mac?.target, 'dmg')) {
+    issues.push('The macOS release requires a universal DMG.')
+  }
+  if (!hasUniversalTarget(mac?.target, 'zip')) {
+    issues.push('The macOS release requires a universal ZIP updater payload.')
+  }
+
+  return issues
+}

--- a/scripts/validate-release.ts
+++ b/scripts/validate-release.ts
@@ -1,17 +1,24 @@
 import { readFile } from 'node:fs/promises'
 import { bundledReleaseNotes, validateReleaseNotes } from '../src/release-notes'
 import { validateBetaReleaseVersion } from './release-version'
+import { validateUpdateReleaseConfiguration } from './update-release-configuration'
 
-const packageMetadata = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as {
-  version: string
-}
+const packageMetadata: unknown = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+const version =
+  packageMetadata &&
+  typeof packageMetadata === 'object' &&
+  'version' in packageMetadata &&
+  typeof packageMetadata.version === 'string'
+    ? packageMetadata.version
+    : ''
 const issues = [
-  ...validateReleaseNotes(bundledReleaseNotes, packageMetadata.version),
-  ...validateBetaReleaseVersion(packageMetadata.version),
+  ...validateReleaseNotes(bundledReleaseNotes, version),
+  ...validateBetaReleaseVersion(version),
+  ...validateUpdateReleaseConfiguration(packageMetadata),
 ]
 
 if (issues.length > 0) {
   throw new Error(issues.join('\n'))
 }
 
-console.log(`Release contract valid for v${packageMetadata.version}.`)
+console.log(`Release contract valid for v${version}.`)

--- a/src/application-update-ipc.test.ts
+++ b/src/application-update-ipc.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { parseApplicationUpdateCommand } from './application-update-ipc'
+
+test('accepts only supported argument-free application update commands', () => {
+  assert.equal(parseApplicationUpdateCommand('check'), 'check')
+  assert.equal(parseApplicationUpdateCommand('download'), 'download')
+  assert.equal(parseApplicationUpdateCommand('restart'), 'restart')
+  assert.equal(parseApplicationUpdateCommand('open-release'), 'open-release')
+  assert.equal(parseApplicationUpdateCommand('install'), undefined)
+  assert.equal(parseApplicationUpdateCommand({ command: 'check' }), undefined)
+})

--- a/src/application-update-ipc.ts
+++ b/src/application-update-ipc.ts
@@ -1,0 +1,15 @@
+export const applicationUpdateIpcChannels = {
+  changed: 'application-update:changed',
+  getSnapshot: 'application-update:get-snapshot',
+  command: 'application-update:command',
+} as const
+
+export type ApplicationUpdateCommand = 'check' | 'download' | 'restart' | 'open-release'
+
+const applicationUpdateCommands = new Set<ApplicationUpdateCommand>(['check', 'download', 'restart', 'open-release'])
+
+export function parseApplicationUpdateCommand(value: unknown): ApplicationUpdateCommand | undefined {
+  return typeof value === 'string' && applicationUpdateCommands.has(value as ApplicationUpdateCommand)
+    ? (value as ApplicationUpdateCommand)
+    : undefined
+}

--- a/src/application-update.ts
+++ b/src/application-update.ts
@@ -1,0 +1,28 @@
+export type ApplicationUpdateStatus =
+  'unavailable' | 'idle' | 'checking' | 'up-to-date' | 'available' | 'downloading' | 'ready' | 'error'
+
+export type ApplicationUpdateSnapshot = Readonly<{
+  currentVersion: string
+  updateMethod: 'self-install' | 'manual' | 'unavailable'
+  status: ApplicationUpdateStatus
+  availableVersion?: string
+  releaseUrl?: string
+  progress?: Readonly<{
+    percent: number
+    transferred: number
+    total: number
+    bytesPerSecond: number
+  }>
+  error?: string
+}>
+
+export type ApplicationUpdateRestartOutcome = 'restarting' | 'blocked-active-run' | 'not-ready'
+
+export interface ApplicationUpdateBridge {
+  getSnapshot(): Promise<ApplicationUpdateSnapshot>
+  check(): Promise<ApplicationUpdateSnapshot>
+  download(): Promise<ApplicationUpdateSnapshot>
+  restartToUpdate(): Promise<ApplicationUpdateRestartOutcome>
+  openRelease(): Promise<boolean>
+  subscribe(listener: (snapshot: ApplicationUpdateSnapshot) => void): () => void
+}

--- a/src/application-update.ts
+++ b/src/application-update.ts
@@ -4,6 +4,7 @@ export type ApplicationUpdateStatus =
 export type ApplicationUpdateSnapshot = Readonly<{
   currentVersion: string
   updateMethod: 'self-install' | 'manual' | 'unavailable'
+  manualUpdateKind?: 'windows' | 'debian' | 'unsupported'
   status: ApplicationUpdateStatus
   availableVersion?: string
   releaseUrl?: string

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -18,6 +18,60 @@ import {
 
 const demoModels = [{ provider: 'openai', providerName: 'OpenAI', id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol' }] as const
 const demoModel = { provider: 'openai', id: 'gpt-5.6-sol' } as const
+const demoCurrentVersion = '2.0.0-beta.1'
+const demoAvailableVersion = '2.0.0-beta.2'
+const demoReleaseUrl = `https://github.com/pi-workspace/railyard/releases/tag/v${demoAvailableVersion}`
+
+function getDemoApplicationUpdateSnapshot(stateName?: string): ApplicationUpdateSnapshot {
+  const current = { currentVersion: demoCurrentVersion } as const
+  const selfInstallUpdate = {
+    ...current,
+    updateMethod: 'self-install',
+    availableVersion: demoAvailableVersion,
+    releaseUrl: demoReleaseUrl,
+  } as const
+
+  switch (stateName) {
+    case 'idle':
+    case 'checking':
+    case 'up-to-date':
+      return { ...current, updateMethod: 'self-install', status: stateName }
+    case 'available':
+    case 'ready':
+      return { ...selfInstallUpdate, status: stateName }
+    case 'downloading':
+      return {
+        ...selfInstallUpdate,
+        status: 'downloading',
+        progress: {
+          percent: 42,
+          transferred: 44_040_192,
+          total: 104_857_600,
+          bytesPerSecond: 8_388_608,
+        },
+      }
+    case 'manual-windows':
+    case 'manual-debian':
+    case 'manual-unsupported':
+      return {
+        ...current,
+        updateMethod: 'manual',
+        status: 'available',
+        availableVersion: demoAvailableVersion,
+        releaseUrl: demoReleaseUrl,
+        manualUpdateKind: stateName.replace('manual-', '') as 'windows' | 'debian' | 'unsupported',
+      }
+    case 'error':
+      return {
+        ...current,
+        updateMethod: 'self-install',
+        status: 'error',
+        error: 'Railyard could not check GitHub Releases. Check your connection and try again.',
+      }
+    default:
+      return { ...current, updateMethod: 'unavailable', status: 'unavailable' }
+  }
+}
 
 const demoRepositories: readonly WorkspaceRepositorySnapshot[] = [
   {
@@ -62,15 +116,11 @@ const demoRepositories: readonly WorkspaceRepositorySnapshot[] = [
   },
 ]
 
-export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
+export function createDemoBridge(scenarioName?: string, applicationUpdateStateName?: string): PiWorkspaceBridge {
   const scenario = structuredClone(getDemoScenario(scenarioName))
   const colorSchemeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
   let settingsSnapshot: SettingsSnapshot = createSettingsSnapshot(defaultSettings, colorSchemeMediaQuery.matches)
-  const applicationUpdateSnapshot: ApplicationUpdateSnapshot = {
-    currentVersion: '2.0.0-beta.1',
-    updateMethod: 'unavailable',
-    status: 'unavailable',
-  }
+  const applicationUpdateSnapshot = getDemoApplicationUpdateSnapshot(applicationUpdateStateName)
   let createdSessionNumber = 0
   let workstreamsSnapshot: WorkstreamsSnapshot = scenario.workstreams
   const transcriptsBySessionId: Record<string, SessionTranscriptSnapshot> = { ...scenario.transcriptsBySessionId }

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -1,3 +1,4 @@
+import type { ApplicationUpdateSnapshot } from '@/src/application-update'
 import type { WorkspaceRepositorySnapshot } from '@/src/application-state'
 import type { PiWorkspaceBridge } from '@/src/pi-workspace'
 import { createSettingsSnapshot, defaultSettings, type SettingsSnapshot } from '@/src/settings'
@@ -65,6 +66,11 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
   const scenario = structuredClone(getDemoScenario(scenarioName))
   const colorSchemeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
   let settingsSnapshot: SettingsSnapshot = createSettingsSnapshot(defaultSettings, colorSchemeMediaQuery.matches)
+  const applicationUpdateSnapshot: ApplicationUpdateSnapshot = {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'unavailable',
+    status: 'unavailable',
+  }
   let createdSessionNumber = 0
   let workstreamsSnapshot: WorkstreamsSnapshot = scenario.workstreams
   const transcriptsBySessionId: Record<string, SessionTranscriptSnapshot> = { ...scenario.transcriptsBySessionId }
@@ -144,6 +150,26 @@ export function createDemoBridge(scenarioName?: string): PiWorkspaceBridge {
   }
 
   return {
+    applicationUpdate: {
+      async getSnapshot() {
+        return applicationUpdateSnapshot
+      },
+      async check() {
+        return applicationUpdateSnapshot
+      },
+      async download() {
+        return applicationUpdateSnapshot
+      },
+      async restartToUpdate() {
+        return 'not-ready'
+      },
+      async openRelease() {
+        return false
+      },
+      subscribe() {
+        return () => {}
+      },
+    },
     applicationState: {
       async getStartup() {
         return { status: 'ready' }

--- a/src/demo/demo-renderer.test.tsx
+++ b/src/demo/demo-renderer.test.tsx
@@ -5,6 +5,34 @@ import { createDemoBridge } from '@/src/demo/demo-bridge'
 import { getDemoScenario, getDemoScenarioPresentation } from '@/src/demo/demo-scenarios'
 import { sessionId } from '@/src/domain/session'
 
+test('the demo bridge previews a selected application update state', async () => {
+  const snapshot = await createDemoBridge(undefined, 'downloading').applicationUpdate.getSnapshot()
+
+  assert.deepEqual(snapshot, {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'self-install',
+    status: 'downloading',
+    availableVersion: '2.0.0-beta.2',
+    releaseUrl: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2',
+    progress: {
+      percent: 42,
+      transferred: 44_040_192,
+      total: 104_857_600,
+      bytesPerSecond: 8_388_608,
+    },
+  })
+})
+
+test('the demo bridge keeps unknown application update previews unavailable', async () => {
+  const snapshot = await createDemoBridge(undefined, 'unknown').applicationUpdate.getSnapshot()
+
+  assert.deepEqual(snapshot, {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'unavailable',
+    status: 'unavailable',
+  })
+})
+
 test('the demo bridge dismisses an available action card', async () => {
   const bridge = createDemoBridge('workstream')
   const implementationSessionId = sessionId('offline-implementation')

--- a/src/demo/index.ts
+++ b/src/demo/index.ts
@@ -2,7 +2,9 @@ import { createDemoBridge } from '@/src/demo/demo-bridge'
 import { getDemoScenarioPresentation } from '@/src/demo/demo-scenarios'
 import { renderApp } from '@/src/renderer/render-app'
 
-const scenarioName = new URLSearchParams(window.location.search).get('scenario') ?? undefined
+const searchParameters = new URLSearchParams(window.location.search)
+const scenarioName = searchParameters.get('scenario') ?? undefined
+const applicationUpdateStateName = searchParameters.get('update') ?? undefined
 
-window.piWorkspace = createDemoBridge(scenarioName)
+window.piWorkspace = createDemoBridge(scenarioName, applicationUpdateStateName)
 renderApp({ initialSessionDisplay: getDemoScenarioPresentation(scenarioName) })

--- a/src/main/application-update-source.test.ts
+++ b/src/main/application-update-source.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  createElectronUpdateSource,
+  createGitHubReleaseUpdateSource,
+  type ElectronUpdateClient,
+} from './application-update-source'
+
+test('the manual update source selects the newest published semantic release', async () => {
+  const source = createGitHubReleaseUpdateSource(async () =>
+    Response.json([
+      {
+        tag_name: 'v2.0.0-beta.2',
+        html_url: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2',
+        draft: false,
+      },
+      {
+        tag_name: 'v2.0.0-beta.3',
+        html_url: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.3',
+        draft: true,
+      },
+      {
+        tag_name: 'v2.0.0-beta.1',
+        html_url: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.1',
+        draft: false,
+      },
+    ])
+  )
+
+  const release = await source.check()
+
+  assert.deepEqual(release, {
+    version: '2.0.0-beta.2',
+    releaseUrl: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2',
+  })
+})
+
+test('the macOS update source disables automatic download, quit installation, and downgrades', async () => {
+  const client: ElectronUpdateClient = {
+    autoDownload: true,
+    autoInstallOnAppQuit: true,
+    allowDowngrade: true,
+    disableWebInstaller: false,
+    checkForUpdates: async () => ({ updateInfo: { version: '2.0.0-beta.2' } }),
+    downloadUpdate: async () => [],
+    quitAndInstall: () => {},
+    onProgress: () => {},
+    onDownloaded: () => {},
+    onError: () => {},
+  }
+
+  const source = createElectronUpdateSource(client)
+  const release = await source.check()
+
+  assert.equal(client.autoDownload, false)
+  assert.equal(client.autoInstallOnAppQuit, false)
+  assert.equal(client.allowDowngrade, false)
+  assert.equal(client.disableWebInstaller, true)
+  assert.deepEqual(release, {
+    version: '2.0.0-beta.2',
+    releaseUrl: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2',
+  })
+})

--- a/src/main/application-update-source.ts
+++ b/src/main/application-update-source.ts
@@ -1,0 +1,105 @@
+import { compareSemanticVersions, isSemanticVersion } from '@/src/release-notes'
+import type { ApplicationUpdateSource } from '@/src/main/application-updater'
+
+const releasesUrl = 'https://api.github.com/repos/pi-workspace/railyard/releases?per_page=20'
+
+type GitHubRelease = Readonly<{
+  tag_name: unknown
+  draft: unknown
+}>
+
+function parseGitHubRelease(value: unknown): Readonly<{ version: string; releaseUrl: string }> | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const release = value as GitHubRelease
+  const version = typeof release.tag_name === 'string' ? release.tag_name.replace(/^v/, '') : undefined
+
+  if (release.draft !== false || !version || !isSemanticVersion(version)) {
+    return undefined
+  }
+
+  return {
+    version,
+    releaseUrl: `https://github.com/pi-workspace/railyard/releases/tag/v${version}`,
+  }
+}
+
+export interface ElectronUpdateClient {
+  autoDownload: boolean
+  autoInstallOnAppQuit: boolean
+  allowDowngrade: boolean
+  disableWebInstaller: boolean
+  checkForUpdates(): Promise<Readonly<{ updateInfo: Readonly<{ version: string }> }> | null>
+  downloadUpdate(): Promise<readonly string[]>
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
+  onProgress(
+    listener: (
+      progress: Readonly<{ percent: number; transferred: number; total: number; bytesPerSecond: number }>
+    ) => void
+  ): void
+  onDownloaded(listener: () => void): void
+  onError(listener: (error: Error) => void): void
+}
+
+export function createElectronUpdateSource(client: ElectronUpdateClient): ApplicationUpdateSource {
+  client.autoDownload = false
+  client.autoInstallOnAppQuit = false
+  client.allowDowngrade = false
+  client.disableWebInstaller = true
+
+  let listener: Parameters<ApplicationUpdateSource['subscribe']>[0] = () => {}
+  client.onProgress((progress) => listener({ type: 'download-progress', ...progress }))
+  client.onDownloaded(() => listener({ type: 'downloaded' }))
+  client.onError(() =>
+    listener({ type: 'error', message: 'Railyard could not complete the update. Check your connection and try again.' })
+  )
+
+  return {
+    async check() {
+      const result = await client.checkForUpdates()
+      const version = result?.updateInfo.version
+
+      return version
+        ? {
+            version,
+            releaseUrl: `https://github.com/pi-workspace/railyard/releases/tag/v${version}`,
+          }
+        : undefined
+    },
+    async download() {
+      await client.downloadUpdate()
+    },
+    install() {
+      client.quitAndInstall(false, true)
+    },
+    subscribe(nextListener) {
+      listener = nextListener
+
+      return () => {
+        if (listener === nextListener) listener = () => {}
+      }
+    },
+  }
+}
+
+export function createGitHubReleaseUpdateSource(
+  fetchRelease: (url: string) => Promise<Response>
+): ApplicationUpdateSource {
+  return {
+    async check() {
+      const response = await fetchRelease(releasesUrl)
+      if (!response.ok) throw new Error(`GitHub Releases returned ${response.status}.`)
+
+      const value: unknown = await response.json()
+      if (!Array.isArray(value)) throw new TypeError('GitHub Releases returned an unsupported response.')
+
+      return value
+        .map(parseGitHubRelease)
+        .filter((release): release is NonNullable<typeof release> => release !== undefined)
+        .sort((first, second) => compareSemanticVersions(second.version, first.version))[0]
+    },
+    download: async () => {},
+    install: () => {},
+    subscribe: () => () => {},
+  }
+}

--- a/src/main/application-updater.test.ts
+++ b/src/main/application-updater.test.ts
@@ -232,6 +232,7 @@ test('manual-update platforms open the matching GitHub Release instead of downlo
   const opened = await updater.openRelease()
 
   assert.equal(opened, true)
+  assert.equal(updater.getSnapshot().manualUpdateKind, 'debian')
   assert.equal(downloadCount, 0)
   assert.deepEqual(openedUrls, ['https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2'])
 })

--- a/src/main/application-updater.test.ts
+++ b/src/main/application-updater.test.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createApplicationUpdater, type ApplicationUpdateSource } from './application-updater'
+
+function updateSource(overrides: Partial<ApplicationUpdateSource> = {}): ApplicationUpdateSource {
+  return {
+    check: async () => undefined,
+    download: async () => {},
+    install: () => {},
+    subscribe: () => () => {},
+    ...overrides,
+  }
+}
+
+function availableRelease(version = '2.0.0-beta.2') {
+  return {
+    version,
+    releaseUrl: `https://github.com/pi-workspace/railyard/releases/tag/v${version}`,
+  }
+}
+
+test('development builds report updates as unavailable without contacting the release source', async () => {
+  let checkCount = 0
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.1',
+    isPackaged: false,
+    platform: 'darwin',
+    source: updateSource({
+      check: async () => {
+        checkCount += 1
+        return undefined
+      },
+    }),
+    hasActiveAgentRun: () => false,
+    openExternal: async () => {},
+  })
+
+  const snapshot = await updater.check()
+
+  assert.equal(snapshot.status, 'unavailable')
+  assert.equal(checkCount, 0)
+})
+
+test('a packaged build reports a newer semantic release as available', async () => {
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.1',
+    isPackaged: true,
+    platform: 'darwin',
+    source: updateSource({
+      check: async () => availableRelease(),
+    }),
+    hasActiveAgentRun: () => false,
+    openExternal: async () => {},
+  })
+
+  const snapshot = await updater.check()
+
+  assert.equal(snapshot.status, 'available')
+  assert.equal(snapshot.availableVersion, '2.0.0-beta.2')
+})
+
+test('a packaged build never offers an older release', async () => {
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.2',
+    isPackaged: true,
+    platform: 'darwin',
+    source: updateSource({
+      check: async () => ({
+        version: '2.0.0-beta.1',
+        releaseUrl: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.1',
+      }),
+    }),
+    hasActiveAgentRun: () => false,
+    openExternal: async () => {},
+  })
+
+  const snapshot = await updater.check()
+
+  assert.equal(snapshot.status, 'up-to-date')
+})
+
+test('macOS download progress ends in an update-ready state', async () => {
+  let notify: Parameters<ApplicationUpdateSource['subscribe']>[0] = () => {}
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.1',
+    isPackaged: true,
+    platform: 'darwin',
+    source: updateSource({
+      check: async () => availableRelease(),
+      download: async () => {
+        notify({
+          type: 'download-progress',
+          percent: 42,
+          transferred: 420,
+          total: 1_000,
+          bytesPerSecond: 100,
+        })
+        notify({ type: 'downloaded' })
+      },
+      subscribe: (listener) => {
+        notify = listener
+        return () => {}
+      },
+    }),
+    hasActiveAgentRun: () => false,
+    openExternal: async () => {},
+  })
+
+  await updater.check()
+  const snapshot = await updater.download()
+
+  assert.equal(snapshot.status, 'ready')
+})
+
+test('macOS download progress is published to update subscribers', async () => {
+  let notify: Parameters<ApplicationUpdateSource['subscribe']>[0] = () => {}
+  const observedPercentages: number[] = []
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.1',
+    isPackaged: true,
+    platform: 'darwin',
+    source: updateSource({
+      check: async () => availableRelease(),
+      download: async () => {
+        notify({
+          type: 'download-progress',
+          percent: 42,
+          transferred: 420,
+          total: 1_000,
+          bytesPerSecond: 100,
+        })
+      },
+      subscribe: (listener) => {
+        notify = listener
+        return () => {}
+      },
+    }),
+    hasActiveAgentRun: () => false,
+    openExternal: async () => {},
+  })
+  updater.subscribe((snapshot) => {
+    if (snapshot.progress) observedPercentages.push(snapshot.progress.percent)
+  })
+
+  await updater.check()
+  await updater.download()
+
+  assert.deepEqual(observedPercentages, [42])
+})
+
+test('a ready macOS update does not restart while an Agent Run is active', async () => {
+  let notify: Parameters<ApplicationUpdateSource['subscribe']>[0] = () => {}
+  let installCount = 0
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.1',
+    isPackaged: true,
+    platform: 'darwin',
+    source: updateSource({
+      check: async () => availableRelease(),
+      download: async () => notify({ type: 'downloaded' }),
+      install: () => {
+        installCount += 1
+      },
+      subscribe: (listener) => {
+        notify = listener
+        return () => {}
+      },
+    }),
+    hasActiveAgentRun: () => true,
+    openExternal: async () => {},
+  })
+
+  await updater.check()
+  await updater.download()
+  const outcome = updater.restartToUpdate()
+
+  assert.equal(outcome, 'blocked-active-run')
+  assert.equal(installCount, 0)
+})
+
+test('a ready macOS update installs only through the explicit restart command', async () => {
+  let notify: Parameters<ApplicationUpdateSource['subscribe']>[0] = () => {}
+  let installCount = 0
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.1',
+    isPackaged: true,
+    platform: 'darwin',
+    source: updateSource({
+      check: async () => availableRelease(),
+      download: async () => notify({ type: 'downloaded' }),
+      install: () => {
+        installCount += 1
+      },
+      subscribe: (listener) => {
+        notify = listener
+        return () => {}
+      },
+    }),
+    hasActiveAgentRun: () => false,
+    openExternal: async () => {},
+  })
+
+  await updater.check()
+  await updater.download()
+  const outcome = updater.restartToUpdate()
+
+  assert.equal(outcome, 'restarting')
+  assert.equal(installCount, 1)
+})
+
+test('manual-update platforms open the matching GitHub Release instead of downloading it', async () => {
+  let downloadCount = 0
+  const openedUrls: string[] = []
+  const updater = createApplicationUpdater({
+    currentVersion: '2.0.0-beta.1',
+    isPackaged: true,
+    platform: 'linux',
+    source: updateSource({
+      check: async () => availableRelease(),
+      download: async () => {
+        downloadCount += 1
+      },
+    }),
+    hasActiveAgentRun: () => false,
+    openExternal: async (url) => {
+      openedUrls.push(url)
+    },
+  })
+
+  await updater.check()
+  await updater.download()
+  const opened = await updater.openRelease()
+
+  assert.equal(opened, true)
+  assert.equal(downloadCount, 0)
+  assert.deepEqual(openedUrls, ['https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2'])
+})

--- a/src/main/application-updater.ts
+++ b/src/main/application-updater.ts
@@ -1,0 +1,165 @@
+import type { ApplicationUpdateRestartOutcome, ApplicationUpdateSnapshot } from '@/src/application-update'
+import { compareSemanticVersions, isSemanticVersion } from '@/src/release-notes'
+
+export type ApplicationUpdateSourceEvent =
+  | Readonly<{
+      type: 'download-progress'
+      percent: number
+      transferred: number
+      total: number
+      bytesPerSecond: number
+    }>
+  | Readonly<{ type: 'downloaded' }>
+  | Readonly<{ type: 'error'; message: string }>
+
+export type ApplicationUpdateSource = Readonly<{
+  check(): Promise<Readonly<{ version: string; releaseUrl: string }> | undefined>
+  download(): Promise<void>
+  install(): void
+  subscribe(listener: (event: ApplicationUpdateSourceEvent) => void): () => void
+}>
+
+type ApplicationUpdaterOptions = Readonly<{
+  currentVersion: string
+  isPackaged: boolean
+  platform: NodeJS.Platform
+  source: ApplicationUpdateSource
+  hasActiveAgentRun(): boolean
+  openExternal(url: string): Promise<void>
+}>
+
+export interface ApplicationUpdater {
+  getSnapshot(): ApplicationUpdateSnapshot
+  check(): Promise<ApplicationUpdateSnapshot>
+  download(): Promise<ApplicationUpdateSnapshot>
+  restartToUpdate(): ApplicationUpdateRestartOutcome
+  openRelease(): Promise<boolean>
+  subscribe(listener: (snapshot: ApplicationUpdateSnapshot) => void): () => void
+}
+
+function isRailyardReleaseUrl(value: string | undefined): value is string {
+  if (!value) return false
+
+  try {
+    const url = new URL(value)
+
+    return (
+      url.protocol === 'https:' &&
+      url.hostname === 'github.com' &&
+      url.pathname.startsWith('/pi-workspace/railyard/releases/') &&
+      !url.username &&
+      !url.password
+    )
+  } catch {
+    return false
+  }
+}
+
+export function createApplicationUpdater(options: ApplicationUpdaterOptions): ApplicationUpdater {
+  const updateMethod = !options.isPackaged ? 'unavailable' : options.platform === 'darwin' ? 'self-install' : 'manual'
+  let snapshot: ApplicationUpdateSnapshot = {
+    currentVersion: options.currentVersion,
+    updateMethod,
+    status: options.isPackaged ? 'idle' : 'unavailable',
+  }
+  const listeners = new Set<(snapshot: ApplicationUpdateSnapshot) => void>()
+
+  function publish(nextSnapshot: ApplicationUpdateSnapshot): void {
+    snapshot = nextSnapshot
+
+    for (const listener of listeners) listener(snapshot)
+  }
+
+  options.source.subscribe((event) => {
+    if (event.type === 'download-progress') {
+      publish({
+        ...snapshot,
+        status: 'downloading',
+        progress: {
+          percent: event.percent,
+          transferred: event.transferred,
+          total: event.total,
+          bytesPerSecond: event.bytesPerSecond,
+        },
+        error: undefined,
+      })
+      return
+    }
+
+    if (event.type === 'downloaded') {
+      publish({ ...snapshot, status: 'ready', progress: undefined, error: undefined })
+      return
+    }
+
+    publish({ ...snapshot, status: 'error', progress: undefined, error: event.message })
+  })
+
+  return {
+    getSnapshot: () => snapshot,
+    async check() {
+      if (!options.isPackaged) return snapshot
+
+      publish({ currentVersion: options.currentVersion, updateMethod, status: 'checking' })
+
+      try {
+        const release = await options.source.check()
+
+        publish(
+          release &&
+            isSemanticVersion(release.version) &&
+            compareSemanticVersions(release.version, options.currentVersion) > 0
+            ? {
+                currentVersion: options.currentVersion,
+                updateMethod,
+                status: 'available',
+                availableVersion: release.version,
+                releaseUrl: release.releaseUrl,
+              }
+            : { currentVersion: options.currentVersion, updateMethod, status: 'up-to-date' }
+        )
+      } catch {
+        publish({
+          currentVersion: options.currentVersion,
+          updateMethod,
+          status: 'error',
+          error: 'Railyard could not check for updates. Check your connection and try again.',
+        })
+      }
+
+      return snapshot
+    },
+    async download() {
+      if (snapshot.status !== 'available' || updateMethod !== 'self-install') return snapshot
+
+      publish({ ...snapshot, status: 'downloading', error: undefined })
+
+      try {
+        await options.source.download()
+      } catch {
+        publish({ ...snapshot, status: 'error', error: 'Railyard could not download the update. Try again.' })
+      }
+
+      return snapshot
+    },
+    restartToUpdate() {
+      if (snapshot.status !== 'ready' || updateMethod !== 'self-install') return 'not-ready'
+      if (options.hasActiveAgentRun()) return 'blocked-active-run'
+
+      options.source.install()
+
+      return 'restarting'
+    },
+    async openRelease() {
+      if (updateMethod !== 'manual' || !isRailyardReleaseUrl(snapshot.releaseUrl)) return false
+
+      await options.openExternal(snapshot.releaseUrl)
+
+      return true
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+
+      return () => listeners.delete(listener)
+    },
+  }
+}

--- a/src/main/application-updater.ts
+++ b/src/main/application-updater.ts
@@ -57,9 +57,21 @@ function isRailyardReleaseUrl(value: string | undefined): value is string {
 
 export function createApplicationUpdater(options: ApplicationUpdaterOptions): ApplicationUpdater {
   const updateMethod = !options.isPackaged ? 'unavailable' : options.platform === 'darwin' ? 'self-install' : 'manual'
-  let snapshot: ApplicationUpdateSnapshot = {
+  const manualUpdateKind =
+    updateMethod !== 'manual'
+      ? undefined
+      : options.platform === 'win32'
+        ? 'windows'
+        : options.platform === 'linux'
+          ? 'debian'
+          : 'unsupported'
+  const updateIdentity = {
     currentVersion: options.currentVersion,
     updateMethod,
+    manualUpdateKind,
+  } as const
+  let snapshot: ApplicationUpdateSnapshot = {
+    ...updateIdentity,
     status: options.isPackaged ? 'idle' : 'unavailable',
   }
   const listeners = new Set<(snapshot: ApplicationUpdateSnapshot) => void>()
@@ -99,7 +111,7 @@ export function createApplicationUpdater(options: ApplicationUpdaterOptions): Ap
     async check() {
       if (!options.isPackaged) return snapshot
 
-      publish({ currentVersion: options.currentVersion, updateMethod, status: 'checking' })
+      publish({ ...updateIdentity, status: 'checking' })
 
       try {
         const release = await options.source.check()
@@ -109,18 +121,16 @@ export function createApplicationUpdater(options: ApplicationUpdaterOptions): Ap
             isSemanticVersion(release.version) &&
             compareSemanticVersions(release.version, options.currentVersion) > 0
             ? {
-                currentVersion: options.currentVersion,
-                updateMethod,
+                ...updateIdentity,
                 status: 'available',
                 availableVersion: release.version,
                 releaseUrl: release.releaseUrl,
               }
-            : { currentVersion: options.currentVersion, updateMethod, status: 'up-to-date' }
+            : { ...updateIdentity, status: 'up-to-date' }
         )
       } catch {
         publish({
-          currentVersion: options.currentVersion,
-          updateMethod,
+          ...updateIdentity,
           status: 'error',
           error: 'Railyard could not check for updates. Check your connection and try again.',
         })

--- a/src/main/application-updates.ts
+++ b/src/main/application-updates.ts
@@ -1,0 +1,93 @@
+import { app, net, shell } from 'electron'
+import { autoUpdater } from 'electron-updater'
+import type { ApplicationUpdateSnapshot } from '@/src/application-update'
+import { applicationUpdateIpcChannels, parseApplicationUpdateCommand } from '@/src/application-update-ipc'
+import {
+  createElectronUpdateSource,
+  createGitHubReleaseUpdateSource,
+  type ElectronUpdateClient,
+} from '@/src/main/application-update-source'
+import { createApplicationUpdater } from '@/src/main/application-updater'
+import type { PiSessionRuntimeRegistry } from '@/src/main/pi-session-runtimes'
+import { broadcastToTrustedRenderers, handleTrustedIpc } from '@/src/main/trusted-ipc'
+
+function electronUpdateClient(): ElectronUpdateClient {
+  return {
+    get autoDownload() {
+      return autoUpdater.autoDownload
+    },
+    set autoDownload(value) {
+      autoUpdater.autoDownload = value
+    },
+    get autoInstallOnAppQuit() {
+      return autoUpdater.autoInstallOnAppQuit
+    },
+    set autoInstallOnAppQuit(value) {
+      autoUpdater.autoInstallOnAppQuit = value
+    },
+    get allowDowngrade() {
+      return autoUpdater.allowDowngrade
+    },
+    set allowDowngrade(value) {
+      autoUpdater.allowDowngrade = value
+    },
+    get disableWebInstaller() {
+      return autoUpdater.disableWebInstaller
+    },
+    set disableWebInstaller(value) {
+      autoUpdater.disableWebInstaller = value
+    },
+    checkForUpdates: () => autoUpdater.checkForUpdates(),
+    downloadUpdate: () => autoUpdater.downloadUpdate(),
+    quitAndInstall: (isSilent, isForceRunAfter) => autoUpdater.quitAndInstall(isSilent, isForceRunAfter),
+    onProgress: (listener) => {
+      autoUpdater.on('download-progress', listener)
+    },
+    onDownloaded: (listener) => {
+      autoUpdater.on('update-downloaded', listener)
+    },
+    onError: (listener) => {
+      autoUpdater.on('error', listener)
+    },
+  }
+}
+
+export function initializeApplicationUpdates(registry: PiSessionRuntimeRegistry): void {
+  const source =
+    process.platform === 'darwin'
+      ? createElectronUpdateSource(electronUpdateClient())
+      : createGitHubReleaseUpdateSource((url) =>
+          net.fetch(url, {
+            headers: {
+              Accept: 'application/vnd.github+json',
+              'X-GitHub-Api-Version': '2022-11-28',
+            },
+          })
+        )
+  const updater = createApplicationUpdater({
+    currentVersion: app.getVersion(),
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+    source,
+    hasActiveAgentRun: () => registry.getWorkingStateSnapshots().some(({ isWorking }) => isWorking),
+    openExternal: (url) => shell.openExternal(url),
+  })
+
+  handleTrustedIpc(applicationUpdateIpcChannels.getSnapshot, (): ApplicationUpdateSnapshot => updater.getSnapshot())
+  handleTrustedIpc(
+    applicationUpdateIpcChannels.command,
+    async (_event, value: unknown, ...additionalArguments: unknown[]) => {
+      const command = additionalArguments.length === 0 ? parseApplicationUpdateCommand(value) : undefined
+      if (!command) throw new TypeError('Unsupported application update command.')
+
+      if (command === 'check') return updater.check()
+      if (command === 'download') return updater.download()
+      if (command === 'open-release') return updater.openRelease()
+
+      return updater.restartToUpdate()
+    }
+  )
+  updater.subscribe((snapshot) => {
+    broadcastToTrustedRenderers(applicationUpdateIpcChannels.changed, snapshot)
+  })
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,8 +4,9 @@ import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { startApplicationLifecycle, type ApplicationWindow } from '@/src/main/application-lifecycle'
 import { initializeApplicationAuthority } from '@/src/main/application-state'
+import { initializeApplicationUpdates } from '@/src/main/application-updates'
 import { initializeApplicationStateIpc } from '@/src/main/application-state-ipc'
-import { initializeComposer } from '@/src/main/composer-ipc'
+import { getPiSessionRuntimeRegistry, initializeComposer } from '@/src/main/composer-ipc'
 import {
   applicationProtocolScheme,
   allowBrowserPermissionCheck,
@@ -120,6 +121,7 @@ async function initializeApplication(): Promise<void> {
     initializeWorkstreamKnowledge(authority)
     const settings = await initializeSettings()
     initializeComposer(authority)
+    initializeApplicationUpdates(getPiSessionRuntimeRegistry())
     windowBackgroundColor = getThemeWindowBackgroundColor(settings.theme, settings.resolvedColorScheme)
   } catch (error) {
     initializationFailed = true

--- a/src/pi-workspace.ts
+++ b/src/pi-workspace.ts
@@ -1,3 +1,4 @@
+import type { ApplicationUpdateBridge } from '@/src/application-update'
 import type { ComposerBridge } from '@/src/composer'
 import type { ApplicationStateBridge } from '@/src/application-state-ipc'
 import type { SessionConfigurationBridge } from '@/src/session-configuration'
@@ -12,6 +13,7 @@ import type { WorkstreamKnowledgeBridge } from '@/src/workstream-knowledge-ipc'
 
 export type PiWorkspaceBridge = Readonly<{
   applicationState: ApplicationStateBridge
+  applicationUpdate: ApplicationUpdateBridge
   composer: ComposerBridge
   sessionSkills: SessionSkillsBridge
   sessionFiles: SessionFilesBridge

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,10 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import type {
+  ApplicationUpdateBridge,
+  ApplicationUpdateRestartOutcome,
+  ApplicationUpdateSnapshot,
+} from '@/src/application-update'
+import { applicationUpdateIpcChannels } from '@/src/application-update-ipc'
 import type { ApplicationStateBridge, CreateWorkspaceOutcome } from '@/src/application-state-ipc'
 import type { WorkspaceMembershipUpdate, WorkspacesSnapshot } from '@/src/application-state'
 import { applicationStateIpcChannels } from '@/src/application-state-ipc'
@@ -35,6 +41,33 @@ import type {
   SessionTranscriptSnapshot,
 } from '@/src/session-transcript'
 import { sessionTranscriptIpcChannels } from '@/src/session-transcript-ipc'
+
+const applicationUpdateBridge: ApplicationUpdateBridge = {
+  getSnapshot() {
+    return ipcRenderer.invoke(applicationUpdateIpcChannels.getSnapshot) as Promise<ApplicationUpdateSnapshot>
+  },
+  check() {
+    return ipcRenderer.invoke(applicationUpdateIpcChannels.command, 'check') as Promise<ApplicationUpdateSnapshot>
+  },
+  download() {
+    return ipcRenderer.invoke(applicationUpdateIpcChannels.command, 'download') as Promise<ApplicationUpdateSnapshot>
+  },
+  restartToUpdate() {
+    return ipcRenderer.invoke(
+      applicationUpdateIpcChannels.command,
+      'restart'
+    ) as Promise<ApplicationUpdateRestartOutcome>
+  },
+  openRelease() {
+    return ipcRenderer.invoke(applicationUpdateIpcChannels.command, 'open-release') as Promise<boolean>
+  },
+  subscribe(listener) {
+    const handleChange = (_event: Electron.IpcRendererEvent, snapshot: ApplicationUpdateSnapshot) => listener(snapshot)
+    ipcRenderer.on(applicationUpdateIpcChannels.changed, handleChange)
+
+    return () => ipcRenderer.removeListener(applicationUpdateIpcChannels.changed, handleChange)
+  },
+}
 
 const settingsBridge: SettingsBridge = {
   getSnapshot() {
@@ -323,6 +356,7 @@ const sessionTranscriptBridge: SessionTranscriptBridge = {
 
 const piWorkspaceBridge: PiWorkspaceBridge = {
   applicationState: applicationStateBridge,
+  applicationUpdate: applicationUpdateBridge,
   composer: composerBridge,
   sessionSkills: sessionSkillsBridge,
   sessionFiles: sessionFilesBridge,

--- a/src/release-notes.ts
+++ b/src/release-notes.ts
@@ -151,7 +151,7 @@ export const bundledReleaseNotes: readonly ReleaseNote[] = [
   },
 ]
 
-function compareReleaseVersions(firstVersion: string, secondVersion: string): number {
+export function compareSemanticVersions(firstVersion: string, secondVersion: string): number {
   const parseVersion = (version: string) => {
     const versionWithoutBuild = version.split('+', 1)[0]!
     const prereleaseSeparator = versionWithoutBuild.indexOf('-')
@@ -265,7 +265,7 @@ export function validateReleaseNotes(
   if (
     releaseNotes.some(
       (releaseNote, index) =>
-        index > 0 && compareReleaseVersions(releaseNotes[index - 1]!.version, releaseNote.version) <= 0
+        index > 0 && compareSemanticVersions(releaseNotes[index - 1]!.version, releaseNote.version) <= 0
     )
   ) {
     issues.push('Release Notes must be ordered newest-first.')

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
 import { act, cleanup, render, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ApplicationUpdateSnapshot } from '@/src/application-update'
 import type { WorkspacesSnapshot } from '@/src/application-state'
 import { sessionId, type SessionId } from '@/src/domain/session'
 import type { Workstream, WorkstreamsSnapshot } from '@/src/domain/workstream'
@@ -87,9 +88,25 @@ function deferred<Value>() {
 
 function createBridge(
   overrides: Partial<PiWorkspaceBridge['workstreams']> = {},
-  applicationStateOverrides: Partial<PiWorkspaceBridge['applicationState']> = {}
+  applicationStateOverrides: Partial<PiWorkspaceBridge['applicationState']> = {},
+  applicationUpdateOverrides: Partial<PiWorkspaceBridge['applicationUpdate']> = {}
 ): PiWorkspaceBridge {
+  const applicationUpdateSnapshot: ApplicationUpdateSnapshot = {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'unavailable',
+    status: 'unavailable',
+  }
+
   return {
+    applicationUpdate: {
+      getSnapshot: async () => applicationUpdateSnapshot,
+      check: async () => applicationUpdateSnapshot,
+      download: async () => applicationUpdateSnapshot,
+      restartToUpdate: async () => 'not-ready',
+      openRelease: async () => false,
+      subscribe: () => () => {},
+      ...applicationUpdateOverrides,
+    },
     applicationState: {
       getStartup: async () => ({ status: 'ready' }),
       getWorkspaces: async () => workspaces,
@@ -183,6 +200,177 @@ test('updates theme immediately from global Settings', async () => {
   await user.click(view.getByRole('radio', { name: 'One' }))
 
   await waitFor(() => assert.deepEqual(updates, [{ theme: 'one' }]))
+})
+
+test('shows the installed version and update check in Settings', async () => {
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(createBridge())
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  await user.click(view.getByRole('button', { name: 'Updates' }))
+
+  assert.ok(view.getByText('2.0.0-beta.1'))
+  assert.ok(view.getByRole('button', { name: 'Check for updates' }))
+})
+
+test('checks for an update and offers a macOS download when a newer release is available', async () => {
+  let checkCount = 0
+  const currentSnapshot: ApplicationUpdateSnapshot = {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'self-install',
+    status: 'idle',
+  }
+  const availableSnapshot: ApplicationUpdateSnapshot = {
+    ...currentSnapshot,
+    status: 'available',
+    availableVersion: '2.0.0-beta.2',
+    releaseUrl: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2',
+  }
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(
+    createBridge(
+      {},
+      {},
+      {
+        getSnapshot: async () => currentSnapshot,
+        check: async () => {
+          checkCount += 1
+          return availableSnapshot
+        },
+      }
+    )
+  )
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  await user.click(view.getByRole('button', { name: 'Updates' }))
+  await user.click(await view.findByRole('button', { name: 'Check for updates' }))
+
+  assert.equal(checkCount, 1)
+  assert.ok(await view.findByText('Version 2.0.0-beta.2 is available.'))
+  assert.ok(view.getByRole('button', { name: 'Download update' }))
+})
+
+test('shows progress while a macOS update downloads', async () => {
+  let updateListener: Parameters<PiWorkspaceBridge['applicationUpdate']['subscribe']>[0] = () => {}
+  const availableSnapshot: ApplicationUpdateSnapshot = {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'self-install',
+    status: 'available',
+    availableVersion: '2.0.0-beta.2',
+  }
+  const downloadingSnapshot: ApplicationUpdateSnapshot = {
+    ...availableSnapshot,
+    status: 'downloading',
+    progress: { percent: 42, transferred: 420, total: 1_000, bytesPerSecond: 100 },
+  }
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(
+    createBridge(
+      {},
+      {},
+      {
+        getSnapshot: async () => availableSnapshot,
+        download: async () => {
+          updateListener(downloadingSnapshot)
+          return downloadingSnapshot
+        },
+        subscribe: (listener) => {
+          updateListener = listener
+          return () => {}
+        },
+      }
+    )
+  )
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  await user.click(view.getByRole('button', { name: 'Updates' }))
+  await user.click(await view.findByRole('button', { name: 'Download update' }))
+
+  const progress = await view.findByRole('progressbar', { name: 'Update download' })
+  assert.equal(progress.getAttribute('aria-valuenow'), '42')
+})
+
+test('keeps a ready update open when an Agent Run blocks restart', async () => {
+  const readySnapshot: ApplicationUpdateSnapshot = {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'self-install',
+    status: 'ready',
+    availableVersion: '2.0.0-beta.2',
+  }
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(
+    createBridge(
+      {},
+      {},
+      {
+        getSnapshot: async () => readySnapshot,
+        restartToUpdate: async () => 'blocked-active-run',
+      }
+    )
+  )
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  await user.click(view.getByRole('button', { name: 'Updates' }))
+  await user.click(await view.findByRole('button', { name: 'Restart to update' }))
+
+  assert.ok(await view.findByText('Wait for every Agent Run to finish, then choose Restart to update again.'))
+  assert.ok(view.getByRole('button', { name: 'Restart to update' }))
+})
+
+test('shows checksum instructions and opens the release for a manual Windows update', async () => {
+  let openCount = 0
+  const availableSnapshot: ApplicationUpdateSnapshot = {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'manual',
+    manualUpdateKind: 'windows',
+    status: 'available',
+    availableVersion: '2.0.0-beta.2',
+    releaseUrl: 'https://github.com/pi-workspace/railyard/releases/tag/v2.0.0-beta.2',
+  }
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(
+    createBridge(
+      {},
+      {},
+      {
+        getSnapshot: async () => availableSnapshot,
+        openRelease: async () => {
+          openCount += 1
+          return true
+        },
+      }
+    )
+  )
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  await user.click(view.getByRole('button', { name: 'Updates' }))
+
+  assert.ok(await view.findByText(/matching \.sha256 file/))
+  await user.click(view.getByRole('button', { name: 'Open GitHub Release' }))
+  assert.equal(openCount, 1)
+})
+
+test('shows an actionable update failure and allows another check', async () => {
+  const errorSnapshot: ApplicationUpdateSnapshot = {
+    currentVersion: '2.0.0-beta.1',
+    updateMethod: 'self-install',
+    status: 'error',
+    error: 'Railyard could not check for updates. Check your connection and try again.',
+  }
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = renderApp(createBridge({}, {}, { getSnapshot: async () => errorSnapshot }))
+
+  await view.findByText('Ship Workspace A')
+  await user.click(view.getByRole('button', { name: 'Settings' }))
+  await user.click(view.getByRole('button', { name: 'Updates' }))
+
+  assert.ok(await view.findByRole('alert'))
+  assert.ok(view.getByRole('button', { name: 'Check for updates' }))
 })
 
 test('closes Settings from its close button', async () => {

--- a/src/renderer/components/application-update-settings.tsx
+++ b/src/renderer/components/application-update-settings.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from 'react'
+import type { ApplicationUpdateSnapshot } from '@/src/application-update'
+import { Button } from '@/components/ui-kit/button'
+
+function updateStatusMessage(snapshot: ApplicationUpdateSnapshot): string | undefined {
+  if (snapshot.status === 'up-to-date') return 'Railyard is up to date.'
+  if (snapshot.status === 'available' && snapshot.availableVersion)
+    return `Version ${snapshot.availableVersion} is available.`
+  if (snapshot.status === 'ready' && snapshot.availableVersion)
+    return `Version ${snapshot.availableVersion} is ready to install.`
+
+  return undefined
+}
+
+export function ApplicationUpdateSettings() {
+  const [snapshot, setSnapshot] = useState<ApplicationUpdateSnapshot>()
+  const [commandPending, setCommandPending] = useState(false)
+  const [commandError, setCommandError] = useState<string>()
+
+  useEffect(() => {
+    const unsubscribe = window.piWorkspace.applicationUpdate.subscribe(setSnapshot)
+
+    void window.piWorkspace.applicationUpdate.getSnapshot().then(setSnapshot, () => {
+      setCommandError('Railyard could not load update information. Close Settings and try again.')
+    })
+
+    return unsubscribe
+  }, [])
+
+  const runSnapshotCommand = async (command: () => Promise<ApplicationUpdateSnapshot>) => {
+    setCommandPending(true)
+    setCommandError(undefined)
+
+    try {
+      setSnapshot(await command())
+    } catch {
+      setCommandError('Railyard could not complete the update action. Check your connection and try again.')
+    } finally {
+      setCommandPending(false)
+    }
+  }
+
+  const restartToUpdate = async () => {
+    setCommandPending(true)
+    setCommandError(undefined)
+
+    try {
+      const outcome = await window.piWorkspace.applicationUpdate.restartToUpdate()
+
+      if (outcome === 'blocked-active-run') {
+        setCommandError('Wait for every Agent Run to finish, then choose Restart to update again.')
+      } else if (outcome === 'not-ready') {
+        setCommandError('The update is no longer ready. Check for updates again.')
+      }
+    } catch {
+      setCommandError('Railyard could not restart to install the update. Try again.')
+    } finally {
+      setCommandPending(false)
+    }
+  }
+
+  const openRelease = async () => {
+    setCommandPending(true)
+    setCommandError(undefined)
+
+    try {
+      if (!(await window.piWorkspace.applicationUpdate.openRelease())) {
+        setCommandError('Railyard could not open the GitHub Release. Open GitHub Releases in your browser instead.')
+      }
+    } catch {
+      setCommandError('Railyard could not open the GitHub Release. Open GitHub Releases in your browser instead.')
+    } finally {
+      setCommandPending(false)
+    }
+  }
+
+  const statusMessage = snapshot && updateStatusMessage(snapshot)
+  const disabled =
+    commandPending ||
+    !snapshot ||
+    snapshot.status === 'unavailable' ||
+    snapshot.status === 'checking' ||
+    snapshot.status === 'downloading'
+  let actionLabel = 'Check for updates'
+  let action = () => runSnapshotCommand(() => window.piWorkspace.applicationUpdate.check())
+
+  if (snapshot?.status === 'checking') actionLabel = 'Checking…'
+  if (snapshot?.status === 'available' && snapshot.updateMethod === 'self-install') {
+    actionLabel = 'Download update'
+    action = () => runSnapshotCommand(() => window.piWorkspace.applicationUpdate.download())
+  }
+  if (snapshot?.status === 'available' && snapshot.updateMethod === 'manual') {
+    actionLabel = 'Open GitHub Release'
+    action = openRelease
+  }
+  if (snapshot?.status === 'downloading') actionLabel = 'Downloading…'
+  if (snapshot?.status === 'ready') {
+    actionLabel = 'Restart to update'
+    action = restartToUpdate
+  }
+
+  const progress = snapshot?.progress
+  const progressPercent = progress ? Math.max(0, Math.min(100, progress.percent)) : undefined
+
+  return (
+    <section aria-labelledby="installed-version-heading" className="max-w-xl">
+      <div className="rounded-lg border border-content-border bg-content-subtle-background px-5 py-4">
+        <h3 id="installed-version-heading" className="text-sm/6 font-medium text-content-foreground">
+          Installed version
+        </h3>
+        <p className="mt-1 font-mono text-sm/6 text-content-muted-foreground">
+          {snapshot?.currentVersion ?? 'Loading…'}
+        </p>
+      </div>
+
+      {statusMessage && (
+        <p className="mt-5 text-sm/6 text-content-foreground" role="status">
+          {statusMessage}
+        </p>
+      )}
+      {snapshot?.status === 'error' && snapshot.error && (
+        <p className="mt-5 text-sm/6 text-form-error-foreground" role="alert">
+          {snapshot.error}
+        </p>
+      )}
+      {snapshot?.status === 'available' && snapshot.updateMethod === 'manual' && (
+        <div className="mt-5 rounded-lg border border-content-border px-5 py-4 text-sm/6 text-content-muted-foreground">
+          {snapshot.manualUpdateKind === 'windows' && (
+            <p>
+              Download the Windows installer and matching .sha256 file. Verify the checksum with the PowerShell steps,
+              then run the installer yourself.
+            </p>
+          )}
+          {snapshot.manualUpdateKind === 'debian' && (
+            <p>
+              Download the Debian package and matching .sha256 file. Run{' '}
+              <code className="font-mono text-content-foreground">sha256sum --check</code>, then install the verified
+              package with <code className="font-mono text-content-foreground">apt</code>.
+            </p>
+          )}
+          {snapshot.manualUpdateKind === 'unsupported' && (
+            <p>This platform cannot install updates in Railyard. Download and verify a supported package manually.</p>
+          )}
+        </div>
+      )}
+      {progressPercent !== undefined && (
+        <div className="mt-5">
+          <div className="mb-2 flex justify-between text-xs/5 text-content-muted-foreground">
+            <span>Downloading update</span>
+            <span>{Math.round(progressPercent)}%</span>
+          </div>
+          <div
+            aria-label="Update download"
+            aria-valuemax={100}
+            aria-valuemin={0}
+            aria-valuenow={Math.round(progressPercent)}
+            className="h-2 overflow-hidden rounded-full bg-content-interaction"
+            role="progressbar"
+          >
+            <div className="h-full rounded-full bg-accent" style={{ width: `${progressPercent}%` }} />
+          </div>
+        </div>
+      )}
+      {commandError && (
+        <p className="mt-5 text-sm/6 text-form-error-foreground" role="alert">
+          {commandError}
+        </p>
+      )}
+
+      <Button className="mt-6" disabled={disabled} onClick={() => void action()}>
+        {actionLabel}
+      </Button>
+      {snapshot?.status === 'unavailable' && (
+        <p className="mt-3 text-sm/6 text-content-muted-foreground">
+          Update checks are unavailable in development builds.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/renderer/components/application-update-settings.tsx
+++ b/src/renderer/components/application-update-settings.tsx
@@ -127,8 +127,9 @@ export function ApplicationUpdateSettings() {
         <div className="mt-5 rounded-lg border border-content-border px-5 py-4 text-sm/6 text-content-muted-foreground">
           {snapshot.manualUpdateKind === 'windows' && (
             <p>
-              Download the Windows installer and matching .sha256 file. Verify the checksum with the PowerShell steps,
-              then run the installer yourself.
+              Download the Windows installer and matching .sha256 file. In PowerShell, compare{' '}
+              <code className="font-mono text-content-foreground">Get-FileHash -Algorithm SHA256</code> for the
+              installer with the first value in the checksum file, then run the installer yourself.
             </p>
           )}
           {snapshot.manualUpdateKind === 'debian' && (

--- a/src/renderer/components/settings-dialog.tsx
+++ b/src/renderer/components/settings-dialog.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
-import { Palette, X } from 'lucide-react'
+import { Palette, RefreshCw, X } from 'lucide-react'
 import { Button } from '@/components/ui-kit/button'
 import { Dialog, DialogBody, DialogDescription, DialogTitle } from '@/components/ui-kit/dialog'
 import { Description, Field, Fieldset, Label } from '@/components/ui-kit/fieldset'
 import { Radio, RadioField, RadioGroup } from '@/components/ui-kit/radio'
 import { getTheme, isThemeId, themes, type AppearancePreference } from '@/src/theme'
+import { ApplicationUpdateSettings } from '@/src/renderer/components/application-update-settings'
 import { useTheme } from '@/src/renderer/theme'
 
 type SettingsDialogProperties = Readonly<{
@@ -12,7 +13,7 @@ type SettingsDialogProperties = Readonly<{
   onClose(): void
 }>
 
-type SettingsSection = 'appearance'
+type SettingsSection = 'appearance' | 'updates'
 
 export function SettingsDialog({ open, onClose }: SettingsDialogProperties) {
   const [section, setSection] = useState<SettingsSection>('appearance')
@@ -27,23 +28,38 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProperties) {
           <div className="px-3 py-2">
             <DialogTitle>Settings</DialogTitle>
           </div>
-          <nav aria-label="Settings sections" className="mt-4">
+          <nav aria-label="Settings sections" className="mt-4 space-y-1">
             <button
               type="button"
               aria-current={section === 'appearance' ? 'page' : undefined}
-              className="flex w-full items-center gap-2 rounded-md bg-content-interaction px-3 py-2 text-left text-sm/5 font-medium text-content-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
+              className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm/5 font-medium text-content-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring ${section === 'appearance' ? 'bg-content-interaction' : 'hover:bg-content-interaction'}`}
               onClick={() => setSection('appearance')}
             >
               <Palette aria-hidden="true" className="size-4" />
               Appearance
+            </button>
+            <button
+              type="button"
+              aria-current={section === 'updates' ? 'page' : undefined}
+              className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm/5 font-medium text-content-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring ${section === 'updates' ? 'bg-content-interaction' : 'hover:bg-content-interaction'}`}
+              onClick={() => setSection('updates')}
+            >
+              <RefreshCw aria-hidden="true" className="size-4" />
+              Updates
             </button>
           </nav>
         </aside>
         <div className="flex min-w-0 flex-col">
           <header className="flex items-start justify-between gap-6 border-b border-content-border px-8 py-6">
             <div>
-              <h2 className="text-xl/7 font-semibold tracking-tight text-content-foreground">Appearance</h2>
-              <DialogDescription className="mt-1">Choose how Railyard looks on this device.</DialogDescription>
+              <h2 className="text-xl/7 font-semibold tracking-tight text-content-foreground">
+                {section === 'appearance' ? 'Appearance' : 'Updates'}
+              </h2>
+              <DialogDescription className="mt-1">
+                {section === 'appearance'
+                  ? 'Choose how Railyard looks on this device.'
+                  : 'Check for a newer Railyard release and choose when to install it.'}
+              </DialogDescription>
             </div>
             <Button plain aria-label="Close settings" className="-mt-2 -mr-2 shrink-0 px-3! py-2!" onClick={onClose}>
               <X aria-hidden="true" data-slot="icon" />
@@ -112,6 +128,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProperties) {
                 </Field>
               </Fieldset>
             )}
+            {section === 'updates' && <ApplicationUpdateSettings />}
           </DialogBody>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds a secure, user-initiated update flow in Settings. Packaged macOS builds can discover, download, and explicitly install a newer signed and notarized release; Windows and Debian remain manual with checksum guidance and never execute unsigned packages automatically.

Closes #47

## Approach

- Add a main-process update state machine with newer-semver enforcement, no downgrade, packaged-build gating, progress/errors, and Agent Run restart protection.
- Expose renderer-safe snapshots and validated argument-free commands through narrow preload IPC.
- Add Settings → Updates for installed version, checks, macOS download/progress/ready actions, actionable failures, and platform-specific manual instructions.
- Publish a universal macOS ZIP and `beta-mac.yml`, verify its SHA-512 metadata and signed/notarized application, and attest every updater payload and metadata asset.
- Correct repository URLs and document the one-time bootstrap install, GitHub connectivity, platform behavior, privacy, and release response.

## Commits

- `d00e5e6` — secure application update authority and IPC
- `28ad4fe` — Settings update controls and renderer interactions
- `dd3b0f9` — authenticated macOS update packaging and documentation
- `2af6955` — updater metadata digest verification
- `a623782` — selectable update states in the browser demo

## Validation

- [x] `bun run check` — 654 tests passed; formatting, lint, typecheck, and build passed
- [x] Demo production build and selectable `?update=` previews
- [x] `bun run release:validate`
- [x] `bun run security:scan` — no issues found; two documented Electron Builder findings remained filtered by repository policy
- [x] `bun run package:linux`
- [x] Packaged ASAR contains `electron-updater`
- [x] Packaged updater configuration targets `pi-workspace/railyard`
- [x] Manual Linux packaging emits no automatic-update metadata
- [x] Focused updater state, source, IPC, renderer interaction, and release-configuration tests
- [ ] Signed/notarized macOS ZIP installation is verified by the release workflow on its macOS runner; it cannot be reproduced on this Linux host

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, privacy, and release documentation is updated.
- [x] New dependency and license inventory changes are disclosed (`electron-updater`, MIT).
- [x] I have read and will follow the Code of Conduct.
