### PR TITLE
fix: align composer controls and correct file tagging

### DIFF
--- a/src/renderer/components/composer-editor.tsx
+++ b/src/renderer/components/composer-editor.tsx
@@ -177,6 +177,12 @@ function getDOMPlainText(node: Node): string {
     : childText
 }
 
+function removeUnmanagedComposerText(rootElement: HTMLElement): void {
+  for (const child of Array.from(rootElement.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) child.remove()
+  }
+}
+
 function getDOMComposerDraft(node: Node): string {
   if (node instanceof HTMLElement && node.hasAttribute('data-skill-reference')) {
     return `/skill:${node.getAttribute('data-skill-reference') ?? ''}`
@@ -1168,6 +1174,9 @@ function FileAutocomplete({
             const markerText = markerElement?.firstChild
             if (!rootElement || !markerText) return
 
+            // Replacing a live at-sign query with a DecoratorNode can leave the
+            // browser's raw query text beside Lexical's managed paragraph.
+            removeUnmanagedComposerText(rootElement)
             rootElement.focus()
             const range = document.createRange()
             range.setStart(markerText, markerText.textContent?.length ?? 0)

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -257,6 +257,27 @@ test('selects a whitespace path from at-sign autocomplete and sends its canonica
   )
 })
 
+test('inserts a file tag by clicking a result after one at-sign', async () => {
+  const user = createUser()
+  const view = renderInBrowser(
+    <FileComposer
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+      sessionFiles={{
+        async getAvailable() {
+          return [{ path: 'README.md', name: 'README.md', kind: 'file' }]
+        },
+      }}
+    />
+  )
+  const editor = view.getByRole('textbox')
+
+  await user.click(editor)
+  await user.keyboard('@')
+  await user.click(await view.findByRole('option', { name: /README\.md/ }))
+
+  assert.equal(composerText(editor), '@README.md')
+})
+
 test('closes file autocomplete after selecting a file', async () => {
   const user = createUser()
   const view = renderInBrowser(

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -340,7 +340,7 @@ export function Composer({
               onEffortChange={changeEffort}
             />
           )}
-          <div className="ml-auto flex items-end gap-1">
+          <div className="ml-auto flex items-center gap-1">
             {contextUsage && <ContextWindowUsage usage={contextUsage} />}
             {contextUsage?.canCompact && !isWorking && !isCompacting && (
               <Button
@@ -362,7 +362,7 @@ export function Composer({
               <button
                 type="button"
                 aria-label="Stop run"
-                className="flex size-11 items-end justify-center rounded-lg text-composer-error-foreground outline-none transition-opacity motion-reduce:transition-none enabled:cursor-pointer focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-composer-background disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex size-11 items-center justify-center rounded-lg text-composer-error-foreground outline-none transition-opacity motion-reduce:transition-none enabled:cursor-pointer focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-composer-background disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={stopping}
                 onClick={(event) => {
                   event.stopPropagation()
@@ -454,7 +454,7 @@ function ContextWindowUsage({ usage }: ContextWindowUsageProperties) {
   const valueText = `${used} used of ${contextWindow} tokens; ${formatTokenCount(remaining)} left`
 
   return (
-    <div className="flex h-11 items-end pb-3">
+    <div className="flex h-11 items-center">
       <span
         aria-label="Context window"
         aria-valuemax={100}


### PR DESCRIPTION
## Summary
- vertically align the stop and context controls with the send action
- remove unmanaged at-sign text left after selecting a file reference
- cover single-`@` file selection with a regression test

## Validation
- `bun run check`
- `bun run security:scan`