### PR TITLE
feat: add Quick Session branch switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Then:
 1. Open Railyard and create a Workspace.
 2. Select one or more local Git Repositories that belong together.
 3. Start a Quick Session for a focused task, or create a Workstream for a durable goal.
-4. Choose an available Model in Composer, review the Repository working location, then send your first message.
+4. Choose an available Model in Composer, review the Repository working location, optionally switch a Quick Session to a local or remote branch, then send your first message.
 
 ### Troubleshooting setup
 
@@ -119,7 +119,9 @@ Then:
 
 ## Repository context
 
-A Quick Session works with one selected Repository. A Workstream selects one or more Repositories and adds their names, locations, roles, relationships, validation commands, and related metadata to every Session's system prompt. Workstream Sessions use current checkouts by default; you can explicitly create a separate Session worktree for an individual Repository.
+A Quick Session works with one selected Repository. Its working-context control beneath Composer can switch to a local branch or lazily fetch known remotes and create a local tracking branch. Switching a shared current checkout requires confirmation, a clean working tree, and idle affected Sessions; a dedicated Quick Session worktree switches in isolation.
+
+A Workstream selects one or more Repositories and adds their names, locations, roles, relationships, validation commands, and related metadata to every Session's system prompt. Workstream Sessions use current checkouts by default; you can explicitly create a separate Session worktree for an individual Repository.
 
 A Workspace and Workstream are routing boundaries, not operating-system sandboxes. Pi, installed extensions, and commands run with your normal user permissions.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -93,6 +93,11 @@ The model provider receives this data under the provider account and the provide
 and regional-processing terms. Railyard cannot delete provider-side copies. Review those terms and do not submit a
 secret unless the chosen provider and account are approved to receive it.
 
+Opening a Quick Session’s branch picker loads local and already-known remote refs immediately, then lazily asks Git to
+fetch each configured remote once per Repository during the application session. A manual refresh fetches them again. These fetches contact the Git
+remote using the user’s existing Git and SSH configuration; they do not use model-provider credentials. Failed
+credential or network checks remain non-interactive and leave cached branch choices available.
+
 Railyard does not automatically publish Sessions and does not expose Pi's `/share` command. Sharing a Session with
 a separate tool is an explicit user action. Installed Pi extensions and packages can make their own network requests,
 so review their source and configuration before use.
@@ -112,7 +117,8 @@ package, and do not ask the Agent to print credential files or environment varia
 A Workspace or Workstream is an application routing boundary, not an operating-system sandbox:
 
 - A **Quick Session** works directly in its selected Repository's current checkout or dedicated worktree with Pi's
-  normal tools.
+  normal tools. Its branch control can switch a clean, idle working location to a local branch or a local tracking
+  branch created from a selected remote ref.
 - A **Workstream Session** receives the Workstream goal plus the selected Repositories' names, working locations,
   roles, relationships, validation commands, and related metadata in its system prompt. It can inspect and modify
   those Repository checkouts with Pi's normal tools.

--- a/src/demo/demo-bridge.ts
+++ b/src/demo/demo-bridge.ts
@@ -128,6 +128,7 @@ export function createDemoBridge(scenarioName?: string, applicationUpdateStateNa
   const settingsListeners = new Set<Parameters<PiWorkspaceBridge['settings']['subscribe']>[0]>()
   const codeReviewDrafts = new Map<string, SessionCodeReviewDraft>()
   const demoSessionWorktrees = new Set<string>()
+  const demoSessionBranches = new Map<string, string>()
   const demoFileStaging = new Map<string, 'staged' | 'unstaged' | 'partial'>([
     ['src/notes/note-store.ts', 'partial'],
     ['src/notes/sync-queue.ts', 'unstaged'],
@@ -155,7 +156,12 @@ export function createDemoBridge(scenarioName?: string, applicationUpdateStateNa
       candidate.sessions.some((session) => session.id === requestedSessionId)
     )
     const session = workstream?.sessions.find((candidate) => candidate.id === requestedSessionId)
-    if (!workstream || !session || session.repositoryAccess.kind === 'direct') return []
+    if (!workstream || !session) return []
+    if (session.repositoryAccess.kind === 'direct') {
+      const repositoryId = session.repositoryAccess.repositoryId
+
+      return demoRepositories.filter((repository) => repository.id === repositoryId)
+    }
 
     const selectedRepositoryIds = workstream.repositoryWorkingLocations.map((location) => location.repositoryId)
 
@@ -417,7 +423,9 @@ export function createDemoBridge(scenarioName?: string, applicationUpdateStateNa
               repositoryName: repository.name,
               kind: usesWorktree ? ('worktree' as const) : ('current-checkout' as const),
               availability: 'available' as const,
-              branch: usesWorktree ? `railyard/demo/${repository.id}` : 'main',
+              branch:
+                demoSessionBranches.get(`${sessionId}:${repository.id}`) ??
+                (usesWorktree ? `railyard/demo/${repository.id}` : 'main'),
               workingPath: usesWorktree
                 ? `/Users/maya/Projects/.worktrees/${sessionId}/${repository.id}`
                 : repository.directoryPath,
@@ -425,9 +433,47 @@ export function createDemoBridge(scenarioName?: string, applicationUpdateStateNa
           }),
         }
       },
+      async getBranches(sessionId, repositoryId) {
+        const current = demoSessionBranches.get(`${sessionId}:${repositoryId}`) ?? 'main'
+
+        return {
+          sessionId,
+          repositoryId,
+          branches: [
+            { ref: 'refs/heads/main', name: 'main', kind: 'local' as const, current: current === 'main' },
+            {
+              ref: 'refs/heads/feature/order-events',
+              name: 'feature/order-events',
+              kind: 'local' as const,
+              current: current === 'feature/order-events',
+            },
+            {
+              ref: 'refs/remotes/origin/feature/order-search',
+              name: 'origin/feature/order-search',
+              kind: 'remote' as const,
+              current: false,
+            },
+          ],
+        }
+      },
+      async switchBranch(sessionId, repositoryId, branchRef) {
+        const branch = (await this.getBranches(sessionId, repositoryId)).branches.find(
+          (candidate) => candidate.ref === branchRef
+        )
+        if (!branch) throw new Error('That branch is no longer available.')
+
+        demoSessionBranches.set(
+          `${sessionId}:${repositoryId}`,
+          branch.kind === 'remote' ? branch.name.slice(branch.name.indexOf('/') + 1) : branch.name
+        )
+        return this.get(sessionId)
+      },
       async createWorktree(sessionId, repositoryId) {
         demoSessionWorktrees.add(`${sessionId}:${repositoryId}`)
         return this.get(sessionId)
+      },
+      subscribe() {
+        return () => {}
       },
     },
     sessionConfiguration: {

--- a/src/demo/demo-renderer.test.tsx
+++ b/src/demo/demo-renderer.test.tsx
@@ -55,6 +55,16 @@ test('the demo bridge projects only a Workstream’s selected Repository locatio
   )
 })
 
+test('the demo bridge projects a Quick Session’s direct Repository location', async () => {
+  const bridge = createDemoBridge('quick-sessions')
+  const locations = await bridge.sessionWorkingLocations.get(sessionId('atlas-api-checkout'))
+
+  assert.deepEqual(
+    locations.repositories.map((repository) => repository.repositoryId),
+    ['Atlas API']
+  )
+})
+
 test('the multi-Session demo includes empty, half-full, and full context windows', () => {
   const scenario = getDemoScenario('multi-session')
   const usages = scenario.workstreams.workstreams

--- a/src/main/application-state/application-state-store.ts
+++ b/src/main/application-state/application-state-store.ts
@@ -300,14 +300,14 @@ export async function initializeApplicationStateStore(storageDirectory: string, 
       database.exec('BEGIN IMMEDIATE;')
       const leases = database
         .prepare(
-          "SELECT lease_id FROM session_run_leases WHERE purpose IN ('agent-run', 'context-compaction', 'session-fork', 'worktree-creation')"
+          "SELECT lease_id FROM session_run_leases WHERE purpose IN ('agent-run', 'branch-switch', 'context-compaction', 'session-fork', 'worktree-creation')"
         )
         .all()
 
       if (leases.length > 0) {
         database
           .prepare(
-            "DELETE FROM session_run_leases WHERE purpose IN ('agent-run', 'context-compaction', 'session-fork', 'worktree-creation')"
+            "DELETE FROM session_run_leases WHERE purpose IN ('agent-run', 'branch-switch', 'context-compaction', 'session-fork', 'worktree-creation')"
           )
           .run()
         incrementRevision(database)

--- a/src/main/application-state/index.ts
+++ b/src/main/application-state/index.ts
@@ -17,14 +17,20 @@ import type {
 } from '@/src/domain/workstream'
 import {
   createWorktree as createGitWorktree,
+  fetchGitBranches,
   inspectGitBranch,
   inspectGitRepository,
+  listGitBranches,
   restoreWorktree as restoreGitWorktree,
+  switchGitBranch,
   type InspectedGitRepository,
   type WorktreeProposal,
 } from '@/src/main/git-repositories'
 import { createPiSessionFileStore, type PiSessionFileStore } from '@/src/main/pi-session-files'
-import type { SessionWorkingLocationsSnapshot } from '@/src/session-working-locations'
+import type {
+  SessionRepositoryBranchesSnapshot,
+  SessionWorkingLocationsSnapshot,
+} from '@/src/session-working-locations'
 import type { SqliteModule } from './sqlite'
 import { createRunLeaseStore } from './run-lease-store'
 import { createSessionFileReconciliation } from './session-file-reconciliation'
@@ -88,6 +94,16 @@ export type ApplicationAuthority = Readonly<{
   renameWorkstreamSession(sessionId: SessionId, title: string): Promise<WorkstreamsSnapshot>
   setSessionDescription(sessionId: SessionId, description: string): Promise<WorkstreamsSnapshot>
   resolveOwnedSession(sessionId: SessionId): Promise<OwnedSessionResolution | undefined>
+  getSessionBranches(
+    sessionId: SessionId,
+    repositoryId: string,
+    refresh: boolean
+  ): Promise<SessionRepositoryBranchesSnapshot>
+  switchQuickSessionBranch(
+    sessionId: SessionId,
+    repositoryId: string,
+    branchRef: string
+  ): Promise<SessionWorkingLocationsSnapshot>
   getSessionWorkingLocations(sessionId: SessionId): Promise<SessionWorkingLocationsSnapshot>
   resolveSessionChangeRepositories(sessionId: SessionId): Promise<readonly SessionChangeRepositoryLocation[]>
   resolveWorkstreamWorkingLocation(workstreamId: string, repositoryId: string): Promise<string>
@@ -151,6 +167,8 @@ export async function initializeApplicationAuthority(
     settleSessionCompactionLease,
     acquireSessionWorktreeLease,
     settleSessionWorktreeLease,
+    acquireSessionBranchSwitchLease,
+    settleSessionBranchSwitchLease,
   } = runLeaseStore
   const {
     getWorkstreamKnowledge,
@@ -163,6 +181,9 @@ export async function initializeApplicationAuthority(
     openDatabase,
     inspectRepository,
     inspectBranch,
+    listBranches: listGitBranches,
+    fetchBranches: fetchGitBranches,
+    switchBranch: switchGitBranch,
     createWorktree,
     restoreWorktree: restoreGitWorktree,
     sessionFiles,
@@ -185,6 +206,8 @@ export async function initializeApplicationAuthority(
     renameWorkstreamSession,
     setSessionDescription,
     resolveOwnedSession,
+    getSessionBranches,
+    switchQuickSessionBranch: switchPersistedQuickSessionBranch,
     getSessionWorkingLocations,
     resolveSessionChangeRepositories,
     resolveWorkstreamWorkingLocation,
@@ -200,6 +223,18 @@ export async function initializeApplicationAuthority(
       return await createPersistedSessionWorktree(sessionId, repositoryId)
     } finally {
       await settleSessionWorktreeLease(sessionId)
+    }
+  }
+
+  const switchQuickSessionBranch = async (sessionId: SessionId, repositoryId: string, branchRef: string) => {
+    if (!(await acquireSessionBranchSwitchLease(sessionId))) {
+      throw new TypeError('Wait for every Session using the checkout to become idle before switching branches.')
+    }
+
+    try {
+      return await switchPersistedQuickSessionBranch(sessionId, repositoryId, branchRef)
+    } finally {
+      await settleSessionBranchSwitchLease(sessionId)
     }
   }
 
@@ -228,6 +263,8 @@ export async function initializeApplicationAuthority(
     renameWorkstreamSession,
     setSessionDescription,
     resolveOwnedSession,
+    getSessionBranches,
+    switchQuickSessionBranch,
     getSessionWorkingLocations,
     resolveSessionChangeRepositories,
     resolveWorkstreamWorkingLocation,

--- a/src/main/application-state/run-lease-store.ts
+++ b/src/main/application-state/run-lease-store.ts
@@ -6,7 +6,7 @@ type RunLeaseStoreOptions = Readonly<{
   openDatabase: () => SqliteDatabase
 }>
 
-type SessionLeasePurpose = 'agent-run' | 'context-compaction' | 'worktree-creation'
+type SessionLeasePurpose = 'agent-run' | 'branch-switch' | 'context-compaction' | 'worktree-creation'
 
 export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
   async function acquireSessionLease(sessionId: SessionId, purpose: SessionLeasePurpose): Promise<boolean> {
@@ -32,7 +32,7 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
         return false
       }
       if (
-        purpose === 'agent-run' &&
+        (purpose === 'agent-run' || purpose === 'branch-switch') &&
         database
           .prepare(
             `WITH effective_locations AS (
@@ -62,7 +62,7 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
                FROM session_run_leases held
                JOIN effective_locations held_location ON held_location.session_id = held.session_id
                JOIN effective_locations requested_location ON requested_location.session_id = ?
-              WHERE held.purpose = 'agent-run'
+              WHERE held.purpose IN ('agent-run', 'branch-switch')
                 AND held.session_id <> ?
                 AND held_location.working_path = requested_location.working_path
               LIMIT 1`
@@ -116,5 +116,7 @@ export function createRunLeaseStore({ openDatabase }: RunLeaseStoreOptions) {
     settleSessionCompactionLease: (sessionId: SessionId) => settleSessionLease(sessionId, 'context-compaction'),
     acquireSessionWorktreeLease: (sessionId: SessionId) => acquireSessionLease(sessionId, 'worktree-creation'),
     settleSessionWorktreeLease: (sessionId: SessionId) => settleSessionLease(sessionId, 'worktree-creation'),
+    acquireSessionBranchSwitchLease: (sessionId: SessionId) => acquireSessionLease(sessionId, 'branch-switch'),
+    settleSessionBranchSwitchLease: (sessionId: SessionId) => settleSessionLease(sessionId, 'branch-switch'),
   }
 }

--- a/src/main/application-state/workstream-session-store.ts
+++ b/src/main/application-state/workstream-session-store.ts
@@ -19,6 +19,7 @@ import {
 import {
   inspectWorktree,
   proposeWorktree,
+  type GitBranchReference,
   type InspectedGitRepository,
   type WorktreeProposal,
 } from '@/src/main/git-repositories'
@@ -26,7 +27,10 @@ import { restorePiUserMessageDraft } from '@/src/main/pi-session-message-mapping
 import { normalizeSessionDescription } from '@/src/session-description'
 import { normalizeSessionTitle } from '@/src/session-title'
 import type { OwnedPiSessionLocation, PiSessionCreationIntent, PiSessionFileStore } from '@/src/main/pi-session-files'
-import type { SessionWorkingLocationsSnapshot } from '@/src/session-working-locations'
+import type {
+  SessionRepositoryBranchesSnapshot,
+  SessionWorkingLocationsSnapshot,
+} from '@/src/session-working-locations'
 import type { SqliteDatabase } from './sqlite'
 import { initializeStoredWorkstreamKnowledge, readCurrentWorkstreamRepositorySet } from './workstream-knowledge-store'
 import {
@@ -38,12 +42,17 @@ import {
 
 type RepositoryInspector = (directoryPath: string) => Promise<InspectedGitRepository>
 type BranchInspector = (directoryPath: string) => Promise<string>
+type BranchLister = (directoryPath: string) => Promise<readonly GitBranchReference[]>
+type BranchSwitcher = (directoryPath: string, branch: GitBranchReference) => Promise<string>
 type SessionCreationStatus = 'available' | 'pending' | 'quarantined'
 
 type WorkstreamSessionStoreOptions = Readonly<{
   openDatabase: () => SqliteDatabase
   inspectRepository: RepositoryInspector
   inspectBranch: BranchInspector
+  listBranches: BranchLister
+  fetchBranches: BranchLister
+  switchBranch: BranchSwitcher
   createWorktree: (proposal: WorktreeProposal) => Promise<WorktreeProposal>
   restoreWorktree: (proposal: WorktreeProposal) => Promise<WorktreeProposal>
   sessionFiles: PiSessionFileStore
@@ -93,6 +102,9 @@ export function createWorkstreamSessionStore({
   openDatabase,
   inspectRepository,
   inspectBranch,
+  listBranches,
+  fetchBranches,
+  switchBranch,
   createWorktree,
   restoreWorktree,
   sessionFiles,
@@ -1576,10 +1588,149 @@ export function createWorkstreamSessionStore({
     }
   }
 
+  function resolveQuickSessionBranchLocation(sessionId: SessionId, repositoryId: string) {
+    const database = openDatabase()
+
+    try {
+      const location = database
+        .prepare(
+          `SELECT session.workstream_id, location.kind, location.working_path
+             FROM sessions session
+             JOIN workstreams workstream ON workstream.id = session.workstream_id
+             JOIN session_repository_locations location
+               ON location.session_id = session.id AND location.repository_id = ?
+            WHERE session.id = ?
+              AND session.repository_id = ?
+              AND session.access_kind = 'direct'
+              AND session.creation_status = 'finalized'
+              AND workstream.lifecycle = 'active'`
+        )
+        .get(repositoryId, sessionId, repositoryId)
+
+      if (!location) throw new TypeError('The Quick Session Repository is unavailable.')
+
+      return {
+        workstreamId: String(location.workstream_id),
+        kind: parseWorkstreamRepositoryLocationKind(location.kind),
+        workingPath: String(location.working_path),
+      }
+    } finally {
+      database.close()
+    }
+  }
+
+  async function getSessionBranches(
+    sessionId: SessionId,
+    repositoryId: string,
+    refresh: boolean
+  ): Promise<SessionRepositoryBranchesSnapshot> {
+    const location = resolveQuickSessionBranchLocation(sessionId, repositoryId)
+    let branches: readonly GitBranchReference[]
+    let refreshError: string | undefined
+
+    if (refresh) {
+      try {
+        branches = await fetchBranches(location.workingPath)
+      } catch {
+        branches = await listBranches(location.workingPath)
+        refreshError = 'Remote branches could not be refreshed. Check network access and Git credentials, then retry.'
+      }
+    } else {
+      branches = await listBranches(location.workingPath)
+    }
+
+    return {
+      sessionId,
+      repositoryId,
+      branches,
+      ...(refreshError ? { refreshError } : {}),
+    }
+  }
+
+  async function switchQuickSessionBranch(
+    sessionId: SessionId,
+    repositoryId: string,
+    branchRef: string
+  ): Promise<SessionWorkingLocationsSnapshot> {
+    const location = resolveQuickSessionBranchLocation(sessionId, repositoryId)
+    const branch = (await listBranches(location.workingPath)).find((candidate) => candidate.ref === branchRef)
+    if (!branch) throw new TypeError('That branch is no longer available in this Repository.')
+
+    const selectedBranch = await switchBranch(location.workingPath, branch)
+    const database = openDatabase()
+
+    try {
+      database.exec('BEGIN IMMEDIATE;')
+      database
+        .prepare('UPDATE session_repository_locations SET branch = ? WHERE session_id = ? AND repository_id = ?')
+        .run(selectedBranch, sessionId, repositoryId)
+      if (location.kind === 'worktree') {
+        database
+          .prepare(
+            'UPDATE workstream_repository_locations SET branch = ? WHERE workstream_id = ? AND repository_id = ?'
+          )
+          .run(selectedBranch, location.workstreamId, repositoryId)
+        incrementSessionWorkingLocationRevision(database, sessionId)
+      }
+      incrementRevision(database)
+      database.exec('COMMIT;')
+    } catch (error) {
+      database.exec('ROLLBACK;')
+      throw error
+    } finally {
+      database.close()
+    }
+
+    return getSessionWorkingLocations(sessionId)
+  }
+
   async function getSessionWorkingLocations(sessionId: SessionId): Promise<SessionWorkingLocationsSnapshot> {
     const resolution = await resolveOwnedSession(sessionId)
     if (!resolution) throw new TypeError('The Session is unavailable.')
-    if (!resolution.managedPolicy) return { sessionId, repositories: [] }
+
+    if (!resolution.managedPolicy) {
+      const database = openDatabase()
+
+      try {
+        const location = database
+          .prepare(
+            `SELECT location.repository_id, location.kind, location.working_path, repository.directory_path
+               FROM sessions session
+               JOIN session_repository_locations location ON location.session_id = session.id
+               JOIN repositories repository ON repository.id = location.repository_id
+              WHERE session.id = ? AND session.access_kind = 'direct'`
+          )
+          .get(sessionId)
+
+        if (!location) return { sessionId, repositories: [] }
+
+        const properties = {
+          repositoryId: String(location.repository_id),
+          repositoryName: repositoryName(String(location.directory_path)),
+          kind: parseWorkstreamRepositoryLocationKind(location.kind),
+        }
+
+        try {
+          const workingPath = String(location.working_path)
+
+          return {
+            sessionId,
+            repositories: [
+              {
+                ...properties,
+                availability: 'available',
+                branch: await inspectBranch(workingPath),
+                workingPath,
+              },
+            ],
+          }
+        } catch {
+          return { sessionId, repositories: [{ ...properties, availability: 'unavailable' }] }
+        }
+      } finally {
+        database.close()
+      }
+    }
 
     const repositories = await Promise.all(
       resolution.managedPolicy.repositories.map(async (repository) => {
@@ -1698,6 +1849,8 @@ export function createWorkstreamSessionStore({
     renameWorkstreamSession,
     setSessionDescription,
     resolveOwnedSession,
+    getSessionBranches,
+    switchQuickSessionBranch,
     getSessionWorkingLocations,
     resolveSessionChangeRepositories,
     resolveWorkstreamWorkingLocation,

--- a/src/main/application-state/workstreams.test.ts
+++ b/src/main/application-state/workstreams.test.ts
@@ -378,6 +378,129 @@ test('reports current checkout, path, and branch context for a Workstream Sessio
   })
 })
 
+test('reports Repository and branch context for a current-checkout Quick Session', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await exec('git', ['-C', repository.directoryPath, 'branch', '-m', 'feature/quick'])
+  const created = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+
+  assert.deepEqual(await authority.getSessionWorkingLocations(created.sessionId), {
+    sessionId: created.sessionId,
+    repositories: [
+      {
+        repositoryId: repository.id,
+        repositoryName: repository.name,
+        kind: 'current-checkout',
+        availability: 'available',
+        branch: 'feature/quick',
+        workingPath: repository.directoryPath,
+      },
+    ],
+  })
+})
+
+test('reports Repository and worktree context for a dedicated-worktree Quick Session', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  const preview = await authority.previewWorktreeLocations(workspace.id, repository.id)
+  const created = await authority.createQuickSession(workspace.id, {
+    repositoryId: repository.id,
+    workingLocation: 'worktrees',
+    workstreamId: preview.workstreamId,
+  })
+
+  const context = await authority.getSessionWorkingLocations(created.sessionId)
+
+  assert.equal(context.repositories[0]?.repositoryName, repository.name)
+  assert.equal(context.repositories[0]?.kind, 'worktree')
+  assert.match(
+    context.repositories[0]?.availability === 'available' ? context.repositories[0].branch : '',
+    /^railyard\//
+  )
+})
+
+test('lists and switches local branches for a current-checkout Quick Session', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  await exec('git', ['-C', repository.directoryPath, 'branch', 'feature/quick-switch'])
+  const created = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+
+  const branches = await authority.getSessionBranches(created.sessionId, repository.id, false)
+  const target = branches.branches.find(({ name }) => name === 'feature/quick-switch')
+  assert.ok(target)
+
+  const locations = await authority.switchQuickSessionBranch(created.sessionId, repository.id, target.ref)
+
+  assert.equal(locations.repositories[0]?.availability, 'available')
+  assert.equal(
+    locations.repositories[0]?.availability === 'available' ? locations.repositories[0].branch : undefined,
+    'feature/quick-switch'
+  )
+})
+
+test('keeps cached branches available when a lazy remote refresh fails', async () => {
+  const { authority, storageDirectory, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  await exec('git', ['-C', repository.directoryPath, 'remote', 'add', 'origin', join(storageDirectory, 'missing.git')])
+  const created = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+
+  const branches = await authority.getSessionBranches(created.sessionId, repository.id, true)
+
+  assert.ok(branches.branches.some(({ current }) => current))
+  assert.equal(
+    branches.refreshError,
+    'Remote branches could not be refreshed. Check network access and Git credentials, then retry.'
+  )
+})
+
+test('persists a dedicated-worktree Quick Session branch switch', async () => {
+  const { authority, storageDirectory, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  await exec('git', ['-C', repository.directoryPath, 'branch', 'feature/worktree-switch'])
+  const preview = await authority.previewWorktreeLocations(workspace.id, repository.id)
+  const created = await authority.createQuickSession(workspace.id, {
+    repositoryId: repository.id,
+    workingLocation: 'worktrees',
+    workstreamId: preview.workstreamId,
+  })
+  const branches = await authority.getSessionBranches(created.sessionId, repository.id, false)
+  const target = branches.branches.find(({ name }) => name === 'feature/worktree-switch')
+  assert.ok(target)
+
+  await authority.switchQuickSessionBranch(created.sessionId, repository.id, target.ref)
+
+  const restarted = await initializeApplicationAuthority(storageDirectory, { sqlite: bunSqlite })
+  const locations = await restarted.getSessionWorkingLocations(created.sessionId)
+  assert.equal(locations.repositories[0]?.kind, 'worktree')
+  assert.equal(
+    locations.repositories[0]?.availability === 'available' ? locations.repositories[0].branch : undefined,
+    'feature/worktree-switch'
+  )
+})
+
+test('blocks a shared-checkout branch switch while another Session is running', async () => {
+  const { authority, workspace } = await createFixture()
+  const repository = workspace.repositories[0]!
+  await commitRepositoryFile(repository.directoryPath, 'tracked.txt', 'committed', 'Initial commit')
+  await exec('git', ['-C', repository.directoryPath, 'branch', 'feature/blocked-switch'])
+  const running = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+  const switching = await authority.createQuickSession(workspace.id, { repositoryId: repository.id })
+  const target = (await authority.getSessionBranches(switching.sessionId, repository.id, false)).branches.find(
+    ({ name }) => name === 'feature/blocked-switch'
+  )
+  assert.ok(target)
+  assert.equal(await authority.acquireSessionRunLease(running.sessionId), true)
+
+  await assert.rejects(
+    authority.switchQuickSessionBranch(switching.sessionId, repository.id, target.ref),
+    /every Session using the checkout to become idle/
+  )
+})
+
 test('prepares the current checkout for a Workstream Session without creating a worktree', async () => {
   const { authority, storageDirectory, workspace } = await createFixture()
   const repository = workspace.repositories[0]!

--- a/src/main/git-repositories.test.ts
+++ b/src/main/git-repositories.test.ts
@@ -7,10 +7,13 @@ import { promisify } from 'node:util'
 import test from 'node:test'
 import {
   createWorktree,
+  fetchGitBranches,
   inspectGitBranch,
   inspectGitRepository,
+  listGitBranches,
   proposeWorktree,
   repositoryRootsOverlap,
+  switchGitBranch,
 } from './git-repositories'
 
 const exec = promisify(execFile)
@@ -36,6 +39,127 @@ test('reads the current branch from a Repository without requiring a commit', as
   await exec('git', ['-C', repositoryPath, 'branch', '-m', 'feature/current'])
 
   assert.equal(await inspectGitBranch(repositoryPath), 'feature/current')
+})
+
+test('lists local and known remote branches without remote symbolic refs', async () => {
+  const repositoryPath = await createRepository()
+  await writeFile(join(repositoryPath, 'tracked.txt'), 'committed')
+  await exec('git', ['-C', repositoryPath, 'add', 'tracked.txt'])
+  await exec('git', [
+    '-C',
+    repositoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    'Initial commit',
+  ])
+  await exec('git', ['-C', repositoryPath, 'branch', 'feature/local'])
+  const currentBranch = await inspectGitBranch(repositoryPath)
+  await exec('git', ['-C', repositoryPath, 'update-ref', 'refs/remotes/origin/feature/remote', 'HEAD'])
+  await exec('git', ['-C', repositoryPath, 'symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/main'])
+
+  const branches = await listGitBranches(repositoryPath)
+
+  assert.deepEqual(
+    branches.map(({ name, kind, current }) => ({ name, kind, current })),
+    [
+      { name: 'feature/local', kind: 'local', current: false },
+      { name: currentBranch, kind: 'local', current: true },
+      { name: 'origin/feature/remote', kind: 'remote', current: false },
+    ]
+  )
+})
+
+test('fetches remote branches only when requested', async () => {
+  const repositoryPath = await createRepository()
+  await writeFile(join(repositoryPath, 'tracked.txt'), 'committed')
+  await exec('git', ['-C', repositoryPath, 'add', 'tracked.txt'])
+  await exec('git', [
+    '-C',
+    repositoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    'Initial commit',
+  ])
+  const remotePath = join(parse(repositoryPath).dir, 'remote.git')
+  await exec('git', ['init', '--bare', remotePath])
+  await exec('git', ['-C', repositoryPath, 'remote', 'add', 'origin', remotePath])
+  await exec('git', ['-C', repositoryPath, 'push', 'origin', 'HEAD:refs/heads/feature/remote'])
+  await exec('git', ['-C', repositoryPath, 'update-ref', '-d', 'refs/remotes/origin/feature/remote'])
+
+  assert.equal(
+    (await listGitBranches(repositoryPath)).some(({ name }) => name === 'origin/feature/remote'),
+    false
+  )
+
+  const branches = await fetchGitBranches(repositoryPath)
+
+  assert.equal(
+    branches.some(({ name }) => name === 'origin/feature/remote'),
+    true
+  )
+})
+
+test('creates a local tracking branch when switching to a remote branch', async () => {
+  const repositoryPath = await createRepository()
+  await writeFile(join(repositoryPath, 'tracked.txt'), 'committed')
+  await exec('git', ['-C', repositoryPath, 'add', 'tracked.txt'])
+  await exec('git', [
+    '-C',
+    repositoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    'Initial commit',
+  ])
+  const remotePath = join(parse(repositoryPath).dir, 'remote.git')
+  await exec('git', ['init', '--bare', remotePath])
+  await exec('git', ['-C', repositoryPath, 'remote', 'add', 'origin', remotePath])
+  await exec('git', ['-C', repositoryPath, 'push', 'origin', 'HEAD:refs/heads/feature/remote'])
+  const remoteBranch = (await listGitBranches(repositoryPath)).find(({ name }) => name === 'origin/feature/remote')
+  assert.ok(remoteBranch)
+
+  assert.equal(await switchGitBranch(repositoryPath, remoteBranch), 'feature/remote')
+  assert.equal((await exec('git', ['-C', repositoryPath, 'branch', '--show-current'])).stdout.trim(), 'feature/remote')
+  assert.equal(
+    (await exec('git', ['-C', repositoryPath, 'rev-parse', '--abbrev-ref', '@{upstream}'])).stdout.trim(),
+    'origin/feature/remote'
+  )
+})
+
+test('refuses to switch branches when the working tree has changes', async () => {
+  const repositoryPath = await createRepository()
+  await writeFile(join(repositoryPath, 'tracked.txt'), 'committed')
+  await exec('git', ['-C', repositoryPath, 'add', 'tracked.txt'])
+  await exec('git', [
+    '-C',
+    repositoryPath,
+    '-c',
+    'user.name=Pi Workspace tests',
+    '-c',
+    'user.email=tests@pi-workspace.invalid',
+    'commit',
+    '-m',
+    'Initial commit',
+  ])
+  await exec('git', ['-C', repositoryPath, 'branch', 'feature/local'])
+  const currentBranch = await inspectGitBranch(repositoryPath)
+  await writeFile(join(repositoryPath, 'tracked.txt'), 'dirty')
+  const localBranch = (await listGitBranches(repositoryPath)).find(({ name }) => name === 'feature/local')
+  assert.ok(localBranch)
+
+  await assert.rejects(() => switchGitBranch(repositoryPath, localBranch), /working tree has changes/i)
+  assert.equal(await inspectGitBranch(repositoryPath), currentBranch)
 })
 
 test('resolves a selected Repository subdirectory to its canonical Git root and common directory', async () => {

--- a/src/main/git-repositories.ts
+++ b/src/main/git-repositories.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util'
 import { worktreeName } from './workstream-id'
 
 const exec = promisify(execFile)
+const branchFetchTimeoutMs = 30_000
 
 export type InspectedGitRepository = Readonly<{
   directoryPath: string
@@ -18,6 +19,13 @@ export type WorktreeProposal = Readonly<{
   worktreePath: string
   branch: string
   baseCommit: string
+}>
+
+export type GitBranchReference = Readonly<{
+  ref: string
+  name: string
+  kind: 'local' | 'remote'
+  current: boolean
 }>
 
 export async function proposeWorktree(options: {
@@ -112,9 +120,89 @@ async function addWorktree(
 }
 
 function worktreeCreationError(proposal: WorktreeProposal, error: unknown): Error {
+  return gitOperationError(error, `Git could not create the worktree at ${proposal.worktreePath}.`)
+}
+
+function gitOperationError(error: unknown, fallback: string): Error {
   const detail = error instanceof Error && 'stderr' in error ? String(error.stderr).trim() : ''
 
-  return new Error(detail || `Git could not create the worktree at ${proposal.worktreePath}.`, { cause: error })
+  return new Error(detail || fallback, { cause: error })
+}
+
+export async function listGitBranches(repositoryPath: string): Promise<readonly GitBranchReference[]> {
+  const { stdout } = await exec('git', [
+    '-C',
+    repositoryPath,
+    'for-each-ref',
+    '--format=%(refname)%09%(refname:short)%09%(HEAD)%09%(symref)',
+    'refs/heads',
+    'refs/remotes',
+  ])
+
+  return stdout
+    .trim()
+    .split(/\r?\n/)
+    .flatMap((line): GitBranchReference[] => {
+      if (!line) return []
+
+      const [ref, name, head, symbolicRef] = line.split('\t')
+      if (!ref || !name || symbolicRef) return []
+
+      const kind = ref.startsWith('refs/heads/') ? 'local' : ref.startsWith('refs/remotes/') ? 'remote' : undefined
+
+      return kind ? [{ ref, name, kind, current: head === '*' }] : []
+    })
+    .sort((left, right) => left.kind.localeCompare(right.kind) || left.name.localeCompare(right.name))
+}
+
+export async function fetchGitBranches(repositoryPath: string): Promise<readonly GitBranchReference[]> {
+  const { stdout } = await exec('git', ['-C', repositoryPath, 'remote'])
+  const remotes = stdout.trim().split(/\r?\n/).filter(Boolean)
+
+  let failed = false
+
+  for (const remote of remotes) {
+    try {
+      await exec('git', ['-C', repositoryPath, 'fetch', '--prune', '--no-tags', remote], {
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+        timeout: branchFetchTimeoutMs,
+      })
+    } catch {
+      failed = true
+    }
+  }
+
+  if (failed) throw new Error('One or more remotes could not be refreshed.')
+
+  return listGitBranches(repositoryPath)
+}
+
+export async function switchGitBranch(repositoryPath: string, branch: GitBranchReference): Promise<string> {
+  const currentBranch = await inspectGitBranch(repositoryPath)
+  if (branch.kind === 'local' && branch.name === currentBranch) return currentBranch
+
+  const { stdout: status } = await exec('git', [
+    '-C',
+    repositoryPath,
+    'status',
+    '--porcelain',
+    '--untracked-files=normal',
+  ])
+  if (status.length > 0)
+    throw new TypeError('The working tree has changes. Commit or stash them before switching branches.')
+
+  const arguments_ =
+    branch.kind === 'local'
+      ? ['-C', repositoryPath, 'switch', branch.name]
+      : ['-C', repositoryPath, 'switch', '--track', branch.name]
+
+  try {
+    await exec('git', arguments_, { env: { ...process.env, GIT_TERMINAL_PROMPT: '0' } })
+  } catch (error) {
+    throw gitOperationError(error, `Git could not switch to ${branch.name}.`)
+  }
+
+  return inspectGitBranch(repositoryPath)
 }
 
 export async function inspectGitBranch(repositoryPath: string): Promise<string> {

--- a/src/main/pi-session-runtime-lifecycle.test.ts
+++ b/src/main/pi-session-runtime-lifecycle.test.ts
@@ -34,6 +34,46 @@ test('passes the Session identity to a newly created runtime', async () => {
   assert.equal(createdSessionId, id)
 })
 
+test('creates one runtime when Session resources load concurrently', async () => {
+  const runtime: PiSessionRuntime = {
+    isStreaming: false,
+    async prompt() {},
+    subscribe() {
+      return () => {}
+    },
+    dispose() {},
+  }
+  let releaseLocation: () => void = () => {}
+  const locationReady = new Promise<void>((resolve) => {
+    releaseLocation = resolve
+  })
+  let createCalls = 0
+  const lifecycle = createSessionRuntimeLifecycle({
+    async findSession() {
+      await locationReady
+
+      return { directoryPath: '/tmp', sessionPath: '/tmp/session.jsonl', runtimeKey: 'default' }
+    },
+    async createSession() {
+      createCalls += 1
+
+      return runtime
+    },
+    attach(_sessionId, _runtimeDirectory, attachedRuntime, runtimeKey) {
+      return { runtime: attachedRuntime, runtimeKey, unsubscribes: [] }
+    },
+  })
+  const id = sessionId('session-1')
+
+  const transcriptRuntime = lifecycle.get(id)
+  const configurationRuntime = lifecycle.get(id)
+  releaseLocation()
+
+  assert.equal(await transcriptRuntime, runtime)
+  assert.equal(await configurationRuntime, runtime)
+  assert.equal(createCalls, 1)
+})
+
 test('returns a registered stable runtime without resolving a Session location', async () => {
   const runtime: PiSessionRuntime = {
     isStreaming: false,

--- a/src/main/pi-session-runtime-lifecycle.ts
+++ b/src/main/pi-session-runtime-lifecycle.ts
@@ -34,6 +34,7 @@ export function createSessionRuntimeLifecycle({
   attach,
 }: SessionRuntimeLifecycleOptions): SessionRuntimeLifecycle {
   const entries = new Map<SessionId, Promise<SessionRuntimeEntry>>()
+  const runtimeRequests = new Map<SessionId, Promise<PiSessionRuntime | undefined>>()
 
   async function retire(sessionId: SessionId, pendingEntry: Promise<SessionRuntimeEntry>): Promise<void> {
     try {
@@ -49,38 +50,50 @@ export function createSessionRuntimeLifecycle({
     }
   }
 
+  async function resolveRuntime(sessionId: SessionId): Promise<PiSessionRuntime | undefined> {
+    const existingEntry = entries.get(sessionId)
+    const existing = existingEntry ? await existingEntry : undefined
+
+    if (existing?.runtime.isStreaming || (existing && existing.runtimeKey === undefined)) return existing.runtime
+
+    const location = await findSession(sessionId)
+    if (!location) return undefined
+    if (existing && existing.runtimeKey === location.runtimeKey) return existing.runtime
+
+    if (existing) {
+      existing.unsubscribes.forEach((unsubscribe) => unsubscribe())
+      existing.runtime.dispose()
+      entries.delete(sessionId)
+    }
+
+    const pendingEntry = createSession(location, sessionId).then((runtime) =>
+      attach(sessionId, location.directoryPath, runtime, location.runtimeKey)
+    )
+    entries.set(sessionId, pendingEntry)
+
+    try {
+      return (await pendingEntry).runtime
+    } catch (error) {
+      entries.delete(sessionId)
+      throw error
+    }
+  }
+
   return {
     register(sessionId, runtimeDirectory, runtime) {
       if (entries.has(sessionId)) throw new Error('The Session runtime is already registered.')
       entries.set(sessionId, Promise.resolve(attach(sessionId, runtimeDirectory, runtime)))
     },
-    async get(sessionId) {
-      const existingEntry = entries.get(sessionId)
-      const existing = existingEntry ? await existingEntry : undefined
+    get(sessionId) {
+      const existingRequest = runtimeRequests.get(sessionId)
+      if (existingRequest) return existingRequest
 
-      if (existing?.runtime.isStreaming || (existing && existing.runtimeKey === undefined)) return existing.runtime
+      const request = resolveRuntime(sessionId).finally(() => {
+        if (runtimeRequests.get(sessionId) === request) runtimeRequests.delete(sessionId)
+      })
+      runtimeRequests.set(sessionId, request)
 
-      const location = await findSession(sessionId)
-      if (!location) return undefined
-      if (existing && existing.runtimeKey === location.runtimeKey) return existing.runtime
-
-      if (existing) {
-        existing.unsubscribes.forEach((unsubscribe) => unsubscribe())
-        existing.runtime.dispose()
-        entries.delete(sessionId)
-      }
-
-      const pendingEntry = createSession(location, sessionId).then((runtime) =>
-        attach(sessionId, location.directoryPath, runtime, location.runtimeKey)
-      )
-      entries.set(sessionId, pendingEntry)
-
-      try {
-        return (await pendingEntry).runtime
-      } catch (error) {
-        entries.delete(sessionId)
-        throw error
-      }
+      return request
     },
     getEntry(sessionId) {
       return entries.get(sessionId)
@@ -99,6 +112,7 @@ export function createSessionRuntimeLifecycle({
           .catch(() => {})
       })
       entries.clear()
+      runtimeRequests.clear()
     },
   }
 }

--- a/src/main/session-working-locations-ipc.ts
+++ b/src/main/session-working-locations-ipc.ts
@@ -1,6 +1,7 @@
 import type { ApplicationAuthority } from '@/src/main/application-state'
-import { handleTrustedIpc } from '@/src/main/trusted-ipc'
+import { broadcastToTrustedRenderers, handleTrustedIpc } from '@/src/main/trusted-ipc'
 import {
+  parseSessionBranchRequest,
   parseSessionWorkingLocationRequest,
   sessionWorkingLocationsIpcChannels,
 } from '@/src/session-working-locations-ipc'
@@ -18,11 +19,33 @@ export function initializeSessionWorkingLocations(authority: ApplicationAuthorit
       : Promise.reject(new TypeError('A Session is required.'))
   })
 
+  handleTrustedIpc(sessionWorkingLocationsIpcChannels.getBranches, (_event, value: unknown) => {
+    const request = parseSessionBranchRequest(value)
+    if (!request || request.branchRef) throw new TypeError('A Quick Session Repository is required.')
+
+    return authority.getSessionBranches(request.sessionId, request.repositoryId, request.refresh ?? false)
+  })
+
+  handleTrustedIpc(sessionWorkingLocationsIpcChannels.switchBranch, async (_event, value: unknown) => {
+    const request = parseSessionBranchRequest(value)
+    if (!request?.branchRef) throw new TypeError('A Quick Session Repository and branch are required.')
+
+    const snapshot = await authority.switchQuickSessionBranch(
+      request.sessionId,
+      request.repositoryId,
+      request.branchRef
+    )
+    broadcastToTrustedRenderers(sessionWorkingLocationsIpcChannels.changed)
+    return snapshot
+  })
+
   handleTrustedIpc(sessionWorkingLocationsIpcChannels.createWorktree, async (_event, value: unknown) => {
     const request = parseSessionWorkingLocationRequest(value)
     if (!request?.repositoryId) throw new TypeError('A Session and Repository are required.')
 
     await authority.createSessionWorktree(request.sessionId, request.repositoryId)
-    return authority.getSessionWorkingLocations(request.sessionId)
+    const snapshot = await authority.getSessionWorkingLocations(request.sessionId)
+    broadcastToTrustedRenderers(sessionWorkingLocationsIpcChannels.changed)
+    return snapshot
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,7 +16,11 @@ import type { SessionSkillsBridge } from '@/src/session-skills'
 import { sessionSkillsIpcChannels } from '@/src/session-skills-ipc'
 import type { SessionChangesBridge, SessionChangesSnapshot, SessionFileDiff } from '@/src/session-changes'
 import { sessionChangesIpcChannels } from '@/src/session-changes-ipc'
-import type { SessionWorkingLocationsBridge, SessionWorkingLocationsSnapshot } from '@/src/session-working-locations'
+import type {
+  SessionRepositoryBranchesSnapshot,
+  SessionWorkingLocationsBridge,
+  SessionWorkingLocationsSnapshot,
+} from '@/src/session-working-locations'
 import { sessionWorkingLocationsIpcChannels } from '@/src/session-working-locations-ipc'
 import type { SessionFilesBridge } from '@/src/session-files'
 import { sessionFilesIpcChannels } from '@/src/session-files-ipc'
@@ -273,11 +277,31 @@ const sessionWorkingLocationsBridge: SessionWorkingLocationsBridge = {
       sessionId,
     }) as Promise<SessionWorkingLocationsSnapshot>
   },
+  getBranches(sessionId, repositoryId, options) {
+    return ipcRenderer.invoke(sessionWorkingLocationsIpcChannels.getBranches, {
+      sessionId,
+      repositoryId,
+      refresh: options?.refresh,
+    }) as Promise<SessionRepositoryBranchesSnapshot>
+  },
+  switchBranch(sessionId, repositoryId, branchRef) {
+    return ipcRenderer.invoke(sessionWorkingLocationsIpcChannels.switchBranch, {
+      sessionId,
+      repositoryId,
+      branchRef,
+    }) as Promise<SessionWorkingLocationsSnapshot>
+  },
   createWorktree(sessionId, repositoryId) {
     return ipcRenderer.invoke(sessionWorkingLocationsIpcChannels.createWorktree, {
       sessionId,
       repositoryId,
     }) as Promise<SessionWorkingLocationsSnapshot>
+  },
+  subscribe(listener) {
+    const handleChange = () => listener()
+    ipcRenderer.on(sessionWorkingLocationsIpcChannels.changed, handleChange)
+
+    return () => ipcRenderer.removeListener(sessionWorkingLocationsIpcChannels.changed, handleChange)
   },
 }
 

--- a/src/renderer/components/composer.test.tsx
+++ b/src/renderer/components/composer.test.tsx
@@ -10,6 +10,7 @@ import type { OwnedSession } from '@/src/domain/workstream'
 import type { SessionConfigurationBridge, SessionConfigurationSnapshot } from '@/src/session-configuration'
 import type { SessionSkillsBridge } from '@/src/session-skills'
 import type { SessionFilesBridge } from '@/src/session-files'
+import type { SessionWorkingLocationsBridge } from '@/src/session-working-locations'
 import { Composer } from './composer'
 import { SessionArea } from './session-area'
 
@@ -906,6 +907,79 @@ test('prevents Session actions while a Model change is pending', async () => {
   await waitFor(() =>
     assert.equal((view.getByRole('button', { name: 'Send message' }) as HTMLButtonElement).disabled, false)
   )
+})
+
+test('prevents Session actions while a branch switch is pending', async () => {
+  let finishSwitch: (snapshot: Awaited<ReturnType<SessionWorkingLocationsBridge['get']>>) => void = () => {}
+  const currentLocations = {
+    sessionId: session.id,
+    repositories: [
+      {
+        repositoryId: 'repository-a',
+        repositoryName: 'Repository A',
+        kind: 'current-checkout' as const,
+        availability: 'available' as const,
+        branch: 'main',
+        workingPath: '/workspace/repository-a',
+      },
+    ],
+  }
+  const bridge: SessionWorkingLocationsBridge = {
+    async get() {
+      return currentLocations
+    },
+    async getBranches(sessionId, repositoryId) {
+      return {
+        sessionId,
+        repositoryId,
+        branches: [
+          { ref: 'refs/heads/main', name: 'main', kind: 'local', current: true },
+          { ref: 'refs/heads/feature/local', name: 'feature/local', kind: 'local', current: false },
+        ],
+      }
+    },
+    switchBranch() {
+      return new Promise((resolve) => {
+        finishSwitch = resolve
+      })
+    },
+    async createWorktree() {
+      throw new Error('Not used.')
+    },
+  }
+  const user = createUser()
+  const view = renderInBrowser(
+    <Composer
+      session={session}
+      draft="Wait for the branch"
+      isWorking={false}
+      onActivate={() => {}}
+      onDraftChange={() => {}}
+      submitMessage={async () => ({ status: 'accepted', delivery: 'prompt' })}
+      sessionWorkingLocations={bridge}
+      canSwitchBranch
+    />
+  )
+
+  await user.click(await view.findByRole('button', { name: 'Current checkout · main' }))
+  await user.click(await view.findByRole('button', { name: 'feature/local' }))
+  await user.click(view.getByRole('button', { name: 'Switch to feature/local' }))
+
+  await waitFor(() =>
+    assert.equal(
+      view.container.querySelector('[aria-label="Message for First Session"]')?.getAttribute('contenteditable'),
+      'false'
+    )
+  )
+  assert.equal(
+    (view.container.querySelector('[aria-label="Send message"]') as HTMLButtonElement | null)?.disabled,
+    true
+  )
+
+  await act(async () => {
+    finishSwitch(currentLocations)
+    await Promise.resolve()
+  })
 })
 
 test('shows the current context window usage in the Composer action cluster', () => {

--- a/src/renderer/components/composer.tsx
+++ b/src/renderer/components/composer.tsx
@@ -37,6 +37,7 @@ type ComposerProperties = Readonly<{
   sessionFiles?: SessionFilesBridge
   sessionWorkingLocations?: SessionWorkingLocationsBridge
   canCreateWorktree?: boolean
+  canSwitchBranch?: boolean
 }>
 
 export function Composer({
@@ -55,6 +56,7 @@ export function Composer({
   sessionFiles,
   sessionWorkingLocations,
   canCreateWorktree = false,
+  canSwitchBranch = false,
 }: ComposerProperties) {
   const descriptionId = useId()
   const statusId = useId()
@@ -75,6 +77,7 @@ export function Composer({
   const [availableSkills, setAvailableSkills] = useState<readonly SessionSkill[]>([])
   const [skillsError, setSkillsError] = useState<string>()
   const [availableFiles, setAvailableFiles] = useState<readonly SessionFile[]>([])
+  const [workingLocationMutating, setWorkingLocationMutating] = useState(false)
   const configurationPending = pendingConfiguration.size > 0
 
   useEffect(() => {
@@ -212,8 +215,8 @@ export function Composer({
   const empty = submissionState.draft.trim().length === 0
   const sendLabel = isWorking ? 'Steer session' : 'Send message'
   const { awaiting, error, status } = submissionState
-  const configurationDisabled = isWorking || awaiting || compacting || isCompacting
-  const agentRunDisabled = awaiting || configurationPending || compacting || isCompacting
+  const configurationDisabled = isWorking || awaiting || compacting || isCompacting || workingLocationMutating
+  const agentRunDisabled = awaiting || configurationPending || compacting || isCompacting || workingLocationMutating
   const modelConfigurationRequired = configuration !== undefined && configuration.models.length === 0
   const configurationMessage = modelConfigurationRequired
     ? 'No Model is available. Install Pi CLI, sign in to a provider, then restart Railyard.'
@@ -400,8 +403,10 @@ export function Composer({
         <SessionWorkingLocationControls
           bridge={sessionWorkingLocations}
           canCreateWorktree={canCreateWorktree}
+          canSwitchBranch={canSwitchBranch}
           isWorking={isWorking}
           sessionId={session.id}
+          onMutationChange={setWorkingLocationMutating}
         />
       )}
       <p id={descriptionId} className="sr-only">

--- a/src/renderer/components/session-branch-picker.tsx
+++ b/src/renderer/components/session-branch-picker.tsx
@@ -1,0 +1,284 @@
+import { Copy, GitBranch, LoaderCircle, RefreshCw, Search } from 'lucide-react'
+import { useRef, useState } from 'react'
+import { Button } from '@/components/ui-kit/button'
+import { Dialog, DialogActions, DialogBody, DialogDescription, DialogTitle } from '@/components/ui-kit/dialog'
+import { Input, InputGroup } from '@/components/ui-kit/input'
+import type { SessionId } from '@/src/domain/session'
+import type {
+  SessionRepositoryBranch,
+  SessionRepositoryBranchesSnapshot,
+  SessionRepositoryWorkingLocation,
+  SessionWorkingLocationsBridge,
+  SessionWorkingLocationsSnapshot,
+} from '@/src/session-working-locations'
+
+const lazilyRefreshedRepositories = new WeakMap<SessionWorkingLocationsBridge, Set<string>>()
+
+type SessionBranchPickerProperties = Readonly<{
+  bridge: SessionWorkingLocationsBridge
+  isWorking: boolean
+  location: Extract<SessionRepositoryWorkingLocation, { availability: 'available' }>
+  sessionId: SessionId
+  onMutationChange: (mutating: boolean) => void
+  onWorkingLocationsChange: (snapshot: SessionWorkingLocationsSnapshot) => void
+}>
+
+export function SessionBranchPicker({
+  bridge,
+  isWorking,
+  location,
+  sessionId,
+  onMutationChange,
+  onWorkingLocationsChange,
+}: SessionBranchPickerProperties) {
+  const request = useRef(0)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [snapshot, setSnapshot] = useState<SessionRepositoryBranchesSnapshot>()
+  const [loading, setLoading] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [switching, setSwitching] = useState(false)
+  const [error, setError] = useState<string>()
+  const [confirmation, setConfirmation] = useState<SessionRepositoryBranch>()
+
+  const loadBranches = async (refresh: boolean) => {
+    const currentRequest = ++request.current
+    if (refresh) setRefreshing(true)
+    else setLoading(true)
+    setError(undefined)
+
+    try {
+      const nextSnapshot = await bridge.getBranches(sessionId, location.repositoryId, { refresh })
+      if (request.current !== currentRequest) return
+
+      setSnapshot(nextSnapshot)
+      if (nextSnapshot.refreshError) setError(nextSnapshot.refreshError)
+    } catch (operationError) {
+      if (request.current === currentRequest) {
+        setError(operationError instanceof Error ? operationError.message : 'Branches could not be loaded.')
+      }
+    } finally {
+      if (request.current === currentRequest) {
+        setLoading(false)
+        setRefreshing(false)
+      }
+    }
+  }
+
+  const openPicker = () => {
+    if (isWorking || switching) return
+
+    setOpen(true)
+    setQuery('')
+    setConfirmation(undefined)
+    setError(undefined)
+
+    void loadBranches(false).then(() => {
+      const refreshedRepositories = lazilyRefreshedRepositories.get(bridge) ?? new Set<string>()
+      lazilyRefreshedRepositories.set(bridge, refreshedRepositories)
+      if (refreshedRepositories.has(location.repositoryId)) return
+
+      refreshedRepositories.add(location.repositoryId)
+      void loadBranches(true)
+    })
+  }
+
+  const closePicker = () => {
+    if (switching) return
+
+    request.current += 1
+    setOpen(false)
+    setConfirmation(undefined)
+    setLoading(false)
+    setRefreshing(false)
+  }
+
+  const switchBranch = async (branch: SessionRepositoryBranch) => {
+    setSwitching(true)
+    setError(undefined)
+    onMutationChange(true)
+
+    try {
+      const nextSnapshot = await bridge.switchBranch(sessionId, location.repositoryId, branch.ref)
+      onWorkingLocationsChange(nextSnapshot)
+      setOpen(false)
+      setConfirmation(undefined)
+    } catch (operationError) {
+      setError(operationError instanceof Error ? operationError.message : 'The branch could not be switched.')
+    } finally {
+      setSwitching(false)
+      onMutationChange(false)
+    }
+  }
+
+  const selectBranch = (branch: SessionRepositoryBranch) => {
+    if (branch.current || switching) return
+
+    if (location.kind === 'current-checkout') {
+      setConfirmation(branch)
+      return
+    }
+
+    void switchBranch(branch)
+  }
+
+  const branches = snapshot?.branches.filter((branch) => branch.name.toLowerCase().includes(query.toLowerCase())) ?? []
+  const localBranches = branches.filter((branch) => branch.kind === 'local')
+  const remoteBranches = branches.filter((branch) => branch.kind === 'remote')
+  const label = location.kind === 'worktree' ? `Worktree · ${location.branch}` : `Current checkout · ${location.branch}`
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={label}
+        disabled={isWorking || switching}
+        className="flex min-w-0 max-w-[55%] items-center gap-1.5 rounded-md px-2 py-1 text-composer-muted-foreground hover:bg-composer-interaction hover:text-content-foreground disabled:opacity-50"
+        title={location.workingPath}
+        onClick={(event) => {
+          event.stopPropagation()
+          openPicker()
+        }}
+      >
+        {switching ? (
+          <LoaderCircle aria-hidden="true" className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none" />
+        ) : (
+          <GitBranch aria-hidden="true" className="size-3.5 shrink-0" />
+        )}
+        <span className="truncate">{switching ? 'Switching branch…' : label}</span>
+      </button>
+
+      <Dialog open={open} onClose={closePicker} size="md">
+        {confirmation ? (
+          <>
+            <DialogTitle>Switch shared checkout?</DialogTitle>
+            <DialogDescription>
+              Switching to {confirmation.name} changes this Repository for every Session using its current checkout. The
+              working tree must be clean and every affected Session must be idle.
+            </DialogDescription>
+            {error && (
+              <p className="mt-4 text-sm/5 text-form-error-foreground" role="alert">
+                {error}
+              </p>
+            )}
+            <DialogActions>
+              <Button plain disabled={switching} onClick={() => setConfirmation(undefined)}>
+                Back
+              </Button>
+              <Button color="accent" disabled={switching} onClick={() => void switchBranch(confirmation)}>
+                {switching ? 'Switching…' : `Switch to ${confirmation.name}`}
+              </Button>
+            </DialogActions>
+          </>
+        ) : (
+          <>
+            <DialogTitle>Switch branch</DialogTitle>
+            <DialogDescription>
+              Choose a local branch or a remote branch to create its local tracking branch.
+            </DialogDescription>
+            <DialogBody>
+              {location.kind === 'worktree' && (
+                <button
+                  type="button"
+                  aria-label="Copy worktree path"
+                  className="mb-3 flex max-w-full items-center gap-2 rounded-md px-2 py-1 text-xs/5 text-content-muted-foreground hover:bg-content-interaction hover:text-content-foreground focus-visible:outline-2 focus-visible:outline-focus-ring"
+                  title={location.workingPath}
+                  onClick={() => void window.navigator.clipboard.writeText(location.workingPath).catch(() => {})}
+                >
+                  <Copy aria-hidden="true" className="size-3.5 shrink-0" />
+                  <span className="truncate">Copy worktree path</span>
+                </button>
+              )}
+              <InputGroup>
+                <Search aria-hidden="true" data-slot="icon" />
+                <Input
+                  aria-label="Search branches"
+                  autoFocus
+                  type="search"
+                  value={query}
+                  placeholder="Search branches"
+                  onChange={(event) => setQuery(event.target.value)}
+                />
+              </InputGroup>
+
+              <div className="mt-4 max-h-72 overflow-y-auto rounded-lg border border-content-border">
+                {loading && !snapshot ? (
+                  <p className="flex items-center gap-2 px-3 py-4 text-sm/5 text-content-muted-foreground">
+                    <LoaderCircle aria-hidden="true" className="size-4 animate-spin motion-reduce:animate-none" />
+                    Loading branches…
+                  </p>
+                ) : branches.length === 0 ? (
+                  <p className="px-3 py-4 text-sm/5 text-content-muted-foreground">No matching branches.</p>
+                ) : (
+                  <>
+                    <BranchGroup label="Local branches" branches={localBranches} onSelect={selectBranch} />
+                    <BranchGroup label="Remote branches" branches={remoteBranches} onSelect={selectBranch} />
+                  </>
+                )}
+              </div>
+
+              <div className="mt-3 flex min-h-8 items-center justify-between gap-3 text-xs/5 text-content-muted-foreground">
+                <span aria-live="polite">
+                  {refreshing ? 'Refreshing remote branches…' : error ? error : 'Remote branches load when needed.'}
+                </span>
+                <Button
+                  plain
+                  aria-label="Refresh branches"
+                  className="shrink-0"
+                  disabled={refreshing || loading}
+                  onClick={() => void loadBranches(true)}
+                >
+                  <RefreshCw
+                    aria-hidden="true"
+                    className={refreshing ? 'animate-spin motion-reduce:animate-none' : ''}
+                  />
+                  Refresh
+                </Button>
+              </div>
+            </DialogBody>
+            <DialogActions>
+              <Button plain onClick={closePicker}>
+                Cancel
+              </Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </>
+  )
+}
+
+function BranchGroup({
+  label,
+  branches,
+  onSelect,
+}: Readonly<{
+  label: string
+  branches: readonly SessionRepositoryBranch[]
+  onSelect: (branch: SessionRepositoryBranch) => void
+}>) {
+  if (branches.length === 0) return null
+
+  return (
+    <section className="border-b border-content-border last:border-b-0">
+      <h3 className="px-3 pt-2.5 pb-1 text-xs/5 font-medium text-content-muted-foreground">{label}</h3>
+      <ul className="pb-1.5">
+        {branches.map((branch) => (
+          <li key={branch.ref}>
+            <button
+              type="button"
+              aria-current={branch.current ? 'true' : undefined}
+              disabled={branch.current}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm/5 text-content-foreground hover:bg-content-interaction focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-focus-ring disabled:cursor-default"
+              onClick={() => onSelect(branch)}
+            >
+              <GitBranch aria-hidden="true" className="size-4 shrink-0 text-content-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate">{branch.name}</span>
+              {branch.current && <span className="text-xs text-content-muted-foreground">Current</span>}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/renderer/components/session-container.tsx
+++ b/src/renderer/components/session-container.tsx
@@ -274,6 +274,7 @@ export function SessionContainer({
               sessionFiles={sessionFiles}
               sessionWorkingLocations={sessionWorkingLocations}
               canCreateWorktree={session.repositoryAccess.kind === 'managed' && workstreamLifecycle === 'active'}
+              canSwitchBranch={session.repositoryAccess.kind === 'direct' && workstreamLifecycle === 'active'}
             />
           )}
         </div>

--- a/src/renderer/components/session-working-location-controls.test.tsx
+++ b/src/renderer/components/session-working-location-controls.test.tsx
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { afterEach, test } from 'node:test'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { sessionId } from '@/src/domain/session'
 import type { SessionWorkingLocationsBridge } from '@/src/session-working-locations'
@@ -29,6 +29,12 @@ test('creates a worktree only after the user requests isolation for the selected
   const bridge: SessionWorkingLocationsBridge = {
     async get() {
       return currentSnapshot
+    },
+    async getBranches() {
+      throw new Error('Not used.')
+    },
+    async switchBranch() {
+      throw new Error('Not used.')
     },
     async createWorktree(...values) {
       requests.push(values)
@@ -83,6 +89,162 @@ test('creates a worktree only after the user requests isolation for the selected
   assert.deepEqual(requests, [[currentSnapshot.sessionId, 'repository-a']])
 })
 
+test('loads cached branches before lazily refreshing remote branches', async () => {
+  const requests: boolean[] = []
+  let finishRefresh: () => void = () => {}
+  const refreshReady = new Promise<void>((resolve) => {
+    finishRefresh = resolve
+  })
+  const bridge: SessionWorkingLocationsBridge = {
+    async get() {
+      return currentSnapshot
+    },
+    async getBranches(sessionId, repositoryId, options) {
+      requests.push(options?.refresh ?? false)
+      if (options?.refresh) await refreshReady
+
+      return {
+        sessionId,
+        repositoryId,
+        branches: [
+          { ref: 'refs/heads/main', name: 'main', kind: 'local', current: true },
+          { ref: 'refs/heads/feature/local', name: 'feature/local', kind: 'local', current: false },
+          ...(options?.refresh
+            ? [
+                {
+                  ref: 'refs/remotes/origin/feature/remote',
+                  name: 'origin/feature/remote',
+                  kind: 'remote' as const,
+                  current: false,
+                },
+              ]
+            : []),
+        ],
+      }
+    },
+    async switchBranch() {
+      throw new Error('Not used.')
+    },
+    async createWorktree() {
+      throw new Error('Not used.')
+    },
+  }
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = render(
+    <SessionWorkingLocationControls
+      bridge={bridge}
+      canCreateWorktree={false}
+      canSwitchBranch
+      isWorking={false}
+      sessionId={currentSnapshot.sessionId}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await user.click(await view.findByRole('button', { name: 'Current checkout · main' }))
+
+  assert.ok(await view.findByRole('button', { name: 'feature/local' }))
+  await waitFor(() => assert.deepEqual(requests, [false, true]))
+  assert.ok(view.getByText('Refreshing remote branches…'))
+
+  finishRefresh()
+
+  assert.ok(await view.findByRole('button', { name: 'origin/feature/remote' }))
+})
+
+test('confirms a shared current-checkout branch switch', async () => {
+  const switches: string[] = []
+  const bridge: SessionWorkingLocationsBridge = {
+    async get() {
+      return currentSnapshot
+    },
+    async getBranches(sessionId, repositoryId) {
+      return {
+        sessionId,
+        repositoryId,
+        branches: [
+          { ref: 'refs/heads/main', name: 'main', kind: 'local', current: true },
+          { ref: 'refs/heads/feature/local', name: 'feature/local', kind: 'local', current: false },
+        ],
+      }
+    },
+    async switchBranch(_sessionId, _repositoryId, branchRef) {
+      switches.push(branchRef)
+      return {
+        ...currentSnapshot,
+        repositories: [{ ...currentSnapshot.repositories[0]!, branch: 'feature/local' }],
+      }
+    },
+    async createWorktree() {
+      throw new Error('Not used.')
+    },
+  }
+  const user = userEvent.setup({ document: browser.document as unknown as Document })
+  const view = render(
+    <SessionWorkingLocationControls
+      bridge={bridge}
+      canCreateWorktree={false}
+      canSwitchBranch
+      isWorking={false}
+      sessionId={currentSnapshot.sessionId}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  await user.click(await view.findByRole('button', { name: 'Current checkout · main' }))
+  await user.click(await view.findByRole('button', { name: 'feature/local' }))
+
+  assert.ok(view.getByRole('heading', { name: 'Switch shared checkout?' }))
+  assert.deepEqual(switches, [])
+
+  await user.click(view.getByRole('button', { name: 'Switch to feature/local' }))
+
+  await waitFor(() => assert.deepEqual(switches, ['refs/heads/feature/local']))
+  assert.ok(await view.findByRole('button', { name: 'Current checkout · feature/local' }))
+})
+
+test('refreshes shared checkout context after another Session switches branches', async () => {
+  let snapshot = currentSnapshot
+  let publishChange: () => void = () => {}
+  const bridge: SessionWorkingLocationsBridge = {
+    async get() {
+      return snapshot
+    },
+    async getBranches() {
+      throw new Error('Not used.')
+    },
+    async switchBranch() {
+      throw new Error('Not used.')
+    },
+    async createWorktree() {
+      throw new Error('Not used.')
+    },
+    subscribe(listener) {
+      publishChange = listener
+      return () => {}
+    },
+  }
+  const view = render(
+    <SessionWorkingLocationControls
+      bridge={bridge}
+      canCreateWorktree={false}
+      isWorking={false}
+      sessionId={currentSnapshot.sessionId}
+    />,
+    { container: browser.document.body as unknown as HTMLElement }
+  )
+
+  assert.ok(await view.findByText('Current checkout · main'))
+
+  snapshot = {
+    ...currentSnapshot,
+    repositories: [{ ...currentSnapshot.repositories[0]!, branch: 'feature/shared' }],
+  }
+  act(() => publishChange())
+
+  assert.ok(await view.findByText('Current checkout · feature/shared'))
+})
+
 test('selects which Workstream Repository context to show', async () => {
   const bridge: SessionWorkingLocationsBridge = {
     async get() {
@@ -100,6 +262,12 @@ test('selects which Workstream Repository context to show', async () => {
           },
         ],
       }
+    },
+    async getBranches() {
+      throw new Error('Not used.')
+    },
+    async switchBranch() {
+      throw new Error('Not used.')
     },
     async createWorktree() {
       throw new Error('Not used.')

--- a/src/renderer/components/session-working-location-controls.tsx
+++ b/src/renderer/components/session-working-location-controls.tsx
@@ -7,19 +7,24 @@ import type {
   SessionWorkingLocationsBridge,
   SessionWorkingLocationsSnapshot,
 } from '@/src/session-working-locations'
+import { SessionBranchPicker } from '@/src/renderer/components/session-branch-picker'
 
 type SessionWorkingLocationControlsProperties = Readonly<{
   bridge: SessionWorkingLocationsBridge
   canCreateWorktree: boolean
+  canSwitchBranch?: boolean
   isWorking: boolean
   sessionId: SessionId
+  onMutationChange?: (mutating: boolean) => void
 }>
 
 export function SessionWorkingLocationControls({
   bridge,
   canCreateWorktree,
+  canSwitchBranch = false,
   isWorking,
   sessionId,
+  onMutationChange = () => {},
 }: SessionWorkingLocationControlsProperties) {
   const request = useRef(0)
   const [snapshot, setSnapshot] = useState<SessionWorkingLocationsSnapshot>()
@@ -28,21 +33,33 @@ export function SessionWorkingLocationControls({
   const [error, setError] = useState<string>()
 
   useEffect(() => {
-    const currentRequest = ++request.current
-    setSnapshot(undefined)
-    setSelectedRepositoryId(undefined)
-    setError(undefined)
-
-    void bridge.get(sessionId).then(
-      (nextSnapshot) => {
-        if (request.current !== currentRequest) return
-        setSnapshot(nextSnapshot)
-        setSelectedRepositoryId(nextSnapshot.repositories[0]?.repositoryId)
-      },
-      () => {
-        if (request.current === currentRequest) setError('Repository context is unavailable.')
+    const load = (reset: boolean) => {
+      const currentRequest = ++request.current
+      if (reset) {
+        setSnapshot(undefined)
+        setSelectedRepositoryId(undefined)
       }
-    )
+      setError(undefined)
+
+      void bridge.get(sessionId).then(
+        (nextSnapshot) => {
+          if (request.current !== currentRequest) return
+          setSnapshot(nextSnapshot)
+          setSelectedRepositoryId((selected) => selected ?? nextSnapshot.repositories[0]?.repositoryId)
+        },
+        () => {
+          if (request.current === currentRequest) setError('Repository context is unavailable.')
+        }
+      )
+    }
+
+    load(true)
+    const unsubscribe = bridge.subscribe?.(() => load(false)) ?? (() => {})
+
+    return () => {
+      request.current += 1
+      unsubscribe()
+    }
   }, [bridge, isWorking, sessionId])
 
   const repositories = snapshot?.repositories ?? []
@@ -54,6 +71,7 @@ export function SessionWorkingLocationControls({
 
     setCreating(true)
     setError(undefined)
+    onMutationChange(true)
     try {
       const nextSnapshot = await bridge.createWorktree(sessionId, selectedRepository.repositoryId)
       setSnapshot(nextSnapshot)
@@ -61,6 +79,7 @@ export function SessionWorkingLocationControls({
       setError(operationError instanceof Error ? operationError.message : 'Could not create the Session worktree.')
     } finally {
       setCreating(false)
+      onMutationChange(false)
     }
   }
 
@@ -98,13 +117,24 @@ export function SessionWorkingLocationControls({
               </DropdownMenu>
             </Dropdown>
           )}
-          <WorkingLocationControl
-            canCreateWorktree={canCreateWorktree}
-            creating={creating}
-            isWorking={isWorking}
-            location={selectedRepository}
-            onCreateWorktree={() => void createWorktree()}
-          />
+          {canSwitchBranch && selectedRepository.availability === 'available' ? (
+            <SessionBranchPicker
+              bridge={bridge}
+              isWorking={isWorking}
+              location={selectedRepository}
+              sessionId={sessionId}
+              onMutationChange={onMutationChange}
+              onWorkingLocationsChange={setSnapshot}
+            />
+          ) : (
+            <WorkingLocationControl
+              canCreateWorktree={canCreateWorktree}
+              creating={creating}
+              isWorking={isWorking}
+              location={selectedRepository}
+              onCreateWorktree={() => void createWorktree()}
+            />
+          )}
         </div>
       )}
       {error && (

--- a/src/session-working-locations-ipc.test.ts
+++ b/src/session-working-locations-ipc.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { parseSessionWorkingLocationRequest } from './session-working-locations-ipc'
+import { parseSessionBranchRequest, parseSessionWorkingLocationRequest } from './session-working-locations-ipc'
 
 test('parses a Session working-location request with an optional Repository', () => {
   assert.deepEqual(parseSessionWorkingLocationRequest({ sessionId: 'session-a', repositoryId: 'repository-a' }), {
@@ -13,4 +13,44 @@ test('parses a Session working-location request with an optional Repository', ()
 test('rejects a malformed Session working-location request', () => {
   assert.equal(parseSessionWorkingLocationRequest({ sessionId: '', repositoryId: 'repository-a' }), undefined)
   assert.equal(parseSessionWorkingLocationRequest({ sessionId: 'session-a', repositoryId: '' }), undefined)
+})
+
+test('parses branch discovery and selection requests', () => {
+  assert.deepEqual(parseSessionBranchRequest({ sessionId: 'session-a', repositoryId: 'repository-a', refresh: true }), {
+    sessionId: 'session-a',
+    repositoryId: 'repository-a',
+    refresh: true,
+  })
+  assert.deepEqual(
+    parseSessionBranchRequest({
+      sessionId: 'session-a',
+      repositoryId: 'repository-a',
+      branchRef: 'refs/remotes/origin/feature/test',
+    }),
+    {
+      sessionId: 'session-a',
+      repositoryId: 'repository-a',
+      branchRef: 'refs/remotes/origin/feature/test',
+    }
+  )
+})
+
+test('rejects malformed branch discovery and selection requests', () => {
+  assert.equal(
+    parseSessionBranchRequest({ sessionId: 'session-a', repositoryId: 'repository-a', refresh: 'yes' }),
+    undefined
+  )
+  assert.equal(
+    parseSessionBranchRequest({ sessionId: 'session-a', repositoryId: 'repository-a', branchRef: '' }),
+    undefined
+  )
+  assert.equal(
+    parseSessionBranchRequest({
+      sessionId: 'session-a',
+      repositoryId: 'repository-a',
+      refresh: true,
+      branchRef: 'refs/heads/main',
+    }),
+    undefined
+  )
 })

--- a/src/session-working-locations-ipc.ts
+++ b/src/session-working-locations-ipc.ts
@@ -2,7 +2,10 @@ import { isSessionId, type SessionId } from '@/src/domain/session'
 
 export const sessionWorkingLocationsIpcChannels = {
   get: 'session-working-locations:get',
+  getBranches: 'session-working-locations:get-branches',
+  switchBranch: 'session-working-locations:switch-branch',
   createWorktree: 'session-working-locations:create-worktree',
+  changed: 'session-working-locations:changed',
 } as const
 
 export function parseSessionWorkingLocationRequest(
@@ -22,4 +25,26 @@ export function parseSessionWorkingLocationRequest(
   }
 
   return { sessionId, ...(repositoryId ? { repositoryId } : {}) }
+}
+
+export function parseSessionBranchRequest(
+  value: unknown
+): Readonly<{ sessionId: SessionId; repositoryId: string; refresh?: boolean; branchRef?: string }> | undefined {
+  const request = parseSessionWorkingLocationRequest(value)
+  if (!request?.repositoryId) return undefined
+
+  const refresh = (value as { refresh?: unknown }).refresh
+  const branchRef = (value as { branchRef?: unknown }).branchRef
+  if (refresh !== undefined && typeof refresh !== 'boolean') return undefined
+  if (branchRef !== undefined && (typeof branchRef !== 'string' || branchRef.length === 0 || branchRef.length > 1024)) {
+    return undefined
+  }
+  if (refresh !== undefined && branchRef !== undefined) return undefined
+
+  return {
+    sessionId: request.sessionId,
+    repositoryId: request.repositoryId,
+    ...(refresh === undefined ? {} : { refresh }),
+    ...(branchRef === undefined ? {} : { branchRef }),
+  }
 }

--- a/src/session-working-locations.ts
+++ b/src/session-working-locations.ts
@@ -15,7 +15,30 @@ export type SessionWorkingLocationsSnapshot = Readonly<{
   repositories: readonly SessionRepositoryWorkingLocation[]
 }>
 
+export type SessionRepositoryBranch = Readonly<{
+  ref: string
+  name: string
+  kind: 'local' | 'remote'
+  current: boolean
+}>
+
+export type SessionRepositoryBranchesSnapshot = Readonly<{
+  sessionId: SessionId
+  repositoryId: string
+  branches: readonly SessionRepositoryBranch[]
+  refreshError?: string
+}>
+
+export type SessionBranchQueryOptions = Readonly<{ refresh?: boolean }>
+
 export interface SessionWorkingLocationsBridge {
   get(sessionId: SessionId): Promise<SessionWorkingLocationsSnapshot>
+  getBranches(
+    sessionId: SessionId,
+    repositoryId: string,
+    options?: SessionBranchQueryOptions
+  ): Promise<SessionRepositoryBranchesSnapshot>
+  switchBranch(sessionId: SessionId, repositoryId: string, branchRef: string): Promise<SessionWorkingLocationsSnapshot>
   createWorktree(sessionId: SessionId, repositoryId: string): Promise<SessionWorkingLocationsSnapshot>
+  subscribe?(listener: () => void): () => void
 }


### PR DESCRIPTION
## Summary

- Restore Model, Effort, Repository, branch, path, and checkout context beneath the Quick Session Composer, including reliable concurrent runtime creation.
- Add a searchable Quick Session branch picker that shows cached refs immediately, lazily refreshes remotes, supports retries, and creates local tracking branches from remote selections.
- Guard branch changes with clean-tree checks, Session run leases, shared-checkout confirmation, dedicated-worktree persistence, and renderer refreshes for other affected Sessions.
- Document branch switching and the Git network access performed by remote refreshes.

## Related issue

None.

## Validation

- [x] `bun run check` — passed formatting, ESLint, TypeScript, 673 tests, production build, and bundle budgets. The first run after updating from main hit one transient timeout in a newly merged Composer test and Bun's follow-on `node:test` cascade; the focused behavior then passed 5/5 and the complete rerun passed.
- [x] Focused Git, application-state, IPC, working-location control, Composer, demo, runtime-lifecycle, dirty-checkout, lease-conflict, lazy-loading, retry, shared-refresh, and remote-tracking tests are included and passed.
- [x] `timeout --signal=INT 30s bun run dev` — the renderer and Electron development processes started successfully on port 5175 before the intentional stop; Electron emitted a non-blocking Wayland/Vulkan warning.
- [x] `bun run security:scan` — no leaks or unfiltered vulnerabilities found.
- [x] Demo DOM verification confirmed the restored Quick Session context controls and branch-picker interaction.

## Review checklist

- [x] The change is focused and does not include unrelated refactoring.
- [x] Changed behavior has appropriate focused tests.
- [x] User-facing, contributor, security, and release documentation is updated where needed.
- [x] New dependencies, copied or generated material, assets, and license implications are disclosed. This change adds none.
- [x] I have read and will follow the Code of Conduct.
