### PR TITLE
fix: load electron-updater from CommonJS in ESM main process

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -32,7 +32,7 @@ async function buildElectronProcesses() {
   const results = await Promise.all([
     Bun.build({
       entrypoints: ['src/main/index.ts'],
-      external: ['electron', '@earendil-works/pi-coding-agent'],
+      external: ['electron', 'electron-updater', '@earendil-works/pi-coding-agent'],
       format: 'esm',
       outdir: 'dist/main',
       target: 'node',

--- a/src/main/application-updates.ts
+++ b/src/main/application-updates.ts
@@ -1,5 +1,5 @@
 import { app, net, shell } from 'electron'
-import { autoUpdater } from 'electron-updater'
+import electronUpdater from 'electron-updater'
 import type { ApplicationUpdateSnapshot } from '@/src/application-update'
 import { applicationUpdateIpcChannels, parseApplicationUpdateCommand } from '@/src/application-update-ipc'
 import {
@@ -10,6 +10,8 @@ import {
 import { createApplicationUpdater } from '@/src/main/application-updater'
 import type { PiSessionRuntimeRegistry } from '@/src/main/pi-session-runtimes'
 import { broadcastToTrustedRenderers, handleTrustedIpc } from '@/src/main/trusted-ipc'
+
+const { autoUpdater } = electronUpdater
 
 function electronUpdateClient(): ElectronUpdateClient {
   return {


### PR DESCRIPTION
## Summary
- load `electron-updater` through its CommonJS-compatible default export
- keep development main-process builds externalizing `electron-updater`

## Validation
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test` — 673 passed

The Electron startup smoke test no longer reports the updater import failure; this environment still has an unrelated GPU/Wayland limitation.